### PR TITLE
fix: by default filter out tags starting with "sha"

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -59,6 +59,9 @@ function getTagCandidates(container, tags, logContainer) {
     if (container.includeTags) {
         const includeTagsRegex = new RegExp(container.includeTags);
         filteredTags = filteredTags.filter((tag) => includeTagsRegex.test(tag));
+    } else {
+        // If no includeTags, filter out tags ending with ".sig"
+        filteredTags = filteredTags.filter(tag => !tag.startsWith('sha'));
     }
 
     // Match exclude tag regex


### PR DESCRIPTION
This filters out any tags starting with "sha".

Unless the user sets a custom filter include, in which case we don't filter this out.
Without this exception users would not be able to use any tags starting with "sha" and it would also be a breaking change for users that do use such a custom filter.


Fixes: #829 