### PR TITLE
fix: override getTagsPage in ECR provider to use link header for pagination

### DIFF
--- a/app/registries/providers/ecr/Ecr.ts
+++ b/app/registries/providers/ecr/Ecr.ts
@@ -111,6 +111,24 @@ class Ecr extends Registry {
             return undefined;
         }
     }
+    getTagsPage(image: ContainerImage, lastItem: string | undefined = undefined, link: string | undefined = undefined) {
+        const itemsPerPage = 1000;
+        if (link) {
+            const linkUrl = link.match(/<(.+?)>/);
+            if (linkUrl) {
+                return this.callRegistry<RegistryTagsList>({
+                    image,
+                    url: `https://public.ecr.aws${linkUrl[1]}`,
+                    resolveWithFullResponse: true,
+                });
+            }
+        }
+        return this.callRegistry<RegistryTagsList>({
+            image,
+            url: `${image.registry.url}/${image.name}/tags/list?n=${itemsPerPage}`,
+            resolveWithFullResponse: true,
+        });
+    }
 }
 
 export default Ecr;


### PR DESCRIPTION
Proposed fix for handling public ECR images in WUD. Relates to issue: #1052 

Tried to build a container, but [ui/**dist/**](https://github.com/getwud/wud/blob/8242a8cb8a8e624b76a3bcc59bb3f8ca51c5424b/Dockerfile#L57) is missing from the repo. So instead I've tested by overriding `/home/node/app/dist/registries/providers/ecr/Ecr.js` in a container through a bind mount with this proposed change, which works.