### PR TITLE
Add support for custom TLDs in SMTP trigger

### DIFF
--- a/app/triggers/providers/smtp/Smtp.js
+++ b/app/triggers/providers/smtp/Smtp.js
@@ -15,11 +15,27 @@ class Smtp extends Trigger {
                 this.joi.string().hostname().required(),
                 this.joi.string().ip().required(),
             ],
+            allowcustomtld: this.joi.boolean().default(false),
             port: this.joi.number().port().required(),
             user: this.joi.string(),
             pass: this.joi.string(),
-            from: this.joi.string().email().required(),
-            to: this.joi.string().email().required(),
+            from: this.joi.string().required().when(
+                'allowcustomtld',
+                {
+                    is: true,
+                    then: this.joi.string().email({ tlds: { allow: false } }),
+                    otherwise: this.joi.string().email(),
+                }
+
+            ),
+            to: this.joi.string().required().when(
+                'allowcustomtld',
+                {
+                    is: true,
+                    then: this.joi.string().email({ tlds: { allow: false } }),
+                    otherwise: this.joi.string().email(),
+                }
+            ),
             tls: this.joi
                 .object({
                     enabled: this.joi.boolean().default(false),

--- a/docs/configuration/triggers/smtp/README.md
+++ b/docs/configuration/triggers/smtp/README.md
@@ -4,16 +4,17 @@ The `smtp` trigger lets you send emails with smtp.
 
 ### Variables
 
-| Env var                                       | Required       | Description                   | Supported values              | Default value when missing |
-| --------------------------------------------- |:--------------:|:----------------------------- | ----------------------------- | -------------------------- | 
-| `WUD_TRIGGER_SMTP_{trigger_name}_HOST`        | :red_circle:   | Smtp server host              | Valid hostname or IP address  |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PORT`        | :red_circle:   | Smtp server port              | Valid smtp port               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_FROM`        | :red_circle:   | Email from address            | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TO`          | :red_circle:   | Email to address              | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_USER`        | :white_circle: | Smtp user                     |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PASS`        | :white_circle: | Smtp password                 |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED` | :white_circle: | Use TLS                       | `true`, `false`               | `false`                    |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`  | :white_circle: | Verify server TLS certificate | `true`, `false`               | `true`                     |
+| Env var                                           | Required       | Description                                | Supported values              | Default value when missing |
+| ------------------------------------------------- |:--------------:|:------------------------------------------ | ----------------------------- | -------------------------- |
+| `WUD_TRIGGER_SMTP_{trigger_name}_HOST`            | :red_circle:   | Smtp server host                           | Valid hostname or IP address  |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_PORT`            | :red_circle:   | Smtp server port                           | Valid smtp port               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_FROM`            | :red_circle:   | Email from address                         | Valid email address           |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TO`              | :red_circle:   | Email to address                           | Valid email address           |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_USER`            | :white_circle: | Smtp user                                  |                               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_PASS`            | :white_circle: | Smtp password                              |                               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED`     | :white_circle: | Use TLS                                    | `true`, `false`               | `false`                    |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`      | :white_circle: | Verify server TLS certificate              | `true`, `false`               | `true`                     |
+| `WUD_TRIGGER_SMTP_{trigger_name}_ALLOWCUSTOMTLD`  | :white_circle: | Allow custom tlds for the email addresses  | `true`, `false`               | `false`                    |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -23,6 +24,7 @@ The `smtp` trigger lets you send emails with smtp.
 
 <!-- tabs:start -->
 #### **Docker Compose**
+
 ```yaml
 services:
   whatsupdocker:
@@ -39,6 +41,7 @@ services:
 ```
 
 #### **Docker**
+
 ```bash
 docker run \
     -e WUD_TRIGGER_SMTP_GMAIL_HOST="smtp.gmail.com" \


### PR DESCRIPTION
Adds a new `allowcustomtld` boolean flag to the SMTP trigger config, allowing support for email addresses with custom (non-standard) TLDs like `.lan`, `.local` or `.internal`. When set to `true`, domain validation will no longer restrict to known public TLDs.

Default behavior remains unchanged. Includes tests for both standard and custom TLD cases

Requested by #636