### PR TITLE
Allows from address of SMTP trigger to takes a display name

### DIFF
--- a/app/triggers/providers/Trigger.js
+++ b/app/triggers/providers/Trigger.js
@@ -315,7 +315,7 @@ class Trigger extends Component {
         const schemaValidated =
             schemaWithDefaultOptions.validate(configuration);
 		if (schemaValidated.warning) {
-			console.log(schemaValidated.warning);
+			this.log.warn(schemaValidated.warning.message);
 		}
         if (schemaValidated.error) {
             throw schemaValidated.error;

--- a/app/triggers/providers/Trigger.js
+++ b/app/triggers/providers/Trigger.js
@@ -314,6 +314,9 @@ class Trigger extends Component {
         });
         const schemaValidated =
             schemaWithDefaultOptions.validate(configuration);
+		if (schemaValidated.warning) {
+			console.log(schemaValidated.warning);
+		}
         if (schemaValidated.error) {
             throw schemaValidated.error;
         }

--- a/app/triggers/providers/smtp/Smtp.js
+++ b/app/triggers/providers/smtp/Smtp.js
@@ -5,14 +5,14 @@ const Trigger = require('../Trigger');
  * SMTP Trigger implementation
  */
 class Smtp extends Trigger {
-	static deprecatedWarningMessage = 'WUD_TRIGGER_SMTP__FROM is deprecated, use WUD_TRIGGER_SMTP__FROM_ADDRESS instead';
+	static deprecatedWarningMessage = 'WUD_TRIGGER_SMTP_{trigger_name}_FROM is deprecated, use WUD_TRIGGER_SMTP_{trigger_name}_FROM_ADDRESS instead';
 	
     /**
      * Get the Trigger configuration schema.
      * @returns {*}
      */
     getConfigurationSchema() {
-		const emailAddressRule = this.joi
+		const emailAddressSchema = this.joi
 	                    .string()
 						.required()
 						.when('/allowcustomtld', {
@@ -21,11 +21,11 @@ class Smtp extends Trigger {
 							otherwise: this.joi.string().email(),
 						});
 						
-		const nodemailerAddressRule = this.joi.extend({
+		const nodemailerAddressSchema = this.joi.extend({
 			type: 'withBackwardCompatibility',
 			base: this.joi
 				.object({
-					address: emailAddressRule,
+					address: emailAddressSchema,
 					name: this.joi.string().optional()
 				})
 				.required(),
@@ -50,8 +50,8 @@ class Smtp extends Trigger {
             port: this.joi.number().port().required(),
             user: this.joi.string(),
             pass: this.joi.string(),
-            from: nodemailerAddressRule,
-            to: emailAddressRule,
+            from: nodemailerAddressSchema,
+            to: emailAddressSchema,
             tls: this.joi
                 .object({
                     enabled: this.joi.boolean().default(false),

--- a/app/triggers/providers/smtp/Smtp.js
+++ b/app/triggers/providers/smtp/Smtp.js
@@ -5,7 +5,7 @@ const Trigger = require('../Trigger');
  * SMTP Trigger implementation
  */
 class Smtp extends Trigger {
-	static deprecatedWarningMessage = 'WUD_TRIGGER_SMTP_{trigger_name}_FROM is deprecated, use WUD_TRIGGER_SMTP_{trigger_name}_FROM_ADDRESS instead';
+	static fromDeprecationWarningMessage = 'WUD_TRIGGER_SMTP_[trigger_name]_FROM is deprecated, use WUD_TRIGGER_SMTP_[trigger_name]_FROM_ADDRESS instead'
 	
     /**
      * Get the Trigger configuration schema.
@@ -30,12 +30,12 @@ class Smtp extends Trigger {
 				})
 				.required(),
 			messages: {
-				'deprecated': Smtp.deprecatedWarningMessage
+				'from.deprecated': Smtp.fromDeprecationWarningMessage
 			},
 			coerce: {
 				from: 'string',
 				method(value, helpers) {
-					helpers.warn('deprecated');
+					helpers.warn('from.deprecated');
 					return { value: { address: value } };
 				} 
 			}

--- a/app/triggers/providers/smtp/Smtp.js
+++ b/app/triggers/providers/smtp/Smtp.js
@@ -5,6 +5,8 @@ const Trigger = require('../Trigger');
  * SMTP Trigger implementation
  */
 class Smtp extends Trigger {
+	static deprecatedWarningMessage = 'WUD_TRIGGER_SMTP__FROM is deprecated, use WUD_TRIGGER_SMTP__FROM_ADDRESS instead';
+	
     /**
      * Get the Trigger configuration schema.
      * @returns {*}
@@ -28,7 +30,7 @@ class Smtp extends Trigger {
 				})
 				.required(),
 			messages: {
-				'deprecated': 'WUD_TRIGGER_SMTP_{trigger_name}_FROM is deprecated, use WUD_TRIGGER_SMTP_{trigger_name}_FROM_ADDRESS instead'
+				'deprecated': Smtp.deprecatedWarningMessage
 			},
 			coerce: {
 				from: 'string',

--- a/app/triggers/providers/smtp/Smtp.test.js
+++ b/app/triggers/providers/smtp/Smtp.test.js
@@ -39,6 +39,39 @@ test('validateConfiguration should return validated configuration when valid', (
 });
 
 test.each([
+    { fromValue: 'This is a display name <from@xx.com>', expectedResult: '"This is a display name" <from@xx.com>' },
+    { fromValue: '"This is a display name" <from@xx.com>', expectedResult: '"This is a display name" <from@xx.com>' },
+    { fromValue: '"This is a display name <from@xx.com>', expectedResult: '"This is a display name" <from@xx.com>' },
+    { fromValue: 'This is a display name" <from@xx.com>', expectedResult: '"This is a display name" <from@xx.com>' },
+    { fromValue: 'This is a display name from@xx.com>', expectedResult: null },
+    { fromValue: 'This is a display name <from@xx.com', expectedResult: '"This is a display name" <from@xx.com>' },
+    { fromValue: 'from@xx.com', expectedResult: 'from@xx.com' },
+    { fromValue: 'This is a display name <from@@xx.com>', expectedResult: null },
+    { fromValue: 'This is a display name from@@xx.com', expectedResult: null },
+    { fromValue: 'from@@xx.com', expectedResult: null },
+])(
+    'trigger final from value sould be \'$expectedResult\' when from configuration value is \'$fromValue\'',
+    async ({ fromValue, expectedResult }) => {
+        const config = {
+            ...configurationValid,
+            from: fromValue
+        };
+
+        if (expectedResult) {
+			let validatedConfiguration;
+            expect(() => {
+                validatedConfiguration = smtp.validateConfiguration(config);
+            }).not.toThrow(ValidationError);
+			expect(validatedConfiguration.from).toStrictEqual(expectedResult);
+        } else {
+            expect(() => {
+                smtp.validateConfiguration(config);
+            }).toThrow(ValidationError);
+        }
+    },
+);
+
+test.each([
     { allowCustomTld: true, field: 'from' },
     { allowCustomTld: false, field: 'from' },
     { allowCustomTld: true, field: 'to' },

--- a/app/triggers/providers/smtp/Smtp.test.js
+++ b/app/triggers/providers/smtp/Smtp.test.js
@@ -11,6 +11,10 @@ var log = bunyan.createLogger({
 const smtp = new Smtp();
 smtp.log = log;
 
+beforeEach(() => {
+  loggerBuffer.records = []
+});
+
 const configurationValid = {
     allowcustomtld: false,
     host: 'smtp.gmail.com',
@@ -67,20 +71,19 @@ test('trigger from value display name is optional', () => {
 });
 
 test('trigger from value provided as string address is correctly transformed to nodemailer model for backward compatibility and raise deprecation warning', () => {
-	const address = 'from@xx.com';
+	const fromAddress = 'from@xx.com';
 	const config = {
             ...configurationValid,
-			from: address
+			from: fromAddress
 	}
 
     let validatedConfiguration = smtp.validateConfiguration(config);
-    validatedConfiguration = smtp.validateConfiguration(config);
 
-	expect(loggerBuffer.records.find(m => m.includes(Smtp.deprecatedWarningMessage))).toBeDefined();
+	expect(loggerBuffer.records.find(m => m.includes(Smtp.fromDeprecationWarningMessage))).toBeDefined();
     expect(validatedConfiguration).toStrictEqual({
         ...configurationValid,
         port: 465,
-		from: { address: address },
+		from: { address: fromAddress },
         tls: {
             enabled: false,
             verify: true,

--- a/docs/configuration/triggers/smtp/README.md
+++ b/docs/configuration/triggers/smtp/README.md
@@ -4,17 +4,19 @@ The `smtp` trigger lets you send emails with smtp.
 
 ### Variables
 
-| Env var                                           | Required       | Description                                | Supported values              | Default value when missing |
-| ------------------------------------------------- |:--------------:|:------------------------------------------ | ----------------------------- | -------------------------- |
-| `WUD_TRIGGER_SMTP_{trigger_name}_HOST`            | :red_circle:   | Smtp server host                           | Valid hostname or IP address  |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PORT`            | :red_circle:   | Smtp server port                           | Valid smtp port               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_FROM`            | :red_circle:   | Email from address                         | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TO`              | :red_circle:   | Email to address                           | Valid email address           |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_USER`            | :white_circle: | Smtp user                                  |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_PASS`            | :white_circle: | Smtp password                              |                               |                            |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED`     | :white_circle: | Use TLS                                    | `true`, `false`               | `false`                    |
-| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`      | :white_circle: | Verify server TLS certificate              | `true`, `false`               | `true`                     |
-| `WUD_TRIGGER_SMTP_{trigger_name}_ALLOWCUSTOMTLD`  | :white_circle: | Allow custom tlds for the email addresses  | `true`, `false`               | `false`                    |
+| Env var                                             | Required       | Description                                | Supported values              | Default value when missing |
+| --------------------------------------------------- |:--------------:|:------------------------------------------ | ----------------------------- | -------------------------- |
+| `WUD_TRIGGER_SMTP_{trigger_name}_HOST`              | :red_circle:   | Smtp server host                           | Valid hostname or IP address  |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_PORT`              | :red_circle:   | Smtp server port                           | Valid smtp port               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_FROM` (deprecated) | :white_circle: | Email from address                         | Valid email address           |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_FROM_ADDRESS`      | :red_circle:   | Email from address                         | Valid email address           |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_FROM_NAME`         | :white_circle: | Email from display name                    |                               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TO`                | :red_circle:   | Email to address                           | Valid email address           |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_USER`              | :white_circle: | Smtp user                                  |                               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_PASS`              | :white_circle: | Smtp password                              |                               |                            |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_ENABLED`       | :white_circle: | Use TLS                                    | `true`, `false`               | `false`                    |
+| `WUD_TRIGGER_SMTP_{trigger_name}_TLS_VERIFY`        | :white_circle: | Verify server TLS certificate              | `true`, `false`               | `true`                     |
+| `WUD_TRIGGER_SMTP_{trigger_name}_ALLOWCUSTOMTLD`    | :white_circle: | Allow custom tlds for the email addresses  | `true`, `false`               | `false`                    |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
 
@@ -35,7 +37,8 @@ services:
         - WUD_TRIGGER_SMTP_GMAIL_PORT=465
         - WUD_TRIGGER_SMTP_GMAIL_USER=john.doe@gmail.com
         - WUD_TRIGGER_SMTP_GMAIL_PASS=mysecretpass
-        - WUD_TRIGGER_SMTP_GMAIL_FROM=john.doe@gmail.com
+        - WUD_TRIGGER_SMTP_GMAIL_FROM_ADDRESS=john.doe@gmail.com
+        - WUD_TRIGGER_SMTP_GMAIL_FROM_NAME=John Doe
         - WUD_TRIGGER_SMTP_GMAIL_TO=jane.doe@gmail.com
         - WUD_TRIGGER_SMTP_GMAIL_TLS_ENABLED=true 
 ```
@@ -48,7 +51,8 @@ docker run \
     -e WUD_TRIGGER_SMTP_GMAIL_PORT="465" \
     -e WUD_TRIGGER_SMTP_GMAIL_USER="john.doe@gmail.com" \
     -e WUD_TRIGGER_SMTP_GMAIL_PASS="mysecretpass" \
-    -e WUD_TRIGGER_SMTP_GMAIL_FROM="john.doe@gmail.com" \
+    -e WUD_TRIGGER_SMTP_GMAIL_FROM_ADDRESS="john.doe@gmail.com" \
+    -e WUD_TRIGGER_SMTP_GMAIL_FROM_NAME="John Doe" \
     -e WUD_TRIGGER_SMTP_GMAIL_TO="jane.doe@gmail.com" \
     -e WUD_TRIGGER_SMTP_GMAIL_TLS_ENABLED="true" \
   ...


### PR DESCRIPTION
- Use a custom joi validator to handle format like "My display name <john.doe@test.com>" 
- Sanitize the validated value as recommended in [nodemailer documentation](https://nodemailer.com/message/addresses#2-formatted-address-display-name--email)
- Add unitary tests

Should adress issue #390