### PR TITLE
fix(dockercompose): handle multiple containers with same image

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -162,11 +162,20 @@ class Dockercompose extends Docker {
             return;
         }
 
+        // Track which services have already been mapped to avoid duplicates
+        // (multiple containers can share the same image/service)
+        const processedServices = new Set();
+
         // [{ current: '1.0.0', update: '2.0.0' }, {...}]
         const currentVersionToUpdateVersionArray = containersFiltered
-            .map((container) =>
-                this.mapCurrentVersionToUpdateVersion(compose, container),
-            )
+            .map((container) => {
+                const mapping = this.mapCurrentVersionToUpdateVersion(
+                    compose,
+                    container,
+                    processedServices,
+                );
+                return mapping;
+            })
             .filter((map) => map !== undefined);
 
         // Dry-run?
@@ -227,9 +236,10 @@ class Dockercompose extends Docker {
      * and the image declaration with the update version.
      * @param compose
      * @param container
+     * @param processedServices - Set to track which services have already been processed
      * @returns {{current, update}|undefined}
      */
-    mapCurrentVersionToUpdateVersion(compose, container) {
+    mapCurrentVersionToUpdateVersion(compose, container, processedServices) {
         // Get registry configuration
         this.log.debug(`Get ${container.image.registry.name} registry manager`);
         const registry = getState().registry[container.image.registry.name];
@@ -252,6 +262,19 @@ class Dockercompose extends Docker {
                 `Could not find service for container ${container.name} with image ${currentImage}`,
             );
             return undefined;
+        }
+
+        // Skip if this service has already been processed (duplicate container with same image)
+        if (processedServices && processedServices.has(serviceKeyToUpdate)) {
+            this.log.debug(
+                `Service ${serviceKeyToUpdate} already processed for container ${container.name} (duplicate image)`,
+            );
+            return undefined;
+        }
+
+        // Mark this service as processed
+        if (processedServices) {
+            processedServices.add(serviceKeyToUpdate);
         }
 
         // Rebuild image definition string


### PR DESCRIPTION
![2026-02-26-clip](https://github.com/user-attachments/assets/77f0bdc8-6e24-4417-9920-0b9eacf9b11e)

When multiple containers share the same image (e.g., multiple redis containers), the dockercompose trigger would fail to update all of them.

The issue was that after processing the first container and updating the compose file, subsequent containers with the same image could no longer find their service (since the image version had changed).

This fix tracks which services have already been processed to avoid duplicate updates while still notifying all containers.

Fixes issue where only one container would upgrade when multiple containers use the same image.