### PR TITLE
feat: Allow disabling Prometheus metrics via env var

### DIFF
--- a/app/configuration/index.js
+++ b/app/configuration/index.js
@@ -150,6 +150,25 @@ function getServerConfiguration() {
     return configurationToValidate.value;
 }
 
+/**
+ * Get Prometheus configurations.
+ */
+function getPrometheusConfiguration() {
+    const configurationFromEnv = get('wud.prometheus', wudEnvVars);
+    const configurationSchema = joi.object().keys({
+        enabled: joi.boolean().default(true),
+    });
+
+    // Validate Configuration
+    const configurationToValidate = configurationSchema.validate(
+        configurationFromEnv || {},
+    );
+    if (configurationToValidate.error) {
+        throw configurationToValidate.error;
+    }
+    return configurationToValidate.value;
+}
+
 function getPublicUrl(req) {
     const publicUrl = wudEnvVars.WUD_PUBLIC_URL;
     if (publicUrl) {
@@ -171,5 +190,6 @@ module.exports = {
     getRegistryConfigurations,
     getAuthenticationConfigurations,
     getServerConfiguration,
+    getPrometheusConfiguration,
     getPublicUrl,
 };

--- a/app/configuration/index.test.js
+++ b/app/configuration/index.test.js
@@ -103,3 +103,17 @@ test('replaceSecrets must read secret in file', () => {
         WUD_SERVER_X: 'super_secret',
     });
 });
+
+test('getPrometheusConfiguration should result in enabled by default', () => {
+    delete configuration.wudEnvVars.WUD_PROMETHEUS_ENABLED;
+    expect(configuration.getPrometheusConfiguration()).toStrictEqual({
+        enabled: true,
+    });
+});
+
+test('getPrometheusConfiguration should be disabled when overridden', () => {
+    configuration.wudEnvVars.WUD_PROMETHEUS_ENABLED = 'false';
+    expect(configuration.getPrometheusConfiguration()).toStrictEqual({
+        enabled: false,
+    });
+});

--- a/app/prometheus/index.js
+++ b/app/prometheus/index.js
@@ -1,6 +1,7 @@
 const { collectDefaultMetrics, register } = require('prom-client');
 
 const log = require('../log').child({ component: 'prometheus' });
+const configuration = require('../configuration');
 const container = require('./container');
 const trigger = require('./trigger');
 const watcher = require('./watcher');
@@ -10,6 +11,11 @@ const registry = require('./registry');
  * Start the Prometheus registry.
  */
 function init() {
+    const prometheusConfiguration = configuration.getPrometheusConfiguration();
+    if (!prometheusConfiguration.enabled) {
+        log.info('Prometheus monitoring disabled');
+        return;
+    }
     log.info('Init Prometheus module');
     collectDefaultMetrics();
     container.init();

--- a/app/prometheus/index.test.js
+++ b/app/prometheus/index.test.js
@@ -1,4 +1,10 @@
 const prometheus = require('./index');
+const configuration = require('../configuration');
+
+// Mock configuration
+jest.mock('../configuration', () => ({
+    getPrometheusConfiguration: jest.fn(() => ({ enabled: true })),
+}));
 
 // Mock prom-client
 jest.mock('prom-client', () => ({
@@ -35,9 +41,10 @@ jest.mock('../log', () => ({
 describe('Prometheus Module', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        configuration.getPrometheusConfiguration.mockReturnValue({ enabled: true });
     });
 
-    test('should initialize all prometheus components', () => {
+    test('should initialize all prometheus components when enabled', () => {
         const { collectDefaultMetrics } = require('prom-client');
         const container = require('./container');
         const trigger = require('./trigger');
@@ -51,6 +58,23 @@ describe('Prometheus Module', () => {
         expect(registry.init).toHaveBeenCalled();
         expect(trigger.init).toHaveBeenCalled();
         expect(watcher.init).toHaveBeenCalled();
+    });
+
+    test('should NOT initialize metrics when disabled', () => {
+        configuration.getPrometheusConfiguration.mockReturnValue({ enabled: false });
+        const { collectDefaultMetrics } = require('prom-client');
+        const container = require('./container');
+        const trigger = require('./trigger');
+        const watcher = require('./watcher');
+        const registry = require('./registry');
+
+        prometheus.init();
+
+        expect(collectDefaultMetrics).not.toHaveBeenCalled();
+        expect(container.init).not.toHaveBeenCalled();
+        expect(registry.init).not.toHaveBeenCalled();
+        expect(trigger.init).not.toHaveBeenCalled();
+        expect(watcher.init).not.toHaveBeenCalled();
     });
 
     test('should return metrics output', async () => {

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -38,6 +38,12 @@ services:
 
 WUD exposes various metrics that [Prometheus](https://prometheus.io/) can scrape.
 
+### Configuration
+
+| Env var                  | Required       | Description               | Supported values | Default value when missing |
+| ------------------------ | :------------: | ------------------------- | ---------------- | -------------------------- |
+| `WUD_PROMETHEUS_ENABLED` | :white_circle: | If Metrics must be exposed | `true`, `false`  | `true`                     |
+
 ### Endpoint
 The metrics are exposed at [/metrics](http://localhost:3000/metrics).
 


### PR DESCRIPTION
## Description
This PR resolves #766 by addressing the report of idle CPU usage spikes.
To give users more control and resource efficiency, this change introduces a new environment variable `WUD_PROMETHEUS_ENABLED`.
- **Default behavior**: `true` (Prometheus enabled).
- **Opt-out**: Users can set `WUD_PROMETHEUS_ENABLED=false` to completely disable the Prometheus module and its background metrics collection.