### PR TITLE
Fix #819. Use manifest mediaType instead of config mediaType for single-platform manifests

### DIFF
--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -275,6 +275,55 @@ test('getImageManifestDigest should throw when no digest found', async () => {
     ).rejects.toEqual(new Error('Unexpected error; no manifest found'));
 });
 
+test('getImageManifestDigest should return manifest digest (not config digest) for single-platform application/vnd.docker.distribution.manifest.v2+json with container image config', async () => {
+    const registryMocked = new Registry();
+    registryMocked.log = log;
+    registryMocked.callRegistry = (options) => {
+        if (
+            options.headers.Accept ===
+            'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
+        ) {
+            return {
+                schemaVersion: 2,
+                mediaType:
+                    'application/vnd.docker.distribution.manifest.v2+json',
+                config: {
+                    digest: 'config_digest',
+                    mediaType:
+                        'application/vnd.docker.container.image.v1+json',
+                },
+            };
+        }
+        if (
+            options.headers.Accept ===
+            'application/vnd.docker.distribution.manifest.v2+json'
+        ) {
+            return {
+                headers: {
+                    'docker-content-digest': 'manifest_digest',
+                },
+            };
+        }
+        throw new Error('Boom!');
+    };
+    expect(
+        registryMocked.getImageManifestDigest({
+            name: 'image',
+            architecture: 'amd64',
+            os: 'linux',
+            tag: {
+                value: 'tag',
+            },
+            registry: {
+                url: 'url',
+            },
+        }),
+    ).resolves.toStrictEqual({
+        version: 2,
+        digest: 'manifest_digest',
+    });
+});
+
 test('callRegistry should call authenticate', async () => {
     const { default: axios } = await import('axios');
     axios.mockResolvedValue({ data: {} });

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -221,7 +221,7 @@ class Registry extends Component {
                         `Manifest found with [digest=${responseManifests.config.digest}, mediaType=${responseManifests.config.mediaType}]`,
                     );
                     manifestDigestFound = responseManifests.config.digest;
-                    manifestMediaType = responseManifests.config.mediaType;
+                    manifestMediaType = responseManifests.mediaType;
                 }
             } else if (responseManifests.schemaVersion === 1) {
                 log.debug('Manifests found with schemaVersion = 1');


### PR DESCRIPTION
This fixes issue #819 where digest changes from custom Docker registries were being ignored. This appears to be caused by the single-platform manifest handling selecting the wrong digest.

When a registry returns a single-platform manifest.v2+json response, the code was setting manifestMediaType to the config's media type (application/vnd.docker.container.image.v1+json) rather than the manifest's media type. This caused the code to skip the HEAD request that retrieves the correct Docker-Content-Digest header, instead returning the config digest directly.

The config digest and the manifest digest are different things - Docker's RepoDigest is a hash of the manifest, not the config blob - so the comparison against the running container's digest never matched, and digest watching never triggered.