### PR TITLE
Add runtime subpath proxy support with WUD_SERVER_BASEPATH

### DIFF
--- a/app/api/ui.ts
+++ b/app/api/ui.ts
@@ -14,6 +14,7 @@ function serveIndex(res) {
         `<script>window.__WUD_BASE_PATH__='${basePath}'</script><div id="app">`,
     );
     res.setHeader('Content-Type', 'text/html');
+    res.setHeader('Cache-Control', 'no-store');
     res.send(injected);
 }
 

--- a/app/api/ui.ts
+++ b/app/api/ui.ts
@@ -1,6 +1,21 @@
 // @ts-nocheck
+import fs from 'fs';
 import path from 'path';
 import express from 'express';
+import { getServerConfiguration } from '../configuration';
+
+const indexHtmlPath = path.join(__dirname, '..', '..', 'ui', 'index.html');
+
+function serveIndex(res) {
+    const basePath = getServerConfiguration().basepath;
+    const html = fs.readFileSync(indexHtmlPath, 'utf-8');
+    const injected = html.replace(
+        '<div id="app">',
+        `<script>window.__WUD_BASE_PATH__='${basePath}'</script><div id="app">`,
+    );
+    res.setHeader('Content-Type', 'text/html');
+    res.send(injected);
+}
 
 /**
  * Init the UI router.
@@ -8,11 +23,11 @@ import express from 'express';
  */
 export function init() {
     const router = express.Router();
-    router.use(express.static(path.join(__dirname, '..', '..', 'ui')));
+    router.use(express.static(path.join(__dirname, '..', '..', 'ui'), { index: false }));
 
     // Redirect all 404 to index.html (for vue history mode)
     router.get('*', (req, res) => {
-        res.sendFile(path.join(__dirname, '..', '..', 'ui', 'index.html'));
+        serveIndex(res);
     });
     return router;
 }

--- a/app/configuration/index.ts
+++ b/app/configuration/index.ts
@@ -132,6 +132,7 @@ export function getServerConfiguration() {
                 methods: joi.string().default('GET,HEAD,PUT,PATCH,POST,DELETE'),
             })
             .default({}),
