### PR TITLE
Improve MQTT trigger

### DIFF
--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -55,10 +55,20 @@ function sanitizeIcon(icon) {
 }
 
 class Hass {
-    constructor({ client, configuration, log }) {
-        this.client = client;
+    constructor({ configuration, log }) {
         this.configuration = configuration;
         this.log = log;
+    }
+
+    /**
+     * Initialize the component.
+     *
+     * Set connection status sensor to online and subscribe to container and watcher events.
+     *
+     * @param client - MQTT client
+     */
+    async init(client) {
+        this.client = client;
 
         // Subscribe to container events to sync HA
         registerContainerAdded((container) =>
@@ -406,6 +416,66 @@ class Hass {
      */
     getDiscoveryTopic({ kind, topic }) {
         return `${this.configuration.hass.prefix}/${kind}/${getHassEntityId(topic)}/config`;
+    }
+
+    /**
+     * Get WUD state topic.
+     * @return {string} WUD state topic
+     */
+    getStateTopic() {
+        return `${this.configuration.topic}/status`;
+    }
+
+    /**
+     * Get will message.
+     *
+     * Allows MQTT broker to set WUD status to offline when WUD disconnects unexpectedly.
+     *
+     * @returns {Object} The will message object with topic, payload, and retain properties
+     */
+    getWill() {
+        return {
+            topic: this.getStateTopic(),
+            payload: 'offline',
+            retain: true,
+        };
+    }
+
+    /**
+     * Update the connection status sensor.
+     * @param connected - Whether WUD is currently connected to the MQTT broker
+     */
+    async updateConnectionStatusSensor(connected: boolean) {
+        const connectionStatusSensor = {
+            kind: 'binary_sensor',
+            topic: this.getStateTopic(),
+        };
+
+        const connectionStatusDiscoveryTopic = this.getDiscoveryTopic({
+            kind: connectionStatusSensor.kind,
+            topic: connectionStatusSensor.topic,
+        });
+
+        // Publish discovery message
+        if (this.configuration.hass.discovery) {
+            await this.publishDiscoveryMessage({
+                discoveryTopic: connectionStatusDiscoveryTopic,
+                stateTopic: connectionStatusSensor.topic,
+                kind: connectionStatusSensor.kind,
+                options: {
+                    device_class: 'connectivity',
+                    payload_on: 'online',
+                    payload_off: 'offline',
+                },
+                name: 'Connection status',
+            });
+        }
+
+        // Publish sensor
+        await this.updateSensor({
+            topic: connectionStatusSensor.topic,
+            value: connected ? 'online' : 'offline',
+        });
     }
 }
 

--- a/app/triggers/providers/mqtt/Mqtt.ts
+++ b/app/triggers/providers/mqtt/Mqtt.ts
@@ -94,6 +94,14 @@ class Mqtt extends Trigger {
         // Enforce simple mode
         this.configuration.mode = 'simple';
 
+        if (this.configuration.hass.enabled) {
+            this.hass = new Hass({
+                configuration: this.configuration,
+                log: this.log,
+            });
+        }
+
+        // Set MQTT connection options and create client
         const options = {
             clientId: this.configuration.clientid,
         };
@@ -115,12 +123,17 @@ class Mqtt extends Trigger {
         options.rejectUnauthorized = this.configuration.tls.rejectunauthorized;
         options.manualConnect = true;
         options.reconnectPeriod = 10000; // Reconnect every 10 seconds
-
+        if (this.hass) {
+            options.will = this.hass.getWill();
+        }
         this.client = mqtt.connect(this.configuration.url, options);
 
-        // Register event handlers for logging
-        this.client.on('connect', (connack) => {
+        // Register MQTT connection event handlers
+        this.client.on('connect', () => {
             this.log.debug('MQTT client connected');
+            if (this.hass) {
+                this.hass.updateConnectionStatusSensor(true);
+            }
         });
 
         this.client.on('reconnect', () => {
@@ -132,26 +145,23 @@ class Mqtt extends Trigger {
         });
 
         this.client.on('disconnect', (packet) => {
-            this.log.debug(`MQTT client disconnected, reasonCode: ${packet?.reasonCode}`);
+            this.log.debug(
+                `MQTT client disconnected, reasonCode: ${packet?.reasonCode}`,
+            );
         });
 
         this.client.on('error', (error) => {
-            this.log.debug(`MQTT client error ${error.code}` );
-
+            this.log.debug(`MQTT client error ${error.code}`);
         });
 
         this.client.on('end', () => {
             this.log.debug('MQTT client ended');
         });
 
+        // Start MQTT client and initialize HA integration if enabled
         this.client.connect();
-        
-        if (this.configuration.hass.enabled) {
-            this.hass = new Hass({
-                client: this.client,
-                configuration: this.configuration,
-                log: this.log,
-            });
+        if (this.hass) {
+            this.hass.init(this.client);
         }
         registerContainerAdded((container) => this.trigger(container));
         registerContainerUpdated((container) => this.trigger(container));
@@ -194,6 +204,9 @@ class Mqtt extends Trigger {
      */
 
     async deregisterComponent(): Promise<void> {
+        if (this.hass) {
+            this.hass.updateConnectionStatusSensor(false);
+        }
         return this.client.end(true);
     }
 }

--- a/app/triggers/providers/mqtt/Mqtt.ts
+++ b/app/triggers/providers/mqtt/Mqtt.ts
@@ -113,9 +113,39 @@ class Mqtt extends Trigger {
             options.ca = [await fs.readFile(this.configuration.tls.cachain)];
         }
         options.rejectUnauthorized = this.configuration.tls.rejectunauthorized;
+        options.manualConnect = true;
+        options.reconnectPeriod = 10000; // Reconnect every 10 seconds
 
-        this.client = await mqtt.connectAsync(this.configuration.url, options);
+        this.client = mqtt.connect(this.configuration.url, options);
 
+        // Register event handlers for logging
+        this.client.on('connect', (connack) => {
+            this.log.debug('MQTT client connected');
+        });
+
+        this.client.on('reconnect', () => {
+            this.log.debug('MQTT client reconnecting');
+        });
+
+        this.client.on('close', () => {
+            this.log.debug('MQTT connection closed');
+        });
+
+        this.client.on('disconnect', (packet) => {
+            this.log.debug(`MQTT client disconnected, reasonCode: ${packet?.reasonCode}`);
+        });
+
+        this.client.on('error', (error) => {
+            this.log.debug(`MQTT client error ${error.code}` );
+
+        });
+
+        this.client.on('end', () => {
+            this.log.debug('MQTT client ended');
+        });
+
+        this.client.connect();
+        
         if (this.configuration.hass.enabled) {
             this.hass = new Hass({
                 client: this.client,
@@ -156,6 +186,15 @@ class Mqtt extends Trigger {
 
     async triggerBatch() {
         throw new Error('This trigger does not support "batch" mode');
+    }
+
+    /**
+     * Deregister the component
+     * @returns {Promise<void>}
+     */
+
+    async deregisterComponent(): Promise<void> {
+        return this.client.end(true);
     }
 }
 


### PR DESCRIPTION
This PR prevents the MQTT trigger creation to fail if MQTT broker is unavailable by using the synchronous MQTT client creation method instead of the asynchronous one.

This PR also publishes a new connection status sensor (and its discovery topic if enabled) which allows MQTT subscribers to know if WUD is connected to the broker. The will added to MQTT client options instructs the MQTT broker to automatically set this sensor to offline when WUD disconnects.

