### PR TITLE
Added LSCR icon

### DIFF
--- a/ui/src/services/registry.js
+++ b/ui/src/services/registry.js
@@ -12,13 +12,13 @@ function getRegistryIcon() {
  * @returns {string}
  */
 function getRegistryProviderIcon(provider) {
-  let icon = "mdi-help";
+  let icon = "si-linuxcontainers";
   switch (provider.split(".")[0]) {
     case "acr":
       icon = "si-microsoftazure";
       break;
     case "custom":
-      icon = "mdi-home";
+      icon = "si-opencontainersinitiative";
       break;
     case "ecr":
       icon = "si-amazonaws";
@@ -43,6 +43,9 @@ function getRegistryProviderIcon(provider) {
       break;
     case "quay":
       icon = "si-redhat";
+      break;
+    case "lscr":
+      icon = "si-linuxserver";
       break;
   }
   return icon;


### PR DESCRIPTION
All [distribution](https://github.com/simple-icons/simple-icons/issues/13635) is based in CNI and for unknown I think using linuxcontainers will the fine.

Allow in future this to have custom icon like I [explain here](https://github.com/getwud/wud/discussions/716) will be nice.