### PR TITLE
fix(docker-watcher): process events only when buffer is complete

### DIFF
--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -445,7 +445,16 @@ class Docker extends Component {
                     this.log.debug(err);
                 }
             } else {
-                stream.on('data', (chunk) => this.onDockerEvent(chunk));
+                let chunks = [];
+                const collectChunks = (chunk) => {
+                    chunks.push(chunk);
+                    if (chunk.toString().endsWith('\n')) {
+                        const dockerEventChunk = Buffer.concat(chunks);
+                        this.onDockerEvent(dockerEventChunk);
+                        chunks = [];
+                    }
+                };
+                stream.on('data', collectChunks);
             }
         });
     }
@@ -457,7 +466,15 @@ class Docker extends Component {
      */
     async onDockerEvent(dockerEventChunk) {
         this.ensureLogger();
-        const dockerEvent = JSON.parse(dockerEventChunk.toString());
+        let dockerEvent;
+        try {
+            dockerEvent = JSON.parse(dockerEventChunk.toString());
+        } catch (e) {
+            this.log.warn(
+                `Unable to parse Docker event (${e.message}): ${dockerEventChunk.toString()}`,
+            );
+            return;
+        }
         const action = dockerEvent.Action;
         const containerId = dockerEvent.id;
 


### PR DESCRIPTION
This is a pull request implementing the code in [this comment](https://github.com/getwud/wud/issues/559#issuecomment-2661457342) by @sirinsidiator :

> The problem is that in https://github.com/getwud/wud/blob/main/app/watchers/providers/docker/Docker.js#L369 the streamed chunks are processed directly on arrival, which ends up attempting to parse a partial docker event.
> I modified the file locally and with this change it works for me
> I'd also add a try catch to the JSON parse in onDockerEvent, as it seems to crash the whole container whenever there is an error

My addition is adding a couple of tests to verify the functionality.

These are probably dupes of the oldest issue: #601, #675, #792, and #793.

Fixes: #275