+        basepath: joi.string().default('/'),
         feature: joi
             .object({
                 delete: joi.boolean().default(true),

--- a/docs/configuration/server/README.md
+++ b/docs/configuration/server/README.md
@@ -15,6 +15,7 @@ You can adjust the server configuration with the following environment variables
 | `WUD_SERVER_CORS_ORIGIN`   | :white_circle: | Supported CORS origin                                                        |                                          | `*`                              |
 | `WUD_SERVER_CORS_METHODS`  | :white_circle: | Supported CORS methods                                                       | Comma separated list of valid HTTP verbs | `GET,HEAD,PUT,PATCH,POST,DELETE` |
 | `WUD_SERVER_FEATURE_DELETE`| :white_circle: | If deleting operations are enabled through API & UI                          | `true`, `false`                          | `true`                           |
+| `WUD_SERVER_BASEPATH`      | :white_circle: | Base path when running behind a prefix-stripping reverse proxy (e.g. `/wud/`) | Any valid URL path ending with `/`      | `/`                              |
 
 ### Examples
 
@@ -59,6 +60,36 @@ docker run \
   getwud/wud
 ```
 <!-- tabs:end -->
+
+#### Run behind a reverse proxy subpath
+
+When WUD is served under a subpath (e.g. `https://example.com/wud/`) by a prefix-stripping reverse proxy, set `WUD_SERVER_BASEPATH` to that subpath so the UI and API calls resolve correctly.
+
+<!-- tabs:start -->
+#### **Docker Compose**
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    ...
+    environment:
+      - WUD_SERVER_BASEPATH=/wud/
+```
+#### **Docker**
+```bash
+docker run \
+  -e "WUD_SERVER_BASEPATH=/wud/" \
+  ...
+  getwud/wud
+```
+<!-- tabs:end -->
+
+Example Caddy configuration (prefix-stripping):
+```
+handle_path /wud/* {
+    reverse_proxy localhost:3000
+}
+```
 
 #### Enable HTTPS
 

--- a/ui/src/App.ts
+++ b/ui/src/App.ts
@@ -8,6 +8,7 @@ import {
   watch,
   defineComponent,
 } from "vue";
+import { url } from "@/services/base";
 import NavigationDrawer from "@/components/NavigationDrawer.vue";
 import AppBar from "@/components/AppBar.vue";
 import SnackBar from "@/components/SnackBar.vue";
@@ -75,7 +76,7 @@ export default defineComponent({
       } else if (!user.value) {
         // Fallback auth check if user not set by router guard
         try {
-          const response = await fetch("/auth/user", {
+          const response = await fetch(url("auth/user"), {
             credentials: "include",
           });
           if (response.ok) {

--- a/ui/src/router/index.ts
+++ b/ui/src/router/index.ts
@@ -46,7 +46,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory((window as any).__WUD_BASE_PATH__ || '/'),
   routes,
 });
 

--- a/ui/src/services/app.ts
+++ b/ui/src/services/app.ts
@@ -1,5 +1,7 @@
+import { url } from "./base";
+
 async function getAppInfos() {
-  const response = await fetch("/api/app", { credentials: "include" });
+  const response = await fetch(url("api/app"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/auth.ts
+++ b/ui/src/services/auth.ts
@@ -1,6 +1,7 @@
 /**
  * Authentication service.
  */
+import { url } from "./base";
 
 // Current logged user
 let user = undefined;
@@ -10,7 +11,7 @@ let user = undefined;
  * @returns {Promise<any>}
  */
 async function getStrategies() {
-  const response = await fetch("/auth/strategies", { credentials: "include" });
+  const response = await fetch(url("auth/strategies"), { credentials: "include" });
   return response.json();
 }
 
@@ -20,7 +21,7 @@ async function getStrategies() {
  */
 async function getUser() {
   try {
-    const response = await fetch("/auth/user", {
+    const response = await fetch(url("auth/user"), {
       redirect: "manual",
       credentials: "include",
     });
@@ -45,7 +46,7 @@ async function getUser() {
  */
 async function loginBasic(username, password) {
   const base64 = btoa(`${username}:${password}`);
-  const response = await fetch(`/auth/login`, {
+  const response = await fetch(url("auth/login"), {
     method: "POST",
     credentials: "include",
     headers: {
@@ -66,7 +67,7 @@ async function loginBasic(username, password) {
  * @returns {Promise<*>}
  */
 async function getOidcRedirection(name) {
-  const response = await fetch(`/auth/oidc/${name}/redirect`, { credentials: "include" });
+  const response = await fetch(url(`auth/oidc/${name}/redirect`), { credentials: "include" });
   user = await response.json();
   return user;
 }
@@ -76,7 +77,7 @@ async function getOidcRedirection(name) {
  * @returns {Promise<any>}
  */
 async function logout() {
-  const response = await fetch(`/auth/logout`, {
+  const response = await fetch(url("auth/logout"), {
     method: "POST",
     credentials: "include",
     redirect: "manual",

--- a/ui/src/services/authentication.ts
+++ b/ui/src/services/authentication.ts
@@ -1,9 +1,11 @@
+import { url } from "./base";
+
 function getAuthenticationIcon() {
   return "mdi-lock";
 }
 
 async function getAllAuthentications() {
-  const response = await fetch("/api/authentications", { credentials: "include" });
+  const response = await fetch(url("api/authentications"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/base.ts
+++ b/ui/src/services/base.ts
@@ -1,5 +1,4 @@
-const basePath: string = (window as any).__WUD_BASE_PATH__ || '/';
-
 export function url(path: string): string {
+  const basePath: string = (window as any).__WUD_BASE_PATH__ || '/';
   return `${basePath}${path}`.replace(/\/\//g, '/');
 }

--- a/ui/src/services/base.ts
+++ b/ui/src/services/base.ts
@@ -1,0 +1,5 @@
+const basePath: string = (window as any).__WUD_BASE_PATH__ || '/';
+
+export function url(path: string): string {
+  return `${basePath}${path}`.replace(/\/\//g, '/');
+}

--- a/ui/src/services/container.ts
+++ b/ui/src/services/container.ts
@@ -1,14 +1,16 @@
+import { url } from "./base";
+
 function getContainerIcon() {
   return "mdi-docker";
 }
 
 async function getAllContainers() {
-  const response = await fetch("/api/containers", { credentials: "include" });
+  const response = await fetch(url("api/containers"), { credentials: "include" });
   return response.json();
 }
 
 async function refreshAllContainers() {
-  const response = await fetch(`/api/containers/watch`, {
+  const response = await fetch(url("api/containers/watch"), {
     method: "POST",
     credentials: "include",
   });
@@ -16,7 +18,7 @@ async function refreshAllContainers() {
 }
 
 async function refreshContainer(containerId) {
-  const response = await fetch(`/api/containers/${containerId}/watch`, {
+  const response = await fetch(url(`api/containers/${containerId}/watch`), {
     method: "POST",
     credentials: "include",
   });
@@ -27,17 +29,17 @@ async function refreshContainer(containerId) {
 }
 
 async function deleteContainer(containerId) {
-  return fetch(`/api/containers/${containerId}`, { method: "DELETE", credentials: "include" });
+  return fetch(url(`api/containers/${containerId}`), { method: "DELETE", credentials: "include" });
 }
 
 async function getContainerTriggers(containerId) {
-  const response = await fetch(`/api/containers/${containerId}/triggers`, { credentials: "include" });
+  const response = await fetch(url(`api/containers/${containerId}/triggers`), { credentials: "include" });
   return response.json();
 }
 
 async function runTrigger({ containerId, triggerType, triggerName }) {
   const response = await fetch(
-    `/api/containers/${containerId}/triggers/${triggerType}/${triggerName}`,
+    url(`api/containers/${containerId}/triggers/${triggerType}/${triggerName}`),
     {
       method: "POST",
       credentials: "include",

--- a/ui/src/services/log.ts
+++ b/ui/src/services/log.ts
@@ -1,9 +1,11 @@
+import { url } from "./base";
+
 function getLogIcon() {
   return "mdi-bug";
 }
 
 async function getLog() {
-  const response = await fetch("/api/log", { credentials: "include" });
+  const response = await fetch(url("api/log"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/registry.ts
+++ b/ui/src/services/registry.ts
@@ -58,8 +58,10 @@ function getRegistryProviderIcon(provider) {
  * get all registries.
  * @returns {Promise<any>}
  */
+import { url } from "./base";
+
 async function getAllRegistries() {
-  const response = await fetch("/api/registries", { credentials: "include" });
+  const response = await fetch(url("api/registries"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/server.ts
+++ b/ui/src/services/server.ts
@@ -1,9 +1,11 @@
+import { url } from "./base";
+
 function getServerIcon() {
   return "mdi-connection";
 }
 
 async function getServer() {
-  const response = await fetch("/api/server", { credentials: "include" });
+  const response = await fetch(url("api/server"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/store.ts
+++ b/ui/src/services/store.ts
@@ -1,9 +1,11 @@
+import { url } from "./base";
+
 function getStoreIcon() {
   return "mdi-file-multiple";
 }
 
 async function getStore() {
-  const response = await fetch("/api/store", { credentials: "include" });
+  const response = await fetch(url("api/store"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/src/services/trigger.ts
+++ b/ui/src/services/trigger.ts
@@ -1,14 +1,16 @@
+import { url } from "./base";
+
 function getTriggerIcon() {
   return "mdi-bell-ring";
 }
 
 async function getAllTriggers() {
-  const response = await fetch("/api/triggers", { credentials: "include" });
+  const response = await fetch(url("api/triggers"), { credentials: "include" });
   return response.json();
 }
 
 async function runTrigger({ triggerType, triggerName, container }) {
-  const response = await fetch(`/api/triggers/${triggerType}/${triggerName}`, {
+  const response = await fetch(url(`api/triggers/${triggerType}/${triggerName}`), {
     method: "POST",
     credentials: "include",
     headers: { "Content-Type": "application/json" },

--- a/ui/src/services/watcher.ts
+++ b/ui/src/services/watcher.ts
@@ -1,9 +1,11 @@
+import { url } from "./base";
+
 function getWatcherIcon() {
   return "mdi-update";
 }
 
 async function getAllWatchers() {
-  const response = await fetch("/api/watchers", { credentials: "include" });
+  const response = await fetch(url("api/watchers"), { credentials: "include" });
   return response.json();
 }
 

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require("@vue/cli-service");
 const webpack = require("webpack");
 
 module.exports = defineConfig({
+  publicPath: './',
   parallel: false, // Disable parallel build to avoid Thread Loader errors
   devServer: {
     host: '0.0.0.0',


### PR DESCRIPTION
This pull request introduces support for serving the application under a configurable base path, enabling deployment behind a prefix-stripping reverse proxy (such as serving under `/wud/` instead of `/`). The changes ensure both the backend and frontend are aware of the base path, and all API/UI requests are correctly routed. Documentation is updated to guide users on this new configuration. Most frontend service calls are refactored to use a central utility that prepends the base path, and the router/history setup is updated to respect the configured base path.

**Backend/API changes:**

* Added a `basepath` configuration option to the server, allowing the base path to be specified via the `WUD_SERVER_BASEPATH` environment variable.
* Updated the UI router in `app/api/ui.ts` to inject the base path into the frontend via a global JS variable and to serve `index.html` with this injection, ensuring the frontend is aware of the base path.

**Frontend changes:**

* Introduced a central `url` utility in `ui/src/services/base.ts` that prepends the configured base path to all API/UI requests; refactored all service files to use this utility instead of hardcoded paths. [[1]](diffhunk://#diff-fad139a36300b559a6788027dfcd45691f4f7a247740022067810ee6e66afac3R1-R5) [[2]](diffhunk://#diff-8127ad68638cf8e5c17a2e1d8a66c5b041d03be5c76ee36d7a9fd823d688d57aR11) [[3]](diffhunk://#diff-639ef009ce25ba733d36037e910c9f7beb1cad742acd344054f0e2aca1a99ee1R1-R4) [[4]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fR4) [[5]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fL13-R14) [[6]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fL23-R24) [[7]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fL48-R49) [[8]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fL69-R70) [[9]](diffhunk://#diff-4c571ba34569caebb49024f3b51fc7f5e3a092118a3d054dbf530e9c9fc1537fL79-R80) [[10]](diffhunk://#diff-f43caf46b5a5f592b04bbeb7e32725816b6d7b35c28f35c6fff6e7354212c80bR1-R8) [[11]](diffhunk://#diff-622cece5bd09861f34c4b7798371bf3831bf2dfa954845b971a652d725fbb3d1R1-R21) [[12]](diffhunk://#diff-622cece5bd09861f34c4b7798371bf3831bf2dfa954845b971a652d725fbb3d1L30-R42) [[13]](diffhunk://#diff-559aecea501ed1a29967bf9b7a42d854758a1f199ee909ea7c2a25f255f2f481R1-R8) [[14]](diffhunk://#diff-972734fc9ce78e3f81c5e5bdb8a7e488c81bc127db031a1dd2679c35b51a7519R61-R64) [[15]](diffhunk://#diff-2196d395b7807b21afab3714ded9ff98baf5bc99357c11f72d9dc3bea1270625R1-R8) [[16]](diffhunk://#diff-e927e73db4e8d049cc0e0eb0ff7b8ecef359f64c7279d769b5567e97ed1ae80fR1-R8) [[17]](diffhunk://#diff-0446186779962b59c92067b4b25484fbc38ffae66b4472b24dfcd33345cdf955R1-R13) [[18]](diffhunk://#diff-f5b126a4252249fd9b68b5fd877db20487125e38ed3a44e5d9dbf2d6fff7c1faR1-R8)
* Updated the Vue Router configuration to use the injected base path from `window.__WUD_BASE_PATH__` for history mode, ensuring correct routing under subpaths.
* Set `publicPath` to `./` in `vue.config.js` to support relative asset loading under different base paths.

**Documentation updates:**

* Added documentation for the new `WUD_SERVER_BASEPATH` environment variable, including examples for Docker, Docker Compose, and reverse proxy setups. [[1]](diffhunk://#diff-38cfb4ef2749b69a460f2920a7c20fab8b126d1a2ccdac8c09e9aded17b5571cR18) [[2]](diffhunk://#diff-38cfb4ef2749b69a460f2920a7c20fab8b126d1a2ccdac8c09e9aded17b5571cR64-R93)