### PR TITLE
Add avatar URL support for Discord webhook notifications

### DIFF
--- a/app/triggers/providers/discord/Discord.test.ts
+++ b/app/triggers/providers/discord/Discord.test.ts
@@ -102,4 +102,130 @@ describe('Discord Trigger', () => {
             },
         });
     });
+
+    test('should validate configuration with avatar URL', async () => {
+        const config = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+            avatarurl: 'https://example.com/avatar.png',
+        };
+
+        expect(() => discord.validateConfiguration(config)).not.toThrow();
+    });
+
+    test('should validate configuration with empty avatar URL', async () => {
+        const config = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+            avatarurl: '',
+        };
+
+        expect(() => discord.validateConfiguration(config)).not.toThrow();
+    });
+
+    test('should validate configuration with no avatar URL', async () => {
+        const config = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+        };
+
+        expect(() => discord.validateConfiguration(config)).not.toThrow();
+    });
+
+    test('should apply default avatar URL when not set', async () => {
+        const config = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+        };
+
+        const validated = discord.validateConfiguration(config);
+        expect(validated.avatarurl).toBe('');
+    });
+
+    test('should reject invalid avatar URL (not HTTPS)', async () => {
+        const config = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+            avatarurl: 'http://example.com/avatar.png',
+        };
+
+        expect(() => discord.validateConfiguration(config)).toThrow();
+    });
+
+    test('should send message with avatar URL', async () => {
+        const { default: axios } = await import('axios');
+        discord.configuration = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+            avatarurl:
+                'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/whats-up-docker.png',
+        };
+
+        await discord.sendMessage('Test Title', 'Test Body');
+        expect(axios).toHaveBeenCalledWith({
+            method: 'POST',
+            url: 'https://discord.com/api/webhooks/123/abc',
+            data: {
+                avatar_url:
+                    'https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/whats-up-docker.png',
+                embeds: [
+                    {
+                        title: 'Test Title',
+                        fields: [
+                            {
+                                value: 'Test Body',
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+
+    test('should send message with empty avatar URL by default', async () => {
+        const { default: axios } = await import('axios');
+        discord.configuration = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+            avatarurl: '',
+        };
+
+        await discord.sendMessage('Test Title', 'Test Body');
+        expect(axios).toHaveBeenCalledWith({
+            method: 'POST',
+            url: 'https://discord.com/api/webhooks/123/abc',
+            data: {
+                avatar_url: '',
+                embeds: [
+                    {
+                        title: 'Test Title',
+                        fields: [
+                            {
+                                value: 'Test Body',
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+
+    test('should send message without avatar URL in configuration', async () => {
+        const { default: axios } = await import('axios');
+        discord.configuration = {
+            url: 'https://discord.com/api/webhooks/123/abc',
+        };
+
+        await discord.sendMessage('Test Title', 'Test Body');
+        expect(axios).toHaveBeenCalledWith({
+            method: 'POST',
+            url: 'https://discord.com/api/webhooks/123/abc',
+            data: {
+                embeds: [
+                    {
+                        title: 'Test Title',
+                        fields: [
+                            {
+                                value: 'Test Body',
+                            },
+                        ],
+                    },
+                ],
+            },
+        });
+    });
+
 });

--- a/app/triggers/providers/discord/Discord.ts
+++ b/app/triggers/providers/discord/Discord.ts
@@ -20,6 +20,11 @@ class Discord extends Trigger {
                 })
                 .required(),
             botusername: this.joi.string().default('WUD'),
+            avatarurl: this.joi
+                .string()
+                .uri({ scheme: ['https'] })
+                .allow('')
+                .default(''),
             cardcolor: this.joi.number().default(65280),
             cardlabel: this.joi.string().default(''),
         });
@@ -70,6 +75,7 @@ class Discord extends Trigger {
         const uri = this.configuration.url;
         const body = {
             username: this.configuration.botusername,
+            avatar_url: this.configuration.avatarurl,
             embeds: [
                 {
                     title,

--- a/docs/configuration/triggers/discord/README.md
+++ b/docs/configuration/triggers/discord/README.md
@@ -9,6 +9,7 @@ The `discord` trigger lets you send realtime notifications using [Discord](https
 |--------------------------------------------------|:--------------:|------------------------------------------|-----------------------|-----------------------------|
 | `WUD_TRIGGER_DISCORD_{trigger_name}_URL`         | :red_circle:   | The Discord webhook URL                  | HTTPS URL             |                             |
 | `WUD_TRIGGER_DISCORD_{trigger_name}_BOTUSERNAME` | :white_circle: | The bot username                         |                       | WUD                         |
+| `WUD_TRIGGER_DISCORD_{trigger_name}_AVATARURL`   | :white_circle: | Avatar image URL for the webhook bot     | HTTPS URL             |                             |
 | `WUD_TRIGGER_DISCORD_{trigger_name}_CARDCOLOR`   | :white_circle: | Color of the message card                | Color in decimal base | 65280                       |
 | `WUD_TRIGGER_DISCORD_{trigger_name}_CARDLABEL`   | :white_circle: | Optional label to display in the message | String                |                             |
 


### PR DESCRIPTION
- Added `avatarurl` configuration parameter to Discord trigger
- Updated documentation with the new `AVATARURL` parameter
- Added tests

## Configuration
```bash
WUD_TRIGGER_DISCORD_{trigger_name}_AVATARURL=https://example.com/avatar.png