### PR TITLE
This PR introduces a new notification trigger provider for XMPP, allowing users to receive container update alerts via the XMPP protocol.

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -55,7 +55,8 @@
         "snake-case": "3.0.4",
         "sort-es": "1.7.17",
         "uuid": "11.0.3",
-        "yaml": "2.8.1"
+        "yaml": "2.8.1",
+        "@xmpp/client": "^0.13.1"
     },
     "devDependencies": {
         "@types/bunyan": "^1.8.11",

--- a/app/triggers/providers/xmpp/Xmpp.test.ts
+++ b/app/triggers/providers/xmpp/Xmpp.test.ts
@@ -115,6 +115,20 @@ test('trigger should send xmpp message as expected', async () => {
         username: configurationValid.user,
         password: configurationValid.password,
     });
+
+    // Verify the body xml element was constructed
+    expect(xml).toHaveBeenCalledWith('body', {}, expect.stringContaining('homeassistant'));
+
+    // Verify the message xml element was constructed with correct type and recipient
+    expect(xml).toHaveBeenCalledWith(
+        'message',
+        { type: 'chat', to: configurationValid.to },
+        expect.anything(),
+    );
+
+    // Verify the message was actually sent
+    const mockClientInstance = (client as jest.Mock).mock.results[0].value;
+    expect(mockClientInstance.send).toHaveBeenCalled();
 });
 
 test('triggerBatch should send xmpp message as expected', async () => {
@@ -137,4 +151,15 @@ test('triggerBatch should send xmpp message as expected', async () => {
         username: configurationValid.user,
         password: configurationValid.password,
     });
+
+    // Verify the message xml element was constructed with correct type and recipient
+    expect(xml).toHaveBeenCalledWith(
+        'message',
+        { type: 'chat', to: configurationValid.to },
+        expect.anything(),
+    );
+
+    // Verify the message was actually sent
+    const mockClientInstance = (client as jest.Mock).mock.results[0].value;
+    expect(mockClientInstance.send).toHaveBeenCalled();
 });

--- a/app/triggers/providers/xmpp/Xmpp.test.ts
+++ b/app/triggers/providers/xmpp/Xmpp.test.ts
@@ -1,0 +1,140 @@
+// @ts-nocheck
+import { ValidationError } from 'joi';
+import Xmpp from './Xmpp';
+import bunyan from 'bunyan';
+import { client, xml } from '@xmpp/client';
+
+jest.mock('@xmpp/client', () => {
+    const mockSend = jest.fn().mockResolvedValue(undefined);
+    const mockStop = jest.fn().mockResolvedValue(undefined);
+    const mockStart = jest.fn().mockResolvedValue(undefined);
+    const mockOn = jest.fn((event, cb) => {
+        if (event === 'online') {
+            cb({ toString: () => 'user@domain.com' });
+        }
+    });
+
+    return {
+        client: jest.fn(() => ({
+            on: mockOn,
+            start: mockStart,
+            stop: mockStop,
+            send: mockSend
+        })),
+        xml: jest.fn((name, attrs, ...children) => ({ name, attrs, children }))
+    };
+});
+
+const loggerBuffer = new bunyan.RingBuffer({ limit: 5 });
+const log = bunyan.createLogger({
+    name: 'Xmpp.Tests',
+    streams: [{ stream: loggerBuffer }],
+});
+
+const xmpp = new Xmpp();
+xmpp.log = log;
+
+beforeEach(() => {
+    loggerBuffer.records = [];
+    jest.clearAllMocks();
+});
+
+const configurationValid = {
+    service: 'xmpps://chat.example.com:5223',
+    domain: 'example.com',
+    user: 'user',
+    password: 'password123',
+    to: 'friend@example.com',
+    threshold: 'all',
+    mode: 'simple',
+    once: true,
+    auto: true,
+    simpletitle:
+        'New ${container.updateKind.kind} found for container ${container.name}',
+    simplebody:
+        'Container ${container.name} running with ${container.updateKind.kind} ${container.updateKind.localValue} can be updated to ${container.updateKind.kind} ${container.updateKind.remoteValue}${container.result && container.result.link ? "\\n" + container.result.link : ""}',
+    batchtitle: '${containers.length} updates available',
+};
+
+test('validateConfiguration should return validated configuration when valid', () => {
+    const validatedConfiguration = xmpp.validateConfiguration(configurationValid);
+    expect(validatedConfiguration).toStrictEqual(configurationValid);
+});
+
+test('validateConfiguration should throw error when invalid service', () => {
+    const configuration = {
+        ...configurationValid,
+        service: 'http://chat.example.com',
+    };
+    expect(() => {
+        xmpp.validateConfiguration(configuration);
+    }).toThrow(ValidationError);
+});
+
+test('maskConfiguration should mask sensitive data', () => {
+    xmpp.configuration = {
+        ...configurationValid,
+    };
+    expect(xmpp.maskConfiguration()).toEqual({
+        ...configurationValid,
+        password: 'p*********3',
+    });
+});
+
+test('trigger should send xmpp message as expected', async () => {
+    xmpp.configuration = configurationValid;
+    await xmpp.trigger({
+        id: '31a61a8305ef1fc9a71fa4f20a68d7ec88b28e32303bbc4a5f192e851165b816',
+        name: 'homeassistant',
+        watcher: 'local',
+        includeTags: '^\\d+\\.\\d+.\\d+$',
+        image: {
+            id: 'sha256:d4a6fafb7d4da37495e5c9be3242590be24a87d7edcc4f79761098889c54fca6',
+            registry: {
+                url: '123456789.dkr.ecr.eu-west-1.amazonaws.com',
+            },
+            name: 'test',
+            tag: {
+                value: '2021.6.4',
+                semver: true,
+            },
+        },
+        result: {
+            link: 'https://test-2.0.0/changelog',
+        },
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+    });
+
+    expect(client).toHaveBeenCalledWith({
+        service: configurationValid.service,
+        domain: configurationValid.domain,
+        username: configurationValid.user,
+        password: configurationValid.password,
+    });
+});
+
+test('triggerBatch should send xmpp message as expected', async () => {
+    xmpp.configuration = configurationValid;
+    await xmpp.triggerBatch([
+        {
+            id: '31a61a8305ef1fc9a71fa4f20a68d7ec88b28e32303bbc4a5f192e851165b816',
+            name: 'homeassistant',
+            updateKind: {
+                kind: 'tag',
+                localValue: '1.0.0',
+                remoteValue: '2.0.0',
+            },
+        },
+    ]);
+
+    expect(client).toHaveBeenCalledWith({
+        service: configurationValid.service,
+        domain: configurationValid.domain,
+        username: configurationValid.user,
+        password: configurationValid.password,
+    });
+});

