### PR TITLE
Adding UI build step into Docker build process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,14 +20,6 @@ jest.config.js
 nodemon.json
 **/.DS_Store
 **/Thumbs.db
-ui/src/
-ui/public/
+
 ui/tests/
 ui/coverage/
-ui/node_modules/
-ui/package*.json
-ui/.eslintrc.js
-ui/babel.config.js
-ui/jest.config.js
-ui/vue.config.js
-ui/.browserslistrc

--- a/app/registries/providers/trueforge/trueforge.test.js
+++ b/app/registries/providers/trueforge/trueforge.test.js
@@ -1,4 +1,4 @@
-const trueforge = require('./trueforge');
+const Trueforge = require('./trueforge');
 
 jest.mock('axios', () =>
     jest.fn().mockImplementation(() => ({
@@ -6,7 +6,7 @@ jest.mock('axios', () =>
     })),
 );
 
-const trueforge = new trueforge();
+const trueforge = new Trueforge();
 trueforge.configuration = {
     username: 'user',
     token: 'token',

--- a/app/watchers/providers/docker/Docker.js
+++ b/app/watchers/providers/docker/Docker.js
@@ -120,7 +120,7 @@ function getTagCandidates(container, tags, logContainer) {
         );
 
         // Remove prefix and suffix (keep only digits and dots)
-        const numericPart = container.image.tag.semver.match(/(\d+(\.\d+)*)/);
+        const numericPart = container.image.tag.value.match(/(\d+(\.\d+)*)/);
         
         if (numericPart) {
           const referenceGroups = numericPart[0].split('.').length;
@@ -158,7 +158,7 @@ function getTagCandidates(container, tags, logContainer) {
         // Non semver tag -> do not propose any other registry tag
         filteredTags = [];
     }
-    throw new Error(`Tag is Neither Semver or not-Semver ${container.image.tag.value}`);
+    return filteredTags;
 }
 
 function normalizeContainer(container) {

--- a/app/watchers/providers/docker/Docker.test.js
+++ b/app/watchers/providers/docker/Docker.test.js
@@ -787,6 +787,56 @@ describe('Docker Watcher', () => {
             expect(result).toBeDefined();
         });
 
+        test('should handle container with implicit docker hub image (no domain)', async () => {
+            await docker.register('watcher', 'docker', 'test', {});
+            const container = {
+                Id: '123',
+                Image: 'prom/prometheus:v3.8.0',
+                Names: ['/prometheus'],
+                State: 'running',
+                Labels: {},
+            };
+            const imageDetails = {
+                RepoTags: ['prom/prometheus:v3.8.0'],
+                Architecture: 'amd64',
+                Os: 'linux',
+                Created: '2023-01-01',
+                Id: 'image123',
+            };
+            mockImage.inspect.mockResolvedValue(imageDetails);
+            // Mock parse to return undefined domain (simulating parse-docker-image-name behavior)
+            mockParse.mockReturnValue({
+                domain: undefined,
+                path: 'prom/prometheus',
+                tag: 'v3.8.0',
+            });
+
+            // Mock registry to handle unknown/docker hub
+            const mockRegistry = {
+                normalizeImage: jest.fn((img) => img),
+                getId: () => 'hub',
+                match: () => true,
+            };
+            registry.getState.mockReturnValue({
+                registry: { hub: mockRegistry },
+            });
+
+            const {
+                validate: validateContainer,
+            } = require('../../../model/container');
+            validateContainer.mockReturnValue({
+                id: '123',
+                name: 'prometheus',
+                image: { architecture: 'amd64' },
+            });
+
+            const result = await docker.addImageDetailsToContainer(container);
+
+            expect(result).toBeDefined();
+            // Verify parse was called
+            expect(mockParse).toHaveBeenCalledWith('prom/prometheus:v3.8.0');
+        });
+
         test('should handle container with SHA256 image', async () => {
             await docker.register('watcher', 'docker', 'test', {});
             const container = {
@@ -979,37 +1029,6 @@ describe('Docker Watcher', () => {
             expect(image.RepoDigests.length).toBe(0);
         });
 
-        test('should determine if container should be watched', () => {
-            expect('true'.toLowerCase() === 'true').toBe(true);
-            expect('false'.toLowerCase() === 'true').toBe(false);
-            expect(undefined !== undefined && undefined !== '').toBe(false);
-        });
-
-        test('should determine digest watching for semver', () => {
-            const isSemver = true;
-            const watchDigestLabel = 'true';
-            let result = false;
-            if (isSemver) {
-                if (watchDigestLabel !== undefined && watchDigestLabel !== '') {
-                    result = watchDigestLabel.toLowerCase() === 'true';
-                }
-            }
-            expect(result).toBe(true);
-        });
-
-        test('should determine digest watching for non-semver', () => {
-            const isSemver = false;
-            const watchDigestLabel = undefined;
-            let result = false;
-            if (!isSemver) {
-                result = true;
-                if (watchDigestLabel !== undefined && watchDigestLabel !== '') {
-                    result = watchDigestLabel.toLowerCase() === 'true';
-                }
-            }
-            expect(result).toBe(true);
-        });
-
         test('should get old containers for pruning', () => {
             const newContainers = [{ id: '1' }, { id: '2' }];
             const storeContainers = [{ id: '1' }, { id: '3' }];
@@ -1027,5 +1046,183 @@ describe('Docker Watcher', () => {
         test('should handle null inputs for old containers', () => {
             expect([].filter(() => false)).toEqual([]);
         });
+    });
+});
+
+describe('isDigestToWatch Logic', () => {
+    let docker;
+    let mockImage;
+
+    beforeEach(() => {
+        // Setup dockerode mock
+        const mockDockerApi = {
+            getImage: jest.fn(),
+        };
+        mockDockerode.mockImplementation(() => mockDockerApi);
+
+        mockImage = {
+            inspect: jest.fn(),
+        };
+        mockDockerApi.getImage.mockReturnValue(mockImage);
+
+        // Setup store mock
+        storeContainer.getContainer.mockReturnValue(undefined);
+        storeContainer.insertContainer.mockImplementation((c) => c);
+        storeContainer.updateContainer.mockImplementation((c) => c);
+
+        // Setup registry mock
+        registry.getState.mockReturnValue({ registry: {} });
+
+        // Setup event mock
+        event.emitContainerReport.mockImplementation(() => {});
+
+        // Setup prometheus mock
+        const mockGauge = { set: jest.fn() };
+        mockPrometheus.getWatchContainerGauge.mockReturnValue(mockGauge);
+
+        // Setup fullName mock
+        fullName.mockReturnValue('test_container');
+
+        docker = new Docker();
+        docker.name = 'test';
+        docker.dockerApi = mockDockerApi;
+        docker.ensureLogger();
+    });
+
+    // Helper to setup the environment for addImageDetailsToContainer
+    const setupTest = (labels, domain, tag, isSemver = false) => {
+        const container = {
+            Id: '123',
+            Image: `${domain ? domain + '/' : ''}repo/image:${tag}`,
+            Names: ['/test'],
+            State: 'running',
+            Labels: labels || {},
+        };
+        const imageDetails = {
+            Id: 'image123',
+            Architecture: 'amd64',
+            Os: 'linux',
+            Created: '2023-01-01',
+            RepoDigests: ['repo/image@sha256:abc'],
+            RepoTags: [`${domain ? domain + '/' : ''}repo/image:${tag}`]
+        };
+        mockImage.inspect.mockResolvedValue(imageDetails);
+        // Mock parse to return appropriate structure
+        mockParse.mockReturnValue({
+            domain: domain,
+            path: 'repo/image',
+            tag: tag,
+        });
+
+        // Mock semver check
+        if (isSemver) {
+            mockTag.parse.mockReturnValue({ major: 1, minor: 0, patch: 0 });
+        } else {
+            mockTag.parse.mockReturnValue(null);
+        }
+
+        const mockRegistry = {
+            normalizeImage: jest.fn((img) => img),
+            getId: () => 'registry',
+            match: () => true,
+        };
+        registry.getState.mockReturnValue({
+            registry: { registry: mockRegistry },
+        });
+
+        const {
+            validate: validateContainer,
+        } = require('../../../model/container');
+        validateContainer.mockImplementation(c => c);
+
+        return container;
+    };
+
+    // Case 1: Explicit Label present
+    test('should watch digest if label is true (semver)', async () => {
+        const container = setupTest(
+            { 'wud.watch.digest': 'true' },
+            'my.registry',
+            '1.0.0',
+            true,
+        );
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(true);
+    });
+
+    test('should watch digest if label is true (non-semver)', async () => {
+        const container = setupTest(
+            { 'wud.watch.digest': 'true' },
+            'my.registry',
+            'latest',
+            false,
+        );
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(true);
+    });
+
+    test('should NOT watch digest if label is false (semver)', async () => {
+        const container = setupTest(
+            { 'wud.watch.digest': 'false' },
+            'my.registry',
+            '1.0.0',
+            true,
+        );
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    test('should NOT watch digest if label is false (non-semver)', async () => {
+        const container = setupTest(
+            { 'wud.watch.digest': 'false' },
+            'my.registry',
+            'latest',
+            false,
+        );
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    // Case 2: Semver (no label) -> default false
+    test('should NOT watch digest by default for semver images', async () => {
+        const container = setupTest({}, 'my.registry', '1.0.0', true);
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    test('should NOT watch digest by default for semver images (Docker Hub)', async () => {
+        const container = setupTest({}, 'docker.io', '1.0.0', true);
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    // Case 3: Non-Semver (no label) -> default true, EXCEPT Docker Hub
+    test('should watch digest by default for non-semver images (Custom Registry)', async () => {
+        const container = setupTest({}, 'my.registry', 'latest', false);
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(true);
+    });
+
+    test('should NOT watch digest by default for non-semver images (Docker Hub Explicit)', async () => {
+        const container = setupTest({}, 'docker.io', 'latest', false);
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    test('should NOT watch digest by default for non-semver images (Docker Hub Registry-1)', async () => {
+        const container = setupTest(
+            {},
+            'registry-1.docker.io',
+            'latest',
+            false,
+        );
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
+    });
+
+    test('should NOT watch digest by default for non-semver images (Docker Hub Implicit)', async () => {
+        const container = setupTest({}, undefined, 'latest', false); // Implicit
+        const result = await docker.addImageDetailsToContainer(container);
+        expect(result.image.digest.watch).toBe(false);
     });
 });


### PR DESCRIPTION
I was trying to get docker-compose trigger working and noticed, that those changes have not yet been released to DockerHub - therefore I needed to build the container locally, when I noticed that the UI is currently not build as one of the build stages (but requires a local build).

Therefore I quickly added an intermediate stage that also builds the UI in Docker to simplify the build and release process.

I've also optimized the overall Dockerfile - let me know if you think I should revert any of those changes:
- Moved metadata from base into production stage
- Removed unnecessary apk dependencies (`jq` and `git`) - I guess `tzdata` and maybe even `openssl` could be removed as well - but I don't know the app's codebase to have high confidence in this
- Removed UI sources from `.dockerignore` to enable UI build in Docker container

P.S.: It would be great if you could release a new version - 8.1.1 is 6 months old and I really need the changes to the dockercompose trigger :) Thanks!!!