### PR TITLE
Pull image name/tag from container.config.image if pinned

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -572,12 +572,9 @@ class Docker extends Component {
         // Parse image to get registry, organization...
         let imageNameToParse = container.Image;
         if (imageNameToParse.includes('sha256:')) {
-            if (!image.RepoTags || image.RepoTags.length === 0) {
-                this.log.warn(`Cannot get a reliable tag for this image [${imageNameToParse}]`);
-                return Promise.resolve();
-            }
-            // Get the first repo tag (better than nothing ;)
-            [imageNameToParse] = image.RepoTags;
+            // Use image information from container.config.image
+            const containerDetails = await this.dockerApi.getContainer(containerId).inspect();
+            [imageNameToParse] = containerDetails.Config.Image.split('@');
         }
         const parsedImage = parse(imageNameToParse);
         const tagName = parsedImage.tag || 'latest';


### PR DESCRIPTION
I ran into the issue described in issue #190 and I was too excited about this project to not do some investigation. I did some digging into the problem containers/images with `docker Inspect` and with the `Node.js dockerode` module, and I think I have a solution.  I don't know how to set up your test apparatus, so I was not able to verify that my code changes didn't break any of your defined tests.  I did test this solution against the vaultwarden example given in the issue on my local Docker Desktop, and also against the containers on my Docker Swarm instance where I encountered the problem. 