### PR TITLE
fix(ntfy): use axios basic auth field names

### DIFF
--- a/app/triggers/providers/ntfy/Ntfy.test.ts
+++ b/app/triggers/providers/ntfy/Ntfy.test.ts
@@ -118,7 +118,7 @@ test('trigger should use basic auth when configured like that', async () => {
         method: 'POST',
 
         url: 'http://xxx.com',
-        auth: { user: 'user', pass: 'pass' },
+        auth: { username: 'user', password: 'pass' },
     });
 });
 

--- a/app/triggers/providers/ntfy/Ntfy.ts
+++ b/app/triggers/providers/ntfy/Ntfy.ts
@@ -93,8 +93,8 @@ class Ntfy extends Trigger {
             this.configuration.auth.password
         ) {
             options.auth = {
-                user: this.configuration.auth.user,
-                pass: this.configuration.auth.password,
+                username: this.configuration.auth.user,
+                password: this.configuration.auth.password,
             };
         }
         if (this.configuration.auth && this.configuration.auth.token) {


### PR DESCRIPTION
Map ntfy basic auth credentials to username/password instead of user/pass so authenticated requests work.