### PR TITLE
Fix(docker-compose-trigger): YAML Parsing Error "Excessive alias count indicates a resource exhaustion attack"

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.js
+++ b/app/triggers/providers/dockercompose/Dockercompose.js
@@ -297,7 +297,7 @@ class Dockercompose extends Docker {
      */
     async getComposeFileAsObject(file = null) {
         try {
-            return yaml.parse((await this.getComposeFile(file)).toString());
+            return yaml.parse((await this.getComposeFile(file)).toString(), {maxAliasCount: 10000});
         } catch (e) {
             const filePath = file || this.configuration.file;
             this.log.error(


### PR DESCRIPTION
The [YAML library](https://eemeli.org/yaml/#tojs-options) has a default limit of 100 aliases, resulting in an error when the docker-compose trigger runs on a file with > 100 aliases:
`Error when parsing the docker-compose yaml file (Excessive alias count indicates a resource exhaustion attack)`

This increases the alias limit to 10,000.

Similar discussion/solution in another project:
(https://github.com/portainer/portainer/issues/6211)