### PR TITLE
Use the automatic docker compose file label

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -69,7 +69,7 @@ class Dockercompose extends Docker {
      * @returns {string|null}
      */
     getComposeFileForContainer(container) {
-        // Check if container has a compose file label
+        // Check if container has a custom wud compose file label
         const composeFileLabel = this.configuration.composeFileLabel;
         if (container.labels && container.labels[composeFileLabel]) {
             const labelValue = container.labels[composeFileLabel];
@@ -77,6 +77,11 @@ class Dockercompose extends Docker {
             return path.isAbsolute(labelValue)
                 ? labelValue
                 : path.resolve(labelValue);
+        }
+
+        // Check if container has automatic compose file label
+        if (container.labels && container.labels["com.docker.compose.project.config_files"]) {
+            return container.labels["com.docker.compose.project.config_files"]
         }
 
         // Fall back to default configuration file

--- a/docs/configuration/triggers/docker-compose/README.md
+++ b/docs/configuration/triggers/docker-compose/README.md
@@ -26,7 +26,7 @@ The trigger will:
 
 !> This trigger will only work with locally watched containers.
 
-!> Do not forget to mount the docker-compose.yml file in the wud container.
+!> Do not forget to mount the docker-compose.yml file in the wud container. If you're relying on the com.docker.compose.project.config_files label, you'll need to mount it so that the path insides the container matches your docker host.
 
 ### Examples
 

--- a/docs/configuration/triggers/docker-compose/README.md
+++ b/docs/configuration/triggers/docker-compose/README.md
@@ -15,12 +15,12 @@ The trigger will:
 
 ### Variables
 
-| Env var                                           | Required       | Description                                                    | Supported values | Default value when missing |
-| ------------------------------------------------- |:--------------:| -------------------------------------------------------------- | ---------------- | -------------------------- | 
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_FILE`   | :red_circle:   | The docker-compose.yml file location                           |                  |                            |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_BACKUP` | :white_circle: | Backup the docker-compose.yml file as `.back` before updating? | `true`, `false`  | `false`                    |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_PRUNE`  | :white_circle: | If the old image must be pruned after upgrade                  | `true`, `false`  | `false`                    |
-| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time            | `true`, `false`  | `false`                    |
+| Env var                                           | Required       | Description                                                    | Supported values | Default value when missing                                               |
+| ------------------------------------------------- |:--------------:| -------------------------------------------------------------- | ---------------- | ------------------------------------------------------------------------ |
+| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_FILE`   | :white_circle: | The docker-compose.yml file location                           |                  | The value of the automatic com.docker.compose.project.config_files label |
+| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_BACKUP` | :white_circle: | Backup the docker-compose.yml file as `.back` before updating? | `true`, `false`  | `false`                                                                  |
+| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_PRUNE`  | :white_circle: | If the old image must be pruned after upgrade                  | `true`, `false`  | `false`                                                                  |
+| `WUD_TRIGGER_DOCKERCOMPOSE_{trigger_name}_DRYRUN` | :white_circle: | When enabled, only pull the new image ahead of time            | `true`, `false`  | `false`                                                                  |
 
 ?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration). but only supports the `batch` mode.
 


### PR DESCRIPTION
Rather than require the compose file to be explicitly set for each container, this PR uses the automatically set `com.docker.compose.project.config_files` if it's available. This works (at least from my testing) as long as you mount the compose files on the same path as the host in the wud container.