### PR TITLE
Fix Ntfy trigger configuration masking

### DIFF
--- a/app/triggers/providers/ntfy/Ntfy.js
+++ b/app/triggers/providers/ntfy/Ntfy.js
@@ -36,9 +36,9 @@ class Ntfy extends Trigger {
             ...this.configuration,
             auth: this.configuration.auth
                 ? {
-                      user: Ntfy.mask(this.configuration.user),
-                      password: Ntfy.mask(this.configuration.password),
-                      token: Ntfy.mask(this.configuration.token),
+                      user: Ntfy.mask(this.configuration.auth.user),
+                      password: Ntfy.mask(this.configuration.auth.password),
+                      token: Ntfy.mask(this.configuration.auth.token),
                   }
                 : undefined,
         };

--- a/app/triggers/providers/ntfy/Ntfy.test.js
+++ b/app/triggers/providers/ntfy/Ntfy.test.js
@@ -42,6 +42,23 @@ test('validateConfiguration should throw error when invalid', () => {
     }).toThrowError(ValidationError);
 });
 
+test('maskConfiguration should mask sensitive data', () => {
+    ntfy.configuration = {
+        auth: {
+            user: 'user',
+            password: 'password',
+            token: 'token',
+        },
+    };
+    expect(ntfy.maskConfiguration()).toEqual({
+        auth: {
+            user: 'u**r',
+            password: 'p******d',
+            token: 't***n',
+        },
+    });
+});
+
 test('trigger should call http client', async () => {
     ntfy.configuration = configurationValid;
     const container = {


### PR DESCRIPTION
When attempting to mask sensitive `auth` parameters in the `maskConfiguration()` method, they would incorrectly get masked with `undefined`, instead of a `e****e` form. This happens due to the method accessing incorrect properties in the configuration object. The PR fixes this.

This test fails without the changes:

```js
// Ntfy.test.js
test('maskConfiguration should mask sensitive data', () => {
    ntfy.configuration = {
        auth: {
            user: 'user',
            password: 'password',
            token: 'token',
        },
    };
    expect(ntfy.maskConfiguration()).toEqual({
        auth: {
            user: 'u**r',
            password: 'p******d',
            token: 't***n',
        },
    });
});
```