### PR TITLE
fix: prefix result bad semver

### DIFF
--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -112,7 +112,7 @@ function getTagCandidates(
         // Prefix is almost-always standardised around "must stay the same" for tags
         if (!container.includeTags) {
             const currentTag = container.image.tag.value;
-            const match = currentTag.match(/^(.*?)(\d+\.\d+\..*)$/);
+            const match = currentTag.match(/^(.*?)(\d+\.\d+\.\d+.*)$/);
             const currentPrefix = match ? match[1] : '';
 
             if (currentPrefix) {

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -112,7 +112,7 @@ function getTagCandidates(
         // Prefix is almost-always standardised around "must stay the same" for tags
         if (!container.includeTags) {
             const currentTag = container.image.tag.value;
-            const match = currentTag.match(/^(.*?)(\d+.*)$/);
+            const match = currentTag.match(/^(.*?)(\d+\.\d+\..*)$/);
             const currentPrefix = match ? match[1] : '';
 
             if (currentPrefix) {


### PR DESCRIPTION
Issue #970 

This PR is not prefect but the regexp now checks if we have at least x.y.z to start the 2nd group. This group will be used for the semver compare.
This will work with tag like amd64-1.2.3 but not with tag like amd64-1 or amd64-1.2 (those tags should use digest and not semver) If we want to keep amd64-1 or amd64-1.2 we'll need to use the include tags.

Fix PR #839