### PR TITLE
feat: only ignore digest pinning on dockerhub

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -215,30 +215,28 @@ function isContainerToWatch(wudWatchLabelValue, watchByDefault) {
 
 /**
  * Return true if container digest must be watched.
- * @param wudWatchDigestLabelValue the value of wud.watch.digest label
- * @param isSemver if image is semver
- * @returns {boolean|*}
+ * @param {string} wudWatchDigestLabelValue - the value of wud.watch.digest label
+ * @param {object} parsedImage - object containing at least `domain` property
+ * @returns {boolean}
  */
-function isDigestToWatch(wudWatchDigestLabelValue, isSemver) {
-    let result = false;
-    if (isSemver) {
-        if (
-            wudWatchDigestLabelValue !== undefined &&
-            wudWatchDigestLabelValue !== ''
-        ) {
-            result = wudWatchDigestLabelValue.toLowerCase() === 'true';
-        }
-    } else {
-        result = true;
-        if (
-            wudWatchDigestLabelValue !== undefined &&
-            wudWatchDigestLabelValue !== ''
-        ) {
-            result = wudWatchDigestLabelValue.toLowerCase() === 'true';
-        }
+function isDigestToWatch(wudWatchDigestLabelValue, parsedImage) {
+    let result = true;
+
+    if (
+        parsedImage.domain === "docker.io" ||
+        parsedImage.domain === "registry-1.docker.io" ||
+        parsedImage.domain === ''
+    ) {
+        result = false;
     }
+
+    if (wudWatchDigestLabelValue) {
+        result = wudWatchDigestLabelValue.toLowerCase() === 'true';
+    }
+
     return result;
 }
+
 
 /**
  * Docker Watcher Component.
@@ -754,7 +752,7 @@ class Docker extends Component {
         const isSemver = parsedTag !== null && parsedTag !== undefined;
         const watchDigest = isDigestToWatch(
             container.Labels[wudWatchDigest],
-            isSemver,
+            parsedImage.domain,
         );
         if (!isSemver && !watchDigest) {
             this.ensureLogger();


### PR DESCRIPTION
Only dockerhub (or other niche repositories) has a retarded rate limit.

On the other side, it is still important to watch digests even on semver versioned containers.
As the container can be tagged with the application version, where dependency updates or base-container updates, get pushed as digest updates.

So simply put:
We should default to always watch digests, unless we detect it being a dockerhub container.

In accordance to the source code of [parse-docker-image-name](https://www.npmjs.com/package/parse-docker-image-name) it should output dockerhub.io even no domain would be set. Just in case I set it to match both known registry domains AND an empty value.

Fixes: #832