### PR TITLE
add title usage to telegram and slack

### DIFF
--- a/app/triggers/providers/slack/Slack.js
+++ b/app/triggers/providers/slack/Slack.js
@@ -13,6 +13,7 @@ class Slack extends Trigger {
         return this.joi.object().keys({
             token: this.joi.string().required(),
             channel: this.joi.string().required(),
+            disabletitle: this.joi.boolean().default(false),
         });
     }
 
@@ -42,11 +43,24 @@ class Slack extends Trigger {
      * @returns {Promise<void>}
      */
     async trigger(container) {
-        return this.postMessage(this.renderSimpleBody(container));
+        const body = this.renderSimpleBody(container);
+
+        if (this.configuration.disabletitle) {
+            return this.sendMessage(body);
+        }
+
+        const title = this.renderSimpleTitle(container);
+        return this.sendMessage(`*${title}*\n\n${body}`);
     }
 
     async triggerBatch(containers) {
-        return this.postMessage(this.renderBatchBody(containers));
+        const body = this.renderBatchBody(containers);
+        if (this.configuration.disabletitle) {
+            return this.sendMessage(body);
+        }
+
+        const title = this.renderBatchTitle(containers);
+        return this.sendMessage(`*${title}*\n\n${body}`);
     }
 
     /**
@@ -54,7 +68,7 @@ class Slack extends Trigger {
      * @param text the text to post
      * @returns {Promise<ChatPostMessageResponse>}
      */
-    async postMessage(text) {
+    async sendMessage(text) {
         return this.client.chat.postMessage({
             channel: this.configuration.channel,
             text,

--- a/app/triggers/providers/slack/Slack.test.js
+++ b/app/triggers/providers/slack/Slack.test.js
@@ -20,6 +20,7 @@ const configurationValid = {
         'Container ${container.name} running with ${container.updateKind.kind} ${container.updateKind.localValue} can be updated to ${container.updateKind.kind} ${container.updateKind.remoteValue}${container.result && container.result.link ? "\\n" + container.result.link : ""}',
 
     batchtitle: '${containers.length} updates available',
+    disabletitle: false,
 };
 
 test('validateConfiguration should return validated configuration when valid', () => {
@@ -91,6 +92,33 @@ test('trigger should format text as expected', async () => {
         },
     });
     expect(response.text).toEqual(
-        'Container homeassistant running with tag 1.0.0 can be updated to tag 2.0.0\nhttps://test-2.0.0/changelog',
+        '*New tag found for container homeassistant*\n\nContainer homeassistant running with tag 1.0.0 can be updated to tag 2.0.0\nhttps://test-2.0.0/changelog',
     );
+});
+
+test('should send message with correct text', async () => {
+    slack.configuration = {
+        ...configurationValid,
+        simpletitle: 'Test Title',
+        simplebody: 'Test Body',
+    };
+    slack.sendMessage = jest.fn();
+    await slack.trigger({});
+    expect(slack.sendMessage).toHaveBeenCalledWith(
+        '*Test Title*\n\nTest Body'
+    );
+});
+
+test('disabletitle should result in no title in message', async () => {
+    slack.configuration = {
+        ...configurationValid,
+        simpletitle: 'Test Title',
+        simplebody: 'Test Body',
+        disabletitle: true,
+    };
+
+    slack.sendMessage = jest.fn();
+    await slack.trigger({});
+
+    expect(slack.sendMessage).toHaveBeenCalledWith('Test Body');
 });

--- a/docs/configuration/triggers/slack/README.md
+++ b/docs/configuration/triggers/slack/README.md
@@ -1,4 +1,5 @@
 # Slack
+
 ![logo](slack.png)
 
 The `slack` trigger lets you post image update notifications to a Slack channel.
@@ -6,9 +7,10 @@ The `slack` trigger lets you post image update notifications to a Slack channel.
 ### Variables
 
 | Env var                                    | Required     | Description                      | Supported values | Default value when missing |
-| ------------------------------------------ |:------------:| -------------------------------- | ---------------- | -------------------------- | 
+| ------------------------------------------ |:------------:| -------------------------------- | ---------------- | -------------------------- |
 | `WUD_TRIGGER_SLACK_{trigger_name}_TOKEN`   | :red_circle: | The Oauth Token of the Slack app |                  |                            |
 | `WUD_TRIGGER_SLACK_{trigger_name}_CHANNEL` | :red_circle: | The name of the channel to post  |                  |                            |
+| `WUD_TRIGGER_SLACK_{trigger_name}_DISABLETITLE` | :white_circle: | Disable title to have full control over the message formatting | `true`, `false`| `false` |
 
 !> The Slack channel must already exist on the workspace (the trigger won't automatically create it)
 
@@ -18,6 +20,7 @@ The `slack` trigger lets you post image update notifications to a Slack channel.
 
 <!-- tabs:start -->
 #### **Docker Compose**
+
 ```yaml
 services:
   whatsupdocker:
@@ -29,6 +32,7 @@ services:
 ```
 
 #### **Docker**
+
 ```bash
 docker run \
     -e WUD_TRIGGER_SLACK_TEST_TOKEN="xoxp-743817063446-xxx" \

--- a/docs/configuration/triggers/telegram/README.md
+++ b/docs/configuration/triggers/telegram/README.md
@@ -1,4 +1,5 @@
 # Telegram
+
 ![logo](telegram.png)
 
 The `telegram` trigger lets you send realtime notifications using [Telegram](https://telegram.org/) bots.
@@ -6,9 +7,11 @@ The `telegram` trigger lets you send realtime notifications using [Telegram](htt
 ### Variables
 
 | Env var                                        | Required       | Description   | Supported values                                                                                   | Default value when missing  |
-|------------------------------------------------|:--------------:|---------------| -------------------------------------------------------------------------------------------------- |-----------------------------| 
+|------------------------------------------------|:--------------:|---------------| -------------------------------------------------------------------------------------------------- |-----------------------------|
 | `WUD_TRIGGER_TELEGRAM_{trigger_name}_BOTTOKEN` | :red_circle:   | The Bot token |                                                                                                    |                             |
 | `WUD_TRIGGER_TELEGRAM_{trigger_name}_CHATID`   | :red_circle:   | The Chat ID   |                                                                                                    |                             |
+| `WUD_TRIGGER_TELEGRAM_{trigger_name}_DISABLETITLE`   |  :white_circle:  | Disable title to have full control over the message formatting   |    `true`, `false`| `false`  |
+| `WUD_TRIGGER_TELEGRAM_{trigger_name}_MESSAGEFORMAT`   | :white_circle: | Send the message as markdown or as html (useful for custom message formatting) | `Markdown`, `HTML`  | `Markdown` |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -17,6 +20,7 @@ The `telegram` trigger lets you send realtime notifications using [Telegram](htt
 #### Configuration
 <!-- tabs:start -->
 #### **Docker Compose**
+
 ```yaml
 services:
   whatsupdocker:
@@ -28,6 +32,7 @@ services:
 ```
 
 #### **Docker**
+
 ```bash
 docker run \
   -e WUD_TRIGGER_TELEGRAM_1_BOTTOKEN="0123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
@@ -38,7 +43,9 @@ docker run \
 <!-- tabs:end -->
 
 ### How to create a bot and get the bot token
+
 [Follow this tutorial](https://medium.com/geekculture/generate-telegram-token-for-bot-api-d26faf9bf064)
 
 ### How to get the chat id
+
 [Follow this tutorial](https://www.alphr.com/find-chat-id-telegram/)


### PR DESCRIPTION
This update ensures a more consistent default behavior by including the title in both Slack and Telegram messages. Previously, the title was omitted in both integrations.

Changes introduced:
- Titles are now included bolded and separated from the message body by a new line.
- A new property `disableTitle` has been added to allow users to revert to the previous behavior or omit the title entirely for more control.
- For Telegram, a new property `messageformat` has been added to let users specify the message format: either `markdown` or `html`.

These changes aim to provide better default formatting while preserving the ability to fully customize the message structure.

Fixes #692 