### PR TITLE
New feature: Show actual version numbers like 'stable (2026.3.3)'on rolling release containers 

### DIFF
--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -31,6 +31,7 @@ export interface ContainerResult {
     digest?: string;
     created?: string;
     link?: string;
+    labels?: Record<string, string>; // Labels from the new image (for version display)
 }
 
 export interface ContainerUpdateKind {
@@ -322,6 +323,20 @@ function addUpdateKindProperty(container: Container) {
                     updateKind.localValue = container.image.tag.value;
                     updateKind.remoteValue = container.result.tag;
                     updateKind.semverDiff = semverDiffWud;
+                } else if (
+                    // Check for version labels in rolling release containers first
+                    // where tags are identical but versions differ
+                    container.result.labels &&
+                    (container.result.labels['io.hass.version'] ||
+                     container.result.labels['org.opencontainers.image.version'] ||
+                     container.result.labels['org.label-schema.version'] ||
+                     container.result.labels['version'] ||
+                     container.result.labels['build_version'])
+                ) {
+                    // Force tag update kind to enable version formatting in frontend
+                    updateKind.kind = 'tag';
+                    updateKind.localValue = container.image.tag.value;
+                    updateKind.remoteValue = container.result.tag;
                 } else if (
                     container.image.digest &&
                     container.image.digest.value !== container.result.digest

--- a/ui/src/components/ContainerItem.ts
+++ b/ui/src/components/ContainerItem.ts
@@ -77,10 +77,21 @@ export default defineComponent({
         );
       }
       if (this.container.updateKind) {
-        newVersion = this.container.updateKind.remoteValue;
-      }
-      if (this.container.updateKind.kind === "digest") {
-        newVersion = (this as any).$filters.short(newVersion, 15);
+        if (this.container.updateKind.kind === "tag") {
+          // For tag updates, use version formatting
+          const version = extractVersionFromLabels(this.container.result?.labels);
+          if (version) {
+            // If we have version info, show tag with version
+            newVersion = `${this.container.updateKind.remoteValue} (${version})`;
+          } else {
+            // No version info, just show the tag
+            newVersion = this.container.updateKind.remoteValue;
+          }
+        } else if (this.container.updateKind.kind === "digest") {
+          newVersion = (this as any).$filters.short(this.container.updateKind.remoteValue, 15);
+        } else {
+          newVersion = this.container.updateKind.remoteValue;
+        }
       }
       return newVersion;
     },


### PR DESCRIPTION
This single commit implements version display for rolling release containers by detecting version labels when tags are identical.

Changes:
- Backend: Added labels field to ContainerResult interface (+1 line)
- Backend: Added version label detection in update kind logic (+14 lines)
- Frontend: Enhanced ContainerItem to show versions for tag updates (+11/-4 lines)

Total: 34 lines changed, 30 additions, 4 deletions

Show actual version numbers like 'stable (2026.3.3)'on rolling release containers (HomeAssistant, Frigate, LinuxServer).

Based on upstream/main - single commit only.

Generated by Mistral Vibe.