### PR TITLE
Document password colon limitation in basic auth

### DIFF
--- a/docs/configuration/authentications/basic/README.md
+++ b/docs/configuration/authentications/basic/README.md
@@ -20,6 +20,8 @@ or use single quotes in Bash commands \
 or escape them in Bash commands \
 `WUD_AUTH_BASIC_JOHN_HASH="\$apr1\$aefKbZEa$ZSA5Y3zv9vDQOxr283NGx/"`
 
+!> **Known limitation:** Passwords containing colon characters (`:`) are not supported due to a bug in the underlying `passport-http` library. Authentication will fail if your password contains a colon. Use passwords without colons until this is resolved.
+
 ### Examples
 
 <!-- tabs:start -->


### PR DESCRIPTION
## Summary
- Add warning about passwords containing colon characters (`:`) not being supported
- References issue #782

## Context
Basic authentication fails when passwords contain colon characters due to a known bug in the `passport-http` library. The library incorrectly parses the Authorization header by splitting on all colons instead of only the first one, which truncates passwords containing `:`.

This documentation update warns users about this limitation until the underlying library issue is resolved.

## Changes
- Added a warning box in the basic auth documentation explaining the colon limitation
- Advises users to avoid colons in passwords as a workaround

Fixes #782