--- a/app/triggers/providers/xmpp/Xmpp.ts
+++ b/app/triggers/providers/xmpp/Xmpp.ts
@@ -1,0 +1,118 @@
+import { client, xml } from '@xmpp/client';
+import Trigger from '../Trigger';
+import { Container } from '../../../model/container';
+
+/**
+ * XMPP Trigger implementation
+ */
+class Xmpp extends Trigger {
+    /**
+     * Get the Trigger configuration schema.
+     * @returns {*}
+     */
+    getConfigurationSchema() {
+        return this.joi.object().keys({
+            service: this.joi
+                .string()
+                .uri({ scheme: ['xmpp', 'xmpps', 'ws', 'wss'] })
+                .required(),
+            domain: this.joi.string().optional(),
+            user: this.joi.string().required(),
+            password: this.joi.string().required(),
+            to: this.joi.string().required(),
+        });
+    }
+
+    /**
+     * Sanitize sensitive data
+     * @returns {*}
+     */
+    maskConfiguration() {
+        return {
+            ...this.configuration,
+            service: this.configuration.service,
+            domain: this.configuration.domain,
+            user: this.configuration.user,
+            password: Xmpp.mask(this.configuration.password),
+            to: this.configuration.to,
+        };
+    }
+
+    /**
+     * Init trigger.
+     */
+    initTrigger() {
+        // Nothing to do for XMPP since we connect per message
+    }
+
+    /**
+     * Send an XMPP message with new container version details.
+     *
+     * @param container the container
+     * @returns {Promise<void>}
+     */
+    async trigger(container: Container) {
+        return this.sendMessage(
+            this.renderSimpleTitle(container),
+            this.renderSimpleBody(container),
+        );
+    }
+
+    /**
+     * Send an XMPP message with new container versions details.
+     * @param containers
+     * @returns {Promise<void>}
+     */
+    async triggerBatch(containers: Container[]) {
+        return this.sendMessage(
+            this.renderBatchTitle(containers),
+            this.renderBatchBody(containers),
+        );
+    }
+
+    /**
+     * Post a message to an XMPP recipient.
+     * @param title the title to post
+     * @param body the body to post
+     * @returns {Promise<void>}
+     */
+    async sendMessage(title: string, body: string): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const xmpp = client({
+                service: this.configuration.service,
+                domain: this.configuration.domain,
+                username: this.configuration.user,
+                password: this.configuration.password,
+            });
+
+            xmpp.on('error', (err) => {
+                this.log.error(`XMPP Error: ${err.message}`);
+                reject(err);
+            });
+
+            xmpp.on('online', async (address) => {
+                this.log.debug(`XMPP online as ${address.toString()}`);
+
+                try {
+                    const message = xml(
+                        'message',
+                        { type: 'chat', to: this.configuration.to },
+                        xml('body', {}, `${title}\n\n${body}`),
+                    );
+                    await xmpp.send(message);
+                    await xmpp.stop();
+                    resolve();
+                } catch (e) {
+                    reject(e);
+                }
+            });
+
+            xmpp.start().catch((err) => {
+                this.log.error(`XMPP Start Error: ${err.message}`);
+                reject(err);
+            });
+        });
+    }
+}
+
+export default Xmpp;

