### PR TITLE
Fix digest fallback when Docker Config.Image is empty

### DIFF
--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -700,6 +700,40 @@ describe('Docker Watcher', () => {
             expect(container.image.digest.value).toBe('sha256:legacy123');
         });
 
+        test('should use image id when legacy image config digest is empty', async () => {
+            await docker.register('watcher', 'docker', 'test', {});
+            const container = {
+                image: {
+                    id: 'image123',
+                    registry: { name: 'hub' },
+                    tag: { value: 'latest' },
+                    digest: { watch: true, repo: 'sha256:abc123' },
+                },
+            };
+            const mockRegistry = {
+                getTags: jest.fn().mockResolvedValue(['latest']),
+                getImageManifestDigest: jest.fn().mockResolvedValue({
+                    digest: 'sha256:def456',
+                    created: '2023-01-01',
+                    version: 1,
+                }),
+            };
+            registry.getState.mockReturnValue({
+                registry: { hub: mockRegistry },
+            });
+            const mockLogChild = { error: jest.fn() };
+            const mockImageInspect = {
+                Config: { Image: '' },
+                Id: 'sha256:local123',
+            };
+            mockImage.inspect.mockResolvedValue(mockImageInspect);
+
+            await docker.findNewVersion(container, mockLogChild);
+
+            expect(mockImage.inspect).toHaveBeenCalled();
+            expect(container.image.digest.value).toBe('sha256:local123');
+        });
+
         test('should handle tag candidates with semver', async () => {
             const container = {
                 includeTags: '^v\\d+',

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -816,9 +816,7 @@ class Docker extends Watcher {
                         .getImage(container.image.id)
                         .inspect();
                     container.image.digest.value =
-                        image.Config.Image === ''
-                            ? undefined
-                            : image.Config.Image;
+                        image.Config.Image || image.Id;
                 }
             }
 


### PR DESCRIPTION
Fixes #1078.

## Summary
- Fall back to Docker image `Id` when `Config.Image` is empty while resolving the local digest for legacy manifest handling.
- Add a Docker watcher regression test for mutable non-semver tags where digest watching is enabled and Docker image inspect returns an empty `Config.Image`.

## Why

For some modern Docker images, `image.Config.Image` is empty while `image.Id` still contains the local image config digest. Leaving `image.digest.value` undefined makes WUD skip digest comparison and fall back to tag comparison, so mutable tags like `latest` can be reported as having no update even when the remote digest changed.

## Validation

From `app/`:
- `npm test -- --runInBand watchers/providers/docker/Docker.test.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings)