### PR TITLE
Update docs: LSCR registry configuration

### DIFF
--- a/docs/configuration/registries/lscr/README.md
+++ b/docs/configuration/registries/lscr/README.md
@@ -7,8 +7,8 @@ The `lscr` registry lets you configure [LSCR](https://fleet.linuxserver.io/) int
 
 | Env var                                      |   Required    | Description     | Supported values                         | Default value when missing |
 |----------------------------------------------|:-------------:|-----------------|------------------------------------------|----------------------------|
-| `WUD_REGISTRY_LSCR_{REGISTRY_NAME}_USERNAME` | :red_circle:  | Github username |                                          |                            |
-| `WUD_REGISTRY_LSCR_{REGISTRY_NAME}_TOKEN`    | :red_circle:  | Github token    | Github password or Github Personal Token |                            |
+| `WUD_REGISTRY_LSCR_USERNAME` | :red_circle:  | Github username |                                          |                            |
+| `WUD_REGISTRY_LSCR_TOKEN`    | :red_circle:  | Github token    | Github password or Github Personal Token |                            |
 
 ### Examples
 
@@ -20,14 +20,14 @@ services:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_LSCR_PRIVATE_USERNAME=john@doe
-      - WUD_REGISTRY_LSCR_PRIVATE_TOKEN=xxxxx 
+      - WUD_REGISTRY_LSCR_USERNAME=johndoe
+      - WUD_REGISTRY_LSCR_TOKEN=xxxxx 
 ```
 #### **Docker**
 ```bash
 docker run \
-  -e WUD_REGISTRY_LSCR_PRIVATE_USERNAME="john@doe" \
-  -e WUD_REGISTRY_LSCR_PRIVATE_TOKEN="xxxxx" \
+  -e WUD_REGISTRY_LSCR_USERNAME="johndoe" \
+  -e WUD_REGISTRY_LSCR_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```


### PR DESCRIPTION
While configuring LSCR, I noticed that the ENV variables configured weren't working as expected/documented.

I took some guesses and figured out that the following variables worked:

|Env|Usage|
|---|-----|
|`WUD_REGISTRY_LSCR_USERNAME`|GitHub username|
|`WUD_REGISTRY_LSCR_TOKEN`|GitHub PAT|

I updated the docs accordingly and adjusted the username `john@doe` in the examples to `johndoe` to make it clearer that this is a username - I was a bit confused with the `@` when I read the docs.