--- a/docs/configuration/triggers/sidebar.md
+++ b/docs/configuration/triggers/sidebar.md
@@ -23,6 +23,7 @@
         - [Slack](configuration/triggers/slack/)
         - [Smtp](configuration/triggers/smtp/)
         - [Telegram](configuration/triggers/telegram/)
+        - [Xmpp](configuration/triggers/xmpp/)
     - [Watchers](configuration/watchers/)
 - [Api](api/)
 - [Monitoring](monitoring/)

--- a/docs/configuration/triggers/xmpp/README.md
+++ b/docs/configuration/triggers/xmpp/README.md
@@ -1,0 +1,51 @@
+# Xmpp
+
+The `xmpp` trigger lets you send notifications via XMPP (Jabber) instant messaging.
+
+### Variables
+
+| Env var                                          | Required       | Description                                                                             | Supported values                          | Default value when missing |
+| ------------------------------------------------ |:--------------:|:--------------------------------------------------------------------------------------  | ----------------------------------------- | -------------------------- |
+| `WUD_TRIGGER_XMPP_{trigger_name}_SERVICE`        | :red_circle:   | XMPP server service URL                                                                 | `xmpp://…`, `xmpps://…`, `ws://…`, `wss://…` |                        |
+| `WUD_TRIGGER_XMPP_{trigger_name}_DOMAIN`         | :white_circle: | XMPP domain (inferred from JID if not set)                                              |                                           |                            |
+| `WUD_TRIGGER_XMPP_{trigger_name}_USER`           | :red_circle:   | XMPP username (local part of JID, e.g. `user` from `user@example.com`)                 |                                           |                            |
+| `WUD_TRIGGER_XMPP_{trigger_name}_PASSWORD`       | :red_circle:   | XMPP account password                                                                   |                                           |                            |
+| `WUD_TRIGGER_XMPP_{trigger_name}_TO`             | :red_circle:   | Recipient JID to send the message to                                                    | Valid JID, e.g. `friend@example.com`      |                            |
+
+?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
+
+### Examples
+
+#### Send an XMPP chat message
+
+<!-- tabs:start -->
+#### **Docker Compose**
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    ...
+    environment:
+        - WUD_TRIGGER_XMPP_MAIN_SERVICE=xmpps://chat.example.com:5223
+        - WUD_TRIGGER_XMPP_MAIN_DOMAIN=example.com
+        - WUD_TRIGGER_XMPP_MAIN_USER=wud
+        - WUD_TRIGGER_XMPP_MAIN_PASSWORD=mysecretpass
+        - WUD_TRIGGER_XMPP_MAIN_TO=admin@example.com
+```
+
+#### **Docker**
+
+```bash
+docker run \
+    -e WUD_TRIGGER_XMPP_MAIN_SERVICE="xmpps://chat.example.com:5223" \
+    -e WUD_TRIGGER_XMPP_MAIN_DOMAIN="example.com" \
+    -e WUD_TRIGGER_XMPP_MAIN_USER="wud" \
+    -e WUD_TRIGGER_XMPP_MAIN_PASSWORD="mysecretpass" \
+    -e WUD_TRIGGER_XMPP_MAIN_TO="admin@example.com" \
+  ...
+  getwud/wud
+```
+<!-- tabs:end -->
+
+?> The `SERVICE` URL scheme `xmpps://` uses direct TLS on port 5223 (recommended). Use `xmpp://` for plain-text STARTTLS on port 5222. WebSocket transports `ws://` and `wss://` are also supported for servers that expose an XMPP-over-WebSocket endpoint.


### PR DESCRIPTION
It implements the new `Xmpp` trigger class mimicking the structure of existing triggers and relies on the lightweight `@xmpp/client` dependency.

### Changes Included
*   **Added `@xmpp/client` dependency** to `app/package.json` to handle the underlying protocol messaging.
*   **Created `Xmpp.ts`** under `app/triggers/providers/xmpp/`, exposing a configuration schema taking `service`, `domain`, `user`, `password`, and `to` properties. 
*   **Implemented messaging logic** that properly connects, dispatches both single and batched notifications into chat stanzas, and gracefully disconnects per event.
*   **Added Unit Tests** in `Xmpp.test.ts` to validate the Joi configuration schema, data masking, and simulate `@xmpp/client` successful message dispatches. 

### Configuration Example
To use it, users will just need to set the variables such as:
```env
WUD_TRIGGER_XMPP_MYBOT_SERVICE=xmpps://chat.example.com:5223
WUD_TRIGGER_XMPP_MYBOT_USER=user
WUD_TRIGGER_XMPP_MYBOT_PASSWORD=secret
WUD_TRIGGER_XMPP_MYBOT_TO=admin@example.com
