### PR TITLE
feat(registries): allow for anonymous LSCR/TrueForge and move TrueForge to default to Quay backend

### DIFF
--- a/app/registries/providers/lscr/Lscr.js
+++ b/app/registries/providers/lscr/Lscr.js
@@ -5,10 +5,13 @@ const Ghcr = require('../ghcr/Ghcr');
  */
 class Lscr extends Ghcr {
     getConfigurationSchema() {
-        return this.joi.object().keys({
-            username: this.joi.string().required(),
-            token: this.joi.string().required(),
-        });
+        return this.joi.alternatives([
+            this.joi.string().allow(''),
+            this.joi.object().keys({
+                username: this.joi.string().required(),
+                token: this.joi.string().required(),
+            }),
+        ]);
     }
 
     /**

--- a/app/registries/providers/trueforge/trueforge.js
+++ b/app/registries/providers/trueforge/trueforge.js
@@ -1,14 +1,21 @@
-const Ghcr = require('../ghcr/Ghcr');
+const Quay = require('../quay/Quay');
 
 /**
  * Linux-Server Container Registry integration.
  */
-class Trueforge extends Ghcr {
+class Trueforge extends Quay {
     getConfigurationSchema() {
-        return this.joi.object().keys({
-            username: this.joi.string().required(),
-            token: this.joi.string().required(),
-        });
+        return this.joi.alternatives([
+            // Anonymous configuration
+            this.joi.string().allow(''),
+
+            // Auth configuration
+            this.joi.object().keys({
+                namespace: this.joi.string().required(),
+                account: this.joi.string().required(),
+                token: this.joi.string().required(),
+            }),
+        ]);
     }
 
     /**


### PR DESCRIPTION
This PR ensures LSCR and TrueForge (both backed by Scarf.sh) are allowed to be used anonymously.

Something their QHCR/QUAY backends allow.

It also moves TrueForge over to use Quay as backend.