### PR TITLE
Add Major and Minor version release tags to docker build & push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ before_install:
 
   - export IMAGE_VERSION=${TRAVIS_BRANCH//\//\_}
   - export IMAGE_VERSION=${IMAGE_VERSION//\#/\_}
+  - export IMAGE_VERSION_MINOR=$(echo $IMAGE_VERSION | sed -rn 's/^(v?[[:digit:]]+.[[:digit:]]+).([[:digit:]]+)(.*)/\1/p')
+  - export IMAGE_VERSION_MAJOR=$(echo $IMAGE_VERSION | sed -rn 's/^(v?[[:digit:]]+).[[:digit:]]+.([[:digit:]]+)(.*)/\1/p')
 
   # Install docker with buildx
   - sudo install -m 0755 -d /etc/apt/keyrings
@@ -194,6 +196,8 @@ script:
   - |
     if [ ! -z "$TRAVIS_TAG" ]
     then
+      export DOCKER_TAGS="${DOCKER_TAGS} -t ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_VERSION_MAJOR} -t ghcr.io/${GITHUB_USERNAME}/${IMAGE_NAME}:${IMAGE_VERSION_MAJOR}"
+      export DOCKER_TAGS="${DOCKER_TAGS} -t ${DOCKER_USERNAME}/${IMAGE_NAME}:${IMAGE_VERSION_MINOR} -t ghcr.io/${GITHUB_USERNAME}/${IMAGE_NAME}:${IMAGE_VERSION_MINOR}"
       export DOCKER_TAGS="${DOCKER_TAGS} -t ${DOCKER_USERNAME}/${IMAGE_NAME}:latest -t ghcr.io/${GITHUB_USERNAME}/${IMAGE_NAME}:latest"
     fi
 


### PR DESCRIPTION
Implements #590.

This PR adds additional tags when publishing new docker images. E.g. when publishing new image `4.5.6`, the tags for this image will be `latest`, `4`, `4.5`, and `4.5.6`.

I'm open to suggestions on different implementations for this feature. I usually deal with Github Workflows instead of Travis so there may be more elegant ways of implementing this for the existing release flow that I am unaware of.