### PR TITLE
chore: git ignore osx crapfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,6 @@ typings/
 
 # Ignore loki file
 .store
+
+# Ignore OSX crap-files
+*.DS_Store


### PR DESCRIPTION
Simply put:
Prevents DS_Store OSX crapfiles to be accidentally pushed with GIT