### PR TITLE
docs(oidc): fix Authelia configuration

### DIFF
--- a/docs/configuration/authentications/oidc/README.md
+++ b/docs/configuration/authentications/oidc/README.md
@@ -35,9 +35,9 @@ identity_providers:
     id_token_lifespan: 1h
     refresh_token_lifespan: 90m
     clients:
-      - id: my-wud-client-id
-        description: WUD openid client
-        secret: this-is-a-very-secure-secret
+      - client_id: my-wud-client-id
+        client_name: WUD openid client
+        client_secret: this-is-a-very-secure-secret
         public: false
         authorization_policy: one_factor
         audience: []


### PR DESCRIPTION
Provided exemple for [Authelia configuration](https://getwud.github.io/wud/#/configuration/authentications/oidc/?id=how-to-integrate-withnbspauthelia) is not valid, according to[ Authelia documentation](https://www.authelia.com/configuration/identity-providers/openid-connect/clients/#configuration).