### PR TITLE
bugfix: Rename 'data' to 'body' in Apprise trigger

### DIFF
--- a/app/triggers/providers/apprise/Apprise.js
+++ b/app/triggers/providers/apprise/Apprise.js
@@ -45,7 +45,7 @@ class Apprise extends Trigger {
         let uri = `${this.configuration.url}/notify`;
         const body = {
             title: this.renderSimpleTitle(container),
-            data: this.renderSimpleBody(container),
+            body: this.renderSimpleBody(container),
             format: 'text',
             type: 'info',
         };
@@ -82,7 +82,7 @@ class Apprise extends Trigger {
             data: {
                 urls: this.configuration.urls,
                 title: this.renderBatchTitle(containers),
-                data: this.renderBatchBody(containers),
+                body: this.renderBatchBody(containers),
                 format: 'text',
                 type: 'info',
             },

--- a/app/triggers/providers/apprise/Apprise.test.js
+++ b/app/triggers/providers/apprise/Apprise.test.js
@@ -78,7 +78,7 @@ test('trigger should send POST http request to notify endpoint', async () => {
         data: {
             urls: 'maito://user:pass@gmail.com',
             title: 'New tag found for container container1',
-            data: 'Container container1 running with tag 1.0.0 can be updated to tag 2.0.0',
+            body: 'Container container1 running with tag 1.0.0 can be updated to tag 2.0.0',
             format: 'text',
             type: 'info',
         },
@@ -105,7 +105,7 @@ test('trigger should use config and tag when configured', async () => {
     expect(axios).toHaveBeenCalledWith({
         data: {
             title: expect.any(String),
-            data: expect.any(String),
+            body: expect.any(String),
             format: 'text',
             type: 'info',
             tag: 'mytag',
@@ -132,7 +132,7 @@ test('trigger should use config without tag', async () => {
     expect(axios).toHaveBeenCalledWith({
         data: {
             title: expect.any(String),
-            data: expect.any(String),
+            body: expect.any(String),
             format: 'text',
             type: 'info',
         },
@@ -166,7 +166,7 @@ test('triggerBatch should send batch notification', async () => {
         data: {
             urls: 'mailto://test@example.com',
             title: expect.any(String),
-            data: expect.any(String),
+            body: expect.any(String),
             format: 'text',
             type: 'info',
         },


### PR DESCRIPTION
This pull request fixes an issue introduced in version `8.2.0` where the Apprise trigger stopped working.  
The request payload was being sent using the `data` field instead of `body`, which causes Apprise to return a *Bad Request* with the error:

```
Payload lacks minimum requirements
```

According to the Apprise API specification, the JSON payload must be sent in the `body` field.  
This PR updates the Apprise trigger implementation to restore the expected behavior.

For additional context, the related issue is documented here: https://github.com/getwud/wud/issues/939