### PR TITLE
fix: Error out when tags are neither semver nor not-semver

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -127,7 +127,7 @@ function getTagCandidates(container, tags, logContainer) {
         // Non semver tag -> do not propose any other registry tag
         filteredTags = [];
     }
-    return filteredTags;
+    throw new Error(`Tag is Neither Semver or not-Semver ${container.image.tag.value}`);
 }
 
 function normalizeContainer(container) {


### PR DESCRIPTION
We check if a tag is semver, before proposing new tags.
This is great otherwise we end up with random new tags.

However, in cases where it somehow, for whatever weird reason, fails due to a tag being both not-semver AND semver at the same time. Which should never happen.

We should error out instead of just continuing on like nothing happened, as this is a potential breaking situation.