### PR TITLE
Mqtt trigger / Home Assistant: replaced dot by hyphen in container (state) topic

### DIFF
--- a/app/triggers/providers/mqtt/Hass.js
+++ b/app/triggers/providers/mqtt/Hass.js
@@ -356,7 +356,8 @@ class Hass {
      * @return {string}
      */
     getContainerStateTopic({ container }) {
-        return `${this.configuration.topic}/${container.watcher}/${container.name}`;
+        const containerName = container.name.replace(/\./g, '-');
+        return `${this.configuration.topic}/${container.watcher}/${containerName}`;
     }
 
     /**

--- a/app/triggers/providers/mqtt/Hass.test.js
+++ b/app/triggers/providers/mqtt/Hass.test.js
@@ -1,6 +1,31 @@
 const log = require('../../../log');
 const Hass = require('./Hass');
 
+const containerData = [
+    {
+        containerName: 'container-name',
+        data: {
+            discoveryTopic:
+                'homeassistant/update/topic_watcher-name_container-name/config',
+            unique_id: 'topic_watcher-name_container-name',
+            object_id: 'topic_watcher-name_container-name',
+            name: 'topic_watcher-name_container-name',
+            topic: 'topic/watcher-name/container-name',
+        },
+    },
+    {
+        containerName: 'container-1.name',
+        data: {
+            discoveryTopic:
+                'homeassistant/update/topic_watcher-name_container-1-name/config',
+            unique_id: 'topic_watcher-name_container-1-name',
+            object_id: 'topic_watcher-name_container-1-name',
+            name: 'topic_watcher-name_container-1-name',
+            topic: 'topic/watcher-name/container-1-name',
+        },
+    },
+];
+
 let hass;
 let mqttClientMock;
 
@@ -54,265 +79,277 @@ test('publishDiscoveryMessage must publish a discovery message expected by HA', 
     );
 });
 
-test('addContainerSensor must publish sensor discovery message expected by HA', async () => {
-    await hass.addContainerSensor({
-        name: 'container-name',
-        watcher: 'watcher-name',
-        displayIcon: 'mdi:docker',
-    });
-    expect(mqttClientMock.publish).toHaveBeenCalledWith(
-        'homeassistant/update/topic_watcher-name_container-name/config',
-        JSON.stringify({
-            unique_id: 'topic_watcher-name_container-name',
-            object_id: 'topic_watcher-name_container-name',
-            name: 'topic_watcher-name_container-name',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/watcher-name/container-name',
-            force_update: true,
-            value_template: '{{ value_json.image_tag_value }}',
-            latest_version_topic: 'topic/watcher-name/container-name',
-            latest_version_template:
-                '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}',
-            json_attributes_topic: 'topic/watcher-name/container-name',
-        }),
-        { retain: true },
-    );
-});
+test.each(containerData)(
+    'addContainerSensor must publish sensor discovery message expected by HA',
+    async ({ containerName, data }) => {
+        await hass.addContainerSensor({
+            name: containerName,
+            watcher: 'watcher-name',
+            displayIcon: 'mdi:docker',
+        });
+        expect(mqttClientMock.publish).toHaveBeenCalledWith(
+            data.discoveryTopic,
+            JSON.stringify({
+                unique_id: data.unique_id,
+                object_id: data.object_id,
+                name: data.name,
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: data.topic,
+                force_update: true,
+                value_template: '{{ value_json.image_tag_value }}',
+                latest_version_topic: data.topic,
+                latest_version_template:
+                    '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.result_tag }}{% endif %}',
+                json_attributes_topic: data.topic,
+            }),
+            { retain: true },
+        );
+    },
+);
 
-test('removeContainerSensor must publish sensor discovery message expected by HA', async () => {
-    await hass.removeContainerSensor({
-        name: 'container-name',
-        watcher: 'watcher-name',
-        displayIcon: 'mdi:docker',
-    });
-    expect(mqttClientMock.publish).toHaveBeenCalledWith(
-        'homeassistant/update/topic_watcher-name_container-name/config',
-        JSON.stringify({}),
-        { retain: true },
-    );
-});
+test.each(containerData)(
+    'removeContainerSensor must publish sensor discovery message expected by HA',
+    async ({ containerName, data }) => {
+        await hass.removeContainerSensor({
+            name: containerName,
+            watcher: 'watcher-name',
+            displayIcon: 'mdi:docker',
+        });
+        expect(mqttClientMock.publish).toHaveBeenCalledWith(
+            data.discoveryTopic,
+            JSON.stringify({}),
+            { retain: true },
+        );
+    },
+);
 
-test('updateContainerSensors must publish all sensors expected by HA', async () => {
-    await hass.updateContainerSensors({
-        name: 'container-name',
-        watcher: 'watcher-name',
-        displayIcon: 'mdi:docker',
-    });
-    expect(mqttClientMock.publish).toHaveBeenCalledTimes(15);
+test.each(containerData)(
+    'updateContainerSensors must publish all sensors expected by HA',
+    async ({ containerName, data }) => {
+        await hass.updateContainerSensors({
+            name: containerName,
+            watcher: 'watcher-name',
+            displayIcon: 'mdi:docker',
+        });
+        expect(mqttClientMock.publish).toHaveBeenCalledTimes(15);
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        1,
-        'homeassistant/sensor/topic_total_count/config',
-        JSON.stringify({
-            unique_id: 'topic_total_count',
-            object_id: 'topic_total_count',
-            name: 'Total container count',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/total_count',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            1,
+            'homeassistant/sensor/topic_total_count/config',
+            JSON.stringify({
+                unique_id: 'topic_total_count',
+                object_id: 'topic_total_count',
+                name: 'Total container count',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/total_count',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        2,
-        'homeassistant/sensor/topic_update_count/config',
-        JSON.stringify({
-            unique_id: 'topic_update_count',
-            object_id: 'topic_update_count',
-            name: 'Total container update count',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/update_count',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            2,
+            'homeassistant/sensor/topic_update_count/config',
+            JSON.stringify({
+                unique_id: 'topic_update_count',
+                object_id: 'topic_update_count',
+                name: 'Total container update count',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/update_count',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        3,
-        'homeassistant/binary_sensor/topic_update_status/config',
-        JSON.stringify({
-            unique_id: 'topic_update_status',
-            object_id: 'topic_update_status',
-            name: 'Total container update status',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/update_status',
-            payload_on: 'true',
-            payload_off: 'false',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            3,
+            'homeassistant/binary_sensor/topic_update_status/config',
+            JSON.stringify({
+                unique_id: 'topic_update_status',
+                object_id: 'topic_update_status',
+                name: 'Total container update status',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/update_status',
+                payload_on: 'true',
+                payload_off: 'false',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        4,
-        'homeassistant/sensor/topic_watcher-name_total_count/config',
-        JSON.stringify({
-            unique_id: 'topic_watcher-name_total_count',
-            object_id: 'topic_watcher-name_total_count',
-            name: 'Watcher watcher-name container count',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/watcher-name/total_count',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            4,
+            'homeassistant/sensor/topic_watcher-name_total_count/config',
+            JSON.stringify({
+                unique_id: 'topic_watcher-name_total_count',
+                object_id: 'topic_watcher-name_total_count',
+                name: 'Watcher watcher-name container count',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/watcher-name/total_count',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        5,
-        'homeassistant/sensor/topic_watcher-name_update_count/config',
-        JSON.stringify({
-            unique_id: 'topic_watcher-name_update_count',
-            object_id: 'topic_watcher-name_update_count',
-            name: 'Watcher watcher-name container update count',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/watcher-name/update_count',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            5,
+            'homeassistant/sensor/topic_watcher-name_update_count/config',
+            JSON.stringify({
+                unique_id: 'topic_watcher-name_update_count',
+                object_id: 'topic_watcher-name_update_count',
+                name: 'Watcher watcher-name container update count',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/watcher-name/update_count',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        6,
-        'homeassistant/binary_sensor/topic_watcher-name_update_status/config',
-        JSON.stringify({
-            unique_id: 'topic_watcher-name_update_status',
-            object_id: 'topic_watcher-name_update_status',
-            name: 'Watcher watcher-name container update status',
-            device: {
-                identifiers: ['wud'],
-                manufacturer: 'wud',
-                model: 'wud',
-                name: 'wud',
-                sw_version: 'unknown',
-            },
-            icon: 'mdi:docker',
-            entity_picture:
-                'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
-            state_topic: 'topic/watcher-name/update_status',
-            payload_on: 'true',
-            payload_off: 'false',
-        }),
-        { retain: true },
-    );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            6,
+            'homeassistant/binary_sensor/topic_watcher-name_update_status/config',
+            JSON.stringify({
+                unique_id: 'topic_watcher-name_update_status',
+                object_id: 'topic_watcher-name_update_status',
+                name: 'Watcher watcher-name container update status',
+                device: {
+                    identifiers: ['wud'],
+                    manufacturer: 'wud',
+                    model: 'wud',
+                    name: 'wud',
+                    sw_version: 'unknown',
+                },
+                icon: 'mdi:docker',
+                entity_picture:
+                    'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
+                state_topic: 'topic/watcher-name/update_status',
+                payload_on: 'true',
+                payload_off: 'false',
+            }),
+            { retain: true },
+        );
 
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        7,
-        'topic/total_count',
-        '0',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        8,
-        'topic/update_count',
-        '0',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        9,
-        'topic/update_status',
-        'false',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        10,
-        'topic/watcher-name/total_count',
-        '0',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        11,
-        'topic/watcher-name/update_count',
-        '0',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        12,
-        'topic/watcher-name/update_status',
-        'false',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        13,
-        'homeassistant/sensor/topic_watcher-name_total_count/config',
-        '{}',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        14,
-        'homeassistant/sensor/topic_watcher-name_update_count/config',
-        '{}',
-        { retain: true },
-    );
-    expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
-        15,
-        'homeassistant/binary_sensor/topic_watcher-name_update_status/config',
-        '{}',
-        { retain: true },
-    );
-});
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            7,
+            'topic/total_count',
+            '0',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            8,
+            'topic/update_count',
+            '0',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            9,
+            'topic/update_status',
+            'false',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            10,
+            'topic/watcher-name/total_count',
+            '0',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            11,
+            'topic/watcher-name/update_count',
+            '0',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            12,
+            'topic/watcher-name/update_status',
+            'false',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            13,
+            'homeassistant/sensor/topic_watcher-name_total_count/config',
+            '{}',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            14,
+            'homeassistant/sensor/topic_watcher-name_update_count/config',
+            '{}',
+            { retain: true },
+        );
+        expect(mqttClientMock.publish).toHaveBeenNthCalledWith(
+            15,
+            'homeassistant/binary_sensor/topic_watcher-name_update_status/config',
+            '{}',
+            { retain: true },
+        );
+    },
+);
 
-test('removeContainerSensor must publish all sensor removal messages expected by HA', async () => {
-    await hass.removeContainerSensor({
-        name: 'container-name',
-        watcher: 'watcher-name',
-        displayIcon: 'mdi:docker',
-    });
-    expect(mqttClientMock.publish).toHaveBeenCalledWith(
-        'homeassistant/update/topic_watcher-name_container-name/config',
-        JSON.stringify({}),
-        { retain: true },
-    );
-});
+test.each(containerData)(
+    'removeContainerSensor must publish all sensor removal messages expected by HA',
+    async ({ containerName, data }) => {
+        await hass.removeContainerSensor({
+            name: containerName,
+            watcher: 'watcher-name',
+            displayIcon: 'mdi:docker',
+        });
+        expect(mqttClientMock.publish).toHaveBeenCalledWith(
+            data.discoveryTopic,
+            JSON.stringify({}),
+            { retain: true },
+        );
+    },
+);
 
 test('updateWatcherSensors must publish all watcher sensor messages expected by HA', async () => {
     await hass.updateWatcherSensors({

--- a/app/triggers/providers/mqtt/Mqtt.js
+++ b/app/triggers/providers/mqtt/Mqtt.js
@@ -18,7 +18,8 @@ const hassDefaultPrefix = 'homeassistant';
  * @return {string}
  */
 function getContainerTopic({ baseTopic, container }) {
-    return `${baseTopic}/${container.watcher}/${container.name}`;
+    const containerName = container.name.replace(/\./g, '-');
+    return `${baseTopic}/${container.watcher}/${containerName}`;
 }
 
 /**

--- a/app/triggers/providers/mqtt/Mqtt.test.js
+++ b/app/triggers/providers/mqtt/Mqtt.test.js
@@ -1,6 +1,7 @@
 const { ValidationError } = require('joi');
 const mqttClient = require('mqtt');
 const log = require('../../../log');
+const { flatten } = require('../../../model/container');
 
 jest.mock('mqtt');
 const Mqtt = require('./Mqtt');
@@ -36,8 +37,28 @@ const configurationValid = {
     batchtitle: '${containers.length} updates available',
 };
 
+const containerData = [
+    {
+        containerName: 'homeassistant',
+        data: {
+            name: 'homeassistant',
+            topic: 'wud/container/local/homeassistant',
+        },
+    },
+    {
+        containerName: 'home.assistant',
+        data: {
+            name: 'home.assistant',
+            topic: 'wud/container/local/home-assistant',
+        },
+    },
+];
+
 beforeEach(() => {
     jest.resetAllMocks();
+    mqtt.client = {
+        publish: jest.fn(() => {}),
+    };
 });
 
 test('validateConfiguration should return validated configuration when valid', () => {
@@ -108,44 +129,44 @@ test('initTrigger should init Mqtt client', async () => {
     });
 });
 
-test('trigger should format json message payload as expected', async () => {
-    mqtt.configuration = {
-        topic: 'wud/container',
-    };
-    mqtt.client = {
-        publish: (topic, message) => ({
-            topic,
-            message,
-        }),
-    };
-    const response = await mqtt.trigger({
-        id: '31a61a8305ef1fc9a71fa4f20a68d7ec88b28e32303bbc4a5f192e851165b816',
-        name: 'homeassistant',
-        watcher: 'local',
-        includeTags: '^\\d+\\.\\d+.\\d+$',
-        image: {
-            id: 'sha256:d4a6fafb7d4da37495e5c9be3242590be24a87d7edcc4f79761098889c54fca6',
-            registry: {
-                url: '123456789.dkr.ecr.eu-west-1.amazonaws.com',
+test.each(containerData)(
+    'trigger should format json message payload as expected',
+    async ({ containerName, data }) => {
+        mqtt.configuration = {
+            topic: 'wud/container',
+        };
+        const container = {
+            id: '31a61a8305ef1fc9a71fa4f20a68d7ec88b28e32303bbc4a5f192e851165b816',
+            name: containerName,
+            watcher: 'local',
+            includeTags: '^\\d+\\.\\d+.\\d+$',
+            image: {
+                id: 'sha256:d4a6fafb7d4da37495e5c9be3242590be24a87d7edcc4f79761098889c54fca6',
+                registry: {
+                    url: '123456789.dkr.ecr.eu-west-1.amazonaws.com',
+                },
+                name: 'test',
+                tag: {
+                    value: '2021.6.4',
+                    semver: true,
+                },
+                digest: {
+                    watch: false,
+                    repo: 'sha256:ca0edc3fb0b4647963629bdfccbb3ccfa352184b45a9b4145832000c2878dd72',
+                },
+                architecture: 'amd64',
+                os: 'linux',
+                created: '2021-06-12T05:33:38.440Z',
             },
-            name: 'test',
-            tag: {
-                value: '2021.6.4',
-                semver: true,
+            result: {
+                tag: '2021.6.5',
             },
-            digest: {
-                watch: false,
-                repo: 'sha256:ca0edc3fb0b4647963629bdfccbb3ccfa352184b45a9b4145832000c2878dd72',
-            },
-            architecture: 'amd64',
-            os: 'linux',
-            created: '2021-06-12T05:33:38.440Z',
-        },
-        result: {
-            tag: '2021.6.5',
-        },
-    });
-    expect(response.message).toEqual(
-        '{"id":"31a61a8305ef1fc9a71fa4f20a68d7ec88b28e32303bbc4a5f192e851165b816","name":"homeassistant","watcher":"local","include_tags":"^\\\\d+\\\\.\\\\d+.\\\\d+$","image_id":"sha256:d4a6fafb7d4da37495e5c9be3242590be24a87d7edcc4f79761098889c54fca6","image_registry_url":"123456789.dkr.ecr.eu-west-1.amazonaws.com","image_name":"test","image_tag_value":"2021.6.4","image_tag_semver":true,"image_digest_watch":false,"image_digest_repo":"sha256:ca0edc3fb0b4647963629bdfccbb3ccfa352184b45a9b4145832000c2878dd72","image_architecture":"amd64","image_os":"linux","image_created":"2021-06-12T05:33:38.440Z","result_tag":"2021.6.5"}',
-    );
-});
+        };
+        await mqtt.trigger(container);
+        expect(mqtt.client.publish).toHaveBeenCalledWith(
+            data.topic,
+            JSON.stringify(flatten(container)),
+            { retain: true },
+        );
+    },
+);


### PR DESCRIPTION
Fixes #722.

I updated Hass getContainerStateTopic and Mqtt getContainerTopic to replace dot by hyphen.

In the tests I added parameters to use original test data and new test data with a dot.

To test the topic in Mqtt.test.js I had to mock mqtt.client.publish. I'm not sure if I did it that correct because mocking of MQTT client in Hass.test.js and Mqtt.test.js differs.