### PR TITLE
Fix mobile responsiveness of the containers page (#958)

### DIFF
--- a/ui/src/components/ContainerFilter.vue
+++ b/ui/src/components/ContainerFilter.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container fluid class="ma-0 mb-3 pa-md-0">
     <v-row dense>
-      <v-col>
+      <v-col cols="12" sm="6" md="">
         <v-select
           :hide-details="true"
           v-model="watcherSelected"
@@ -13,7 +13,7 @@
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="12" sm="6" md="">
         <v-select
           :hide-details="true"
           v-model="registrySelected"
@@ -25,7 +25,7 @@
           density="compact"
         ></v-select>
       </v-col>
-      <v-col>
+      <v-col cols="12" sm="6" md="">
         <v-select
           :hide-details="true"
           v-model="updateKindSelected"
@@ -38,7 +38,7 @@
         ></v-select>
       </v-col>
 
-      <v-col>
+      <v-col cols="12" sm="6" md="">
         <v-autocomplete
           label="Group by label"
           :items="groupLabels"
@@ -50,7 +50,7 @@
         >
         </v-autocomplete>
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="">
         <v-switch
           class="switch-top"
           label="Update available"
@@ -60,7 +60,7 @@
           density="compact"
         />
       </v-col>
-      <v-col>
+      <v-col cols="6" sm="4" md="">
         <v-switch
           class="switch-top"
           label="Oldest first"
@@ -70,7 +70,7 @@
           density="compact"
         />
       </v-col>
-      <v-col class="text-right">
+      <v-col cols="12" sm="4" md="" class="text-right">
         <v-btn
           color="secondary"
           @click.stop="refreshAllContainers"


### PR DESCRIPTION
@ -0,0 +1,44 @@
# PR: Fix mobile responsiveness of the containers page

**Title:** Fix mobile responsiveness of the containers page

**Closes:** #958

---

## Description

This PR addresses the container filter form overflow reported in #958. On mobile devices and narrow windows, the 7 filter controls are placed in a single row without responsive sizing, causing horizontal overflow and broken/unreadable text. 

I kept the scope small since I don't know if there is any ongoing development or anything for mobile responsiveness and wanted to keep it simple. I use wud a lot on my mobile and this has been annoying for a while so wanted to fix at least this part. 

## Key Changes

**File:** `ContainerFilter.vue`

- Added responsive column sizing (`cols`, `sm`, `md` breakpoints) to all 7 `<v-col>` elements in the filter row
- On mobile (xs, <600px): select filters stack vertically (full width), switches display side-by-side, button gets its own row
- On small tablets (sm, 600-959px): select filters display 2-per-row, switches and button share a row
- On desktop (md+, ≥960px): unchanged - `md=""` preserves the original horizontal layout

## Testing

- Tested at multiple viewport widths using Chrome DevTools device toolbar:
  - **xs (<600px):** Filters stack vertically, switches paired, button full width
  - **sm (600-959px):** Filters 2-per-row
  - **md+ (960px+):** No changes to existing behavior
- Existing unit tests pass (`npm run test:unit` - 157 tests, 26 suites)
- Linting passes (`npm run lint`)

## Breaking Changes

None. Only adds standard Vuetify responsive grid attributes. Desktop layout is fully preserved.

## Screenshots

### Before (mobile 375px)
<img width="750" height="1334" alt="before-mobile" src="https://github.com/user-attachments/assets/ff8ec263-1103-4b41-add2-613969c34b7f" />


### After (mobile 375px)
<img width="750" height="1334" alt="after-mobile" src="https://github.com/user-attachments/assets/e03490b5-5939-4279-999b-5945367919cf" />


### After (desktop 1400px) — unchanged behavior
<img width="1390" height="1277" alt="after-desktop" src="https://github.com/user-attachments/assets/39b3a94d-fb95-4bd8-8989-979d7ca7ba40" />