### PR TITLE
fix: default to keep semver-prefix

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -79,21 +79,30 @@ function getTagCandidates(container, tags, logContainer) {
 
         // If user has not specified custom include regex, default to keep current prefix
         // Prefix is almost-always standardised around "must stay the same" for tags
-        if (! container.includeTags){
-            // Determine current tag prefix
+        if (!container.includeTags) {
             const currentTag = container.image.tag.value;
-            const match = currentTag.match(/^(.*?)(\d+\.\d+\.\d+.*)$/);
+            const match = currentTag.match(/^(.*?)(\d+.*)$/);
             const currentPrefix = match ? match[1] : '';
-    
-            // Retain only tags with the same prefix
+        
             if (currentPrefix) {
+                // Retain only tags with the same non-empty prefix
                 filteredTags = filteredTags.filter(tag => tag.startsWith(currentPrefix));
+            } else {
+                // Retain only tags that start with a number (no prefix)
+                filteredTags = filteredTags.filter(tag => /^\d/.test(tag));
             }
-    
+        
+            // Ensure we throw good errors when we've prefix-related issues
             if (filteredTags.length === 0) {
-                logContainer.warn(
-                   "No tags found with existing prefix: " + currentPrefix + " ; check you regex filters",
-                );
+                if (currentPrefix) {
+                    logContainer.warn(
+                        "No tags found with existing prefix: '" + currentPrefix + "'; check your regex filters",
+                    );
+                } else {
+                    logContainer.warn(
+                        "No tags found starting with a number (no prefix); check your regex filters",
+                    );
+                }
             }
         }
 


### PR DESCRIPTION
By default many projects utilise prefixes for semver versions, as a "sticky" system.
Where the prefix defines different "tastes" or even different pieces of software all-together.

While users can setup override regex to ensure this stays the same, by default we should take this de-facto "industry-standard" into account when calculating acceptable candidate tags

There is also the case of non-prefixes semvers, we should ensure we keep pulling non-prefixed semvers. Instead or arbitrarily grabbing the highest one with-or-without prefix.

The later case, also leads to 1-digit semvers, resulting in downloading weird tags as long as they contain any digit anywhere.

Fixes: #836
Fixes: #816