### PR TITLE
feat: keep same number of tag semver parts

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -84,6 +84,22 @@ function getTagCandidates(container, tags, logContainer) {
                 null,
         );
 
+        // Remove prefix and suffix (keep only digits and dots)
+        const numericPart = container.image.tag.semver.match(/(\d+(\.\d+)*)/);
+        
+        if (numericPart) {
+          const referenceGroups = numericPart[0].split('.').length;
+        
+          filteredTags = filteredTags.filter((tag) => {
+            const tagNumericPart = tag.match(/(\d+(\.\d+)*)/);
+            if (!tagNumericPart) return false; // skip tags without numeric part
+            const tagGroups = tagNumericPart[0].split('.').length;
+        
+            // Keep only tags with the same number of numeric segments
+            return tagGroups === referenceGroups;
+          });
+        }
+
         // Keep only greater semver
         filteredTags = filteredTags.filter((tag) =>
             isGreaterSemver(


### PR DESCRIPTION
Currently, the code in theory allows for tag `6` to be upgraded to `6.0.1`
This happens because parsing turns `6` into `6.0.0`

However, for dockertags this isn't correct in most cases.
As a pinned `6` would mean "the latest minor and patch version, of major version 6", effectively ```6.*.*```

This patch should ensure the filtered tags are always filtered to match the amount of semver "digit groupings" of the current container configuration.

I think this should:
Fixes: #835
