### PR TITLE
fix(dockercompose): deal with services without images

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -22,7 +22,7 @@ function doesContainerBelongToCompose(compose, container) {
     );
     return Object.keys(compose.services).some((key) => {
         const service = compose.services[key];
-        return service.image.includes(currentImage);
+        return (service.image && []).includes(currentImage);
     });
 }
 
@@ -243,7 +243,7 @@ class Dockercompose extends Docker {
         const serviceKeyToUpdate = Object.keys(compose.services).find(
             (serviceKey) => {
                 const service = compose.services[serviceKey];
-                return service.image.includes(currentImage);
+                return (service.image && []).includes(currentImage);
             },
         );
 


### PR DESCRIPTION
When docker-compose.yml have a service without image like use `build` instead of `image` the following error is raised and trigger do nothing.

Log error:
```
WARN whats-up-docker/container: Error when running trigger (type=dockercompose, name=mydockercompose) (Cannot read properties of undefined (reading 'includes'))
```