### PR TITLE
fix: always ignore .sig tags

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -69,6 +69,9 @@ function getTagCandidates(container, tags, logContainer) {
         );
     }
 
+    // Always filter out tags ending with ".sig"
+    filteredTags = filteredTags.filter(tag => !tag.endsWith('.sig'));
+    
     // Semver image -> find higher semver tag
     if (container.image.tag.semver) {
         if (filteredTags.length === 0) {


### PR DESCRIPTION
This should fix the issue of ".sig" tags appearing as detected version updates

Fixes: #829 