### PR TITLE
Pushover: Allow for optional html formatting in message

### DIFF
--- a/app/triggers/providers/pushover/Pushover.js
+++ b/app/triggers/providers/pushover/Pushover.js
@@ -14,6 +14,7 @@ class Pushover extends Trigger {
             user: this.joi.string().required(),
             token: this.joi.string().required(),
             device: this.joi.string(),
+            html: this.joi.number().valid(0, 1).default(0),
             sound: this.joi.string().allow(
                 'alien',
                 'bike',
@@ -95,6 +96,7 @@ class Pushover extends Trigger {
             sound: this.configuration.sound,
             device: this.configuration.device,
             priority: this.configuration.priority,
+            html: this.configuration.html,
         };
 
         // Emergency priority needs retry/expire props

--- a/docs/configuration/triggers/pushover/README.md
+++ b/docs/configuration/triggers/pushover/README.md
@@ -5,15 +5,17 @@ The `pushover` trigger lets you send realtime notifications to your devices (And
 
 ### Variables
 
-| Env var                                        | Required       | Description                                               | Supported values                                                                                   | Default value when missing  |
-|------------------------------------------------|:--------------:|-----------------------------------------------------------| -------------------------------------------------------------------------------------------------- |-----------------------------| 
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_TOKEN`    | :red_circle:   | The API token                                             |                                                                                                    |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_USER`     | :red_circle:   | The User key                                              |                                                                                                    |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_DEVICE`   | :white_circle: | The Device(s) to notify                                   | Coma separated list of devices (e.g. dev1,dev2) ([see here](https://pushover.net/api#identifiers)) |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_SOUND`    | :white_circle: | The notification sound                                    | [see here](https://pushover.net/api#sounds)                                                        | `pushover`                  |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_PRIORITY` | :white_circle: | The notification priority                                 | [see here](https://pushover.net/api#priority)                                                      | `0`                         |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_EXPIRE`   | :white_circle: | The notification expire in seconds (only when priority=2) | [see here](https://pushover.net/api#priority)                                                      |                             |
-| `WUD_TRIGGER_PUSHOVER_{trigger_name}_RETRY`    | :white_circle: | The notification retry in seconds (only when priority=2)  | [see here](https://pushover.net/api#priority)                                                      |                             |
+| Env var                                        | Required       | Description                                                          | Supported values                                                                                   | Default value when missing  |
+|------------------------------------------------|:--------------:|----------------------------------------------------------------------| -------------------------------------------------------------------------------------------------- |-----------------------------| 
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_TOKEN`    | :red_circle:   | The API token                                                        |                                                                                                    |                             |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_USER`     | :red_circle:   | The User key                                                         |                                                                                                    |                             |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_DEVICE`   | :white_circle: | The Device(s) to notify                                              | Coma separated list of devices (e.g. dev1,dev2) ([see here](https://pushover.net/api#identifiers)) |                             |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_SOUND`    | :white_circle: | The notification sound                                               | [see here](https://pushover.net/api#sounds)                                                        | `pushover`                  |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_PRIORITY` | :white_circle: | The notification priority                                            | [see here](https://pushover.net/api#priority)                                                      | `0`                         |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_EXPIRE`   | :white_circle: | The notification expire in seconds (only when priority=2)            | [see here](https://pushover.net/api#priority)                                                      |                             |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_RETRY`    | :white_circle: | The notification retry in seconds (only when priority=2)             | [see here](https://pushover.net/api#priority)                                                      |                             |
+| `WUD_TRIGGER_PUSHOVER_{trigger_name}_HTML`     | :white_circle: | Allow HTML formatting in message body (supported in Pushover 2.3+)   | [see here](https://pushover.net/api#html)                                                          | `0`                         |
+
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 


### PR DESCRIPTION
Adds optional html formatting functionality to Pushover messages. 

Add `WUD_TRIGGER_PUSHOVER_{trigger_name}_HTML=1` to your Pushover environment variables to enable it. 
Modify `WUD_TRIGGER_PUSHOVER_{trigger_name}_SIMPLEBODY` to contain HTML formatting tags as specified in the Pushover documentation. 

Pushover API documentation on HTML formatting: https://pushover.net/api#html

Resolves feature request #463