### PR TITLE
Added support for linked/dependent containers

### DIFF
--- a/app/triggers/providers/docker/Docker.js
+++ b/app/triggers/providers/docker/Docker.js
@@ -2,6 +2,7 @@ const parse = require('parse-docker-image-name');
 const Trigger = require('../Trigger');
 const { getState } = require('../../../registry');
 const { fullName } = require('../../../model/container');
+const { flatten, unflatten } = require('flat');
 
 /**
  * Replace a Docker container with an updated one.
@@ -40,6 +41,101 @@ class Docker extends Trigger {
             return await dockerApi.getContainer(container.id);
         } catch (e) {
             this.log.warn(`Error when getting container ${container.id}`);
+            throw e;
+        }
+    }
+
+    /**
+     * Get other containers dependent on current container.
+     * @param dockerApi
+     * @param container
+     * @param logContainer
+     * @returns {Promise<*>}
+     */
+    async getDependentContainers(dockerApi, container, serviceName, logContainer) {
+        this.log.debug(`Get container dependent containers for ${container.id} : ${container.name}`);
+        try {
+            let checks = [
+                this.getAllContainersWithLabel(dockerApi, 'fmartinou.whatsupdocker.container.depends_on', container.name)
+            ];
+
+            if (serviceName) {
+                checks = checks.concat([
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_started:true`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_started:false`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_healthy:true`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_healthy:false`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_completed_successfully:true`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'com.docker.compose.depends_on', `${serviceName}:service_completed_successfully:false`, logContainer),
+                    this.getAllContainersWithLabel(dockerApi, 'fmartinou.whatsupdocker.container.depends_on', serviceName, logContainer)
+                ]);
+            }
+
+            const containers = await Promise.all(checks)
+                .then(containers => containers.flat())
+                .then(containers => Array.from(new Map(containers.map(container => [container.Id, container])).values()))
+                .then(
+                    containers => Promise.all(
+                        containers.map(
+                            container => this.getCurrentContainer(dockerApi, { id: container.Id })
+                                .then(
+                                    containerInstance => this.inspectContainer(containerInstance, logContainer)
+                                        .then(inspectedContainer => ({ container: containerInstance, inspected: inspectedContainer }))
+                                )
+                        )
+                    )
+                );
+
+            this.log.debug(`Gotten ${containers.length} dependent containers for ${container.id} : ${container.name}`);
+
+            return containers;
+        } catch (e) {
+            logContainer.warn(`Error when getting dependent containers for container ${container.id}`);
+            throw e;
+        }
+    }
+
+    /**
+     * Get all containers which have the specified label
+     * @param dockerApi
+     * @param key
+     * @param value
+     * @param logContainer
+     * @returns {Promise<*>}
+     */
+    async getAllContainersWithLabel(dockerApi, key, value = null, logContainer) {
+        this.log.debug(`Get all containers with label "${key}=${value ?? '<not_set>'}"`);
+        try {
+            const containers = await dockerApi.listContainers({
+                filters: JSON.stringify({
+                    label: [
+                        value ? `${key}=${value}` : `${key}`
+                    ]
+                })
+            });
+
+            this.log.debug(`Gotten ${containers.length} container(s) with label "${key}=${value ?? '<not_set>'}"`);
+
+            return containers;
+        } catch (e) {
+            logContainer.warn(`Error when getting all containers with label "${key}=${value ?? '<not_set>'}"`);
+            throw e;
+        }
+    }
+
+    /**
+     * Get other containers dependent on current container by `network_mode: container:*`.
+     * @param dockerApi
+     * @param container
+     * @param logContainer
+     * @returns {Promise<*>}
+     */
+    async getDependentContainersByNetworkMode(dockerApi, container, logContainer) {
+        this.log.debug(`Get container ${container.id}`);
+        try {
+            return []; //TODO: Currently there's no way to filter on `network_mode` through the API, so this function is an empty shell
+        } catch (e) {
+            logContainer.warn(`Error when getting container ${container.id}`);
             throw e;
         }
     }
@@ -185,6 +281,140 @@ class Docker extends Trigger {
     }
 
     /**
+     * Recreate a container.
+     * @param dockerApi
+     * @param container
+     * @param newImage
+     * @param currentContainer
+     * @param logContainer
+     * @param containerSpecPatch
+     * @param forceStart
+     * @returns {Promise<*>}
+     */
+    async recreateContainer(dockerApi, container, newImage, currentContainer, logContainer, containerSpecPatch = null, forceStart = false) {
+        logContainer.info(`Recreate container ${container.name} with image ${newImage}`, {container, currentContainer});
+        try {
+            const currentContainerSpec = await this.inspectContainer(
+                currentContainer,
+                logContainer,
+            );
+            const currentContainerState = currentContainerSpec.State;
+
+            logContainer.debug('Inspected container: ', currentContainerSpec);
+
+            const dependentContainers = [
+                // Check for dependent containers
+                ...(await this.getDependentContainers(dockerApi, container, currentContainerSpec?.Config?.Labels?.['com.docker.compose.service'] ?? null, logContainer)),
+                // Check for containers with `network_mode: container:{CONTAINER_NAME}` or `network_mode: service:*` (as this is equal to `network_mode: container:{CONTAINER_ID}`)
+                ...(await this.getDependentContainersByNetworkMode(dockerApi, container, logContainer))
+            ];
+
+            logContainer.debug(`All dependent containers for ${container.name} are: \r\n\t` + dependentContainers.map(c => c.inspected.Name.replace(/\//, '')).join('\r\n\t'));
+
+            const containersToRestart = dependentContainers.filter(c => !c?.inspected?.HostConfig?.NetworkMode || !c.inspected.HostConfig.NetworkMode.startsWith(`container:${container.id}`));
+            const containersToRecreate = dependentContainers.filter(c => c?.inspected?.HostConfig?.NetworkMode && c.inspected.HostConfig.NetworkMode.startsWith(`container:${container.id}`));
+
+            logContainer.debug(`Of which\r\n\t${containersToRestart.length} container(s) need to be restarted\r\n\t${containersToRecreate.length} container(s) need to be recreated`);
+
+            // Stop current container
+            if (currentContainerState.Running) {
+                // Need to stop dependent containers before the current one
+                logContainer.debug(`Containers to stop: \r\n\t` + dependentContainers.filter(c => c.inspected.State.Running).map(c => c.inspected.Name.replace(/\//, '')).join('\r\n\t'));
+                await Promise.all(
+                    dependentContainers.filter(c => c.inspected.State.Running).map(c => this.stopContainer(c.container, `${container.name} => ${c.inspected.Name.replace(/\//, '')}`, `${container.id} => ${c.inspected.Id}`, logContainer))
+                );
+
+                await this.stopContainer(
+                    currentContainer,
+                    container.name,
+                    container.id,
+                    logContainer,
+                );
+            }
+
+            // Clone current container spec
+            const containerToCreateInspect = this.cloneContainer(
+                currentContainerSpec,
+                newImage,
+                logContainer,
+            );
+
+            // Remove current container
+            await this.removeContainer(
+                currentContainer,
+                container.name,
+                container.id,
+                logContainer,
+            );
+
+            // Create new container
+            const newContainer = await this.createContainer(
+                dockerApi,
+                containerSpecPatch ? this.patchContainerSpec(containerToCreateInspect, containerSpecPatch, logContainer) : containerToCreateInspect,
+                container.name,
+                logContainer,
+            );
+
+            // Start container if it was running
+            if (currentContainerState.Running || forceStart) {
+                await this.startContainer(newContainer, container.name, logContainer);
+
+                // Need to restart dependent containers after the current one
+                logContainer.debug(`Containers to start again: \r\n\t` + containersToRestart.filter(c => c.State.Running).map(c => c.inspected.Name.replace(/\//, '')).join('\r\n\t'));
+                await Promise.all(
+                    containersToRestart.filter(c => c.inspected.State.Running).map(c => this.startContainer(c.container, `${container.name} => ${c.inspected.Name.replace(/\//, '')}`, logContainer))
+                );
+            }
+
+            // Need to recreate all dependent containers with the correct id
+            logContainer.debug(`Containers to recreate: \r\n\t` + containersToRecreate.map(c => c.inspected.Name.replace(/\//, '')).join('\r\n\t'));
+            await Promise.all(
+                containersToRecreate.map(
+                    c => this.recreateContainer(
+                        dockerApi,
+                        { id: c.inspected.Id, name: c.inspected.Name.replace(/\//, '') },
+                        c.inspected.Config.Image,
+                        c.container,
+                        logContainer,
+                        { HostConfig: { NetworkMode: `container:${newContainer.id}` } },
+                        true
+                    )
+                )
+            );
+        } catch (e) {
+            logContainer.warn(`Error when recreating container ${container.name} (${e.message})`);
+            throw e;
+        }
+    }
+
+    /**
+     * Combine spec with patch
+     * @param spec
+     * @param patch
+     * @param logContainer
+     */
+    patchContainerSpec(spec, patch, logContainer) {
+        logContainer.debug('Going to patch spec with patch: ', { spec, patch });
+
+        const flattenPatch = flatten(patch);
+
+        for (const [key, value] of Object.entries(flattenPatch)) {
+            let current = spec;
+            const paths = key.split('.');
+            const keyToBeSet = paths.pop();
+            for (const path of paths) {
+                if (!current[path]) current[path] = {};
+                current = current[path];
+            }
+            current[keyToBeSet] = value;
+        }
+
+        logContainer.debug('Patched spec with patch: ', spec);
+
+        return spec;
+    }
+
+    /**
      * Create a new container.
      * @param dockerApi
      * @param containerToCreate
@@ -196,7 +426,7 @@ class Docker extends Trigger {
         logContainer.info(`Create container ${containerName}`);
         try {
             const newContainer = await dockerApi.createContainer(containerToCreate);
-            logContainer.info(`Container ${containerName} recreated on new image with success`);
+            logContainer.info(`Container ${containerName} recreated on new image with success`, newContainer);
             return newContainer;
         } catch (e) {
             logContainer.warn(`Error when creating container ${containerName} (${e.message})`);
@@ -311,6 +541,8 @@ class Docker extends Trigger {
         // Child logger for the container to process
         const logContainer = this.log.child({ container: fullName(container) });
 
+        logContainer.debug("Received container: ", container);
+
         // Get watcher
         const watcher = this.getWatcher(container);
 
@@ -324,19 +556,10 @@ class Docker extends Trigger {
         logContainer.debug(`Get ${container.image.registry.name} registry credentials`);
         const auth = registry.getAuthPull();
 
-        // Rebuild image definition string
-        const newImage = this.getNewImageFullName(registry, container);
-
         // Get current container
         const currentContainer = await this.getCurrentContainer(dockerApi, container);
 
         if (currentContainer) {
-            const currentContainerSpec = await this.inspectContainer(
-                currentContainer,
-                logContainer,
-            );
-            const currentContainerState = currentContainerSpec.State;
-
             // Try to remove previous pulled images
             if (this.configuration.prune) {
                 await this.pruneImages(
@@ -347,6 +570,9 @@ class Docker extends Trigger {
                 );
             }
 
+            // Rebuild image definition string
+            const newImage = this.getNewImageFullName(registry, container);
+
             // Pull new image ahead of time
             await this.pullImage(dockerApi, auth, newImage, logContainer);
 
@@ -354,43 +580,8 @@ class Docker extends Trigger {
             if (this.configuration.dryrun) {
                 logContainer.info('Do not replace the existing container because dry-run mode is enabled');
             } else {
-                // Clone current container spec
-                const containerToCreateInspect = this.cloneContainer(
-                    currentContainerSpec,
-                    newImage,
-                    logContainer,
-                );
-
-                // Stop current container
-                if (currentContainerState.Running) {
-                    await this.stopContainer(
-                        currentContainer,
-                        container.name,
-                        container.id,
-                        logContainer,
-                    );
-                }
-
-                // Remove current container
-                await this.removeContainer(
-                    currentContainer,
-                    container.name,
-                    container.id,
-                    logContainer,
-                );
-
-                // Create new container
-                const newContainer = await this.createContainer(
-                    dockerApi,
-                    containerToCreateInspect,
-                    container.name,
-                    logContainer,
-                );
-
-                // Start container if it was running
-                if (currentContainerState.Running) {
-                    await this.startContainer(newContainer, container.name, logContainer);
-                }
+                // Handle recreation of container
+                await this.recreateContainer(dockerApi, container, newImage, currentContainer, logContainer);
 
                 // Remove previous image (only when updateKind is tag)
                 if (this.configuration.prune) {


### PR DESCRIPTION
This pull request add supports by for linkend/dependent containers by checking the labels of other containers for specific values, including a custom label for manual linking: `fmartinou.whatsupdocker.container.depends_on`

This also resolves the issue when a containers get recreated which has other containers depend on it by `network_mode: container:{CONTAINER_ID}` (Also known with syntax sugar as `network_mode: service:{SERVICE_NAME}`)

Should fix: https://github.com/fmartinou/whats-up-docker/issues/311
Locally running to test, also tested in testing environment by running the following docker-compose:
```yaml
version: "3.9"

volumes:
  nexus_data:
    driver: local
  wud_data:
    driver: local
  certification:
    driver: local

services:
  parent:
   image: alpine:latest
   command: sleep infinity
   ports:
     - 8080:80
  child:
    image: nginxdemos/hello:latest
    network_mode: service:parent
  whatsupdocker:
    labels:
      - wud.watch=false
    environment:
      - WUD_LOG_LEVEL=debug
      - {ALL OTHER ENVS NOT INCLUDED}
```