### PR TITLE
Adds install feature to HTTP trigger

### DIFF
--- a/docs/configuration/triggers/http/README.md
+++ b/docs/configuration/triggers/http/README.md
@@ -13,6 +13,9 @@ The `http` trigger lets you send container update notifications via HTTP.
 | `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_PASSWORD` | :white_circle: | The Auth user password if `BASIC` Auth is enabled |                              |                            |
 | `WUD_TRIGGER_HTTP_{trigger_name}_AUTH_BEARER`   | :white_circle: | The Auth bearer token if `BEARER` Auth is enabled |                              |                            |
 | `WUD_TRIGGER_HTTP_{trigger_name}_PROXY`         | :white_circle: | The HTTP Proxy                                    |                              |                            |
+| `WUD_TRIGGER_HTTP_{trigger_name}_INSTALL`       | :white_circle: | Sets this HTTP trigger as an install type\*       | `true`, or `false`           | `false`                    |
+
+\* By setting the INSTALL variable to `true`, this trigger is only executed manually in the containers UI page by clicking the "Install" button next to the upgrade version. Typical scheduled watch triggers for this http trigger will not occur when INSTALL is `true`. Only one INSTALL variable can be set across all trigger types - if more than one is set the UI will throw an error and the trigger will not be executed. 
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "6.6.0",
+    "axios": "^0.27.2",
     "core-js": "3.38.1",
     "install": "0.13.0",
     "npm": "10.9.0",

--- a/ui/src/components/SnackBar.vue
+++ b/ui/src/components/SnackBar.vue
@@ -1,8 +1,8 @@
 <template>
   <v-snackbar
     :value="show"
-    :timeout="timeout"
-    color="primary"
+    :timeout="computedTimeout"
+    :color="computedColor"
     @input="closeSnackbar"
     outlined
   >
@@ -33,7 +33,23 @@ export default {
       default: "info",
     },
   },
-
+  computed: {
+    computedColor() {
+      switch (this.level) {
+        case "success":
+          return "green";
+        case "warning":
+          return "orange";
+        case "error":
+          return "red";
+        default:
+          return "primary";
+      }
+    },
+    computedTimeout() {
+      return this.level === "error" ? 0 : this.timeout;
+    },
+  },
   methods: {
     closeSnackbar() {
       this.$root.$emit("notify:close");


### PR DESCRIPTION
Adds install feature to HTTP trigger. The intention of the feature is to allow for manual container upgrades when an update is available. This requires a listening webhook external to WUD that will respond to the HTTP call and trigger the upgrade process.  

When "WUD_TRIGGER_HTTP_{trigger_name}_INSTALL" is set to `true`:
1.  An "Install" button appears next to the upgrade version in the UI. See below for an example screenshot. When there is no upgrade available the install button will not show either. 
2. Clicking the "Install" button executes the HTTP trigger.
3. If "INSTALL" env variable is true, normal scheduled watch triggers do not happen for this trigger. 
4. Only one INSTALL env variable is allowed across all triggers. If more than one is set, the UI throws an error message indicating that only one is allowed and the HTTP trigger is not executed. 
5. Adds "install" key to the containers API endpoint for the UI to action on. 
6. Data sent by the HTTP trigger to the destination web hook will contain `actionType: install`. This could be used by the webhook to filter received HTTP calls if necessary. 

With the addition of the install key to the API it should be possible to add the INSTALL env feature to other trigger types as well. 

Should resolve (at least partially) #210

Screenshot:
<img width="652" alt="install_button_example" src="https://github.com/user-attachments/assets/a696af60-5a85-46bd-b764-05e85d7b6cd7">

