### PR TITLE
Handle image lookup failures to prevent the `No such image...` error along with a blank container list

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -542,9 +542,12 @@ class Docker extends Component {
                 container.Labels[wudDisplayIcon],
                 container.Labels[wudTriggerInclude],
                 container.Labels[wudTriggerExclude],
-            ),
+            ).catch(e => {
+                this.log.warn(`Failed to fetch image detail for container ${container.Id}: ${e.message}`);
+                return e;
+            }),
         );
-        const containersWithImage = await Promise.all(containerPromises);
+        const containersWithImage = (await Promise.all(containerPromises)).filter(result => !(result instanceof Error));
 
         // Return containers to process
         const containersToReturn = containersWithImage.filter(


### PR DESCRIPTION
Catch image lookup failures to prevent one/more unknown images from throwing the `No such image...` error while being queried, therefore presenting the user with a blank container list ([#450](https://github.com/getwud/wud/issues/450))