### PR TITLE
Fix digest comparison for single-platform manifests resolved from a manifest list

### DIFF
--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -165,22 +165,25 @@ test('getImageManifestDigest should return digest for application/vnd.docker.dis
     });
 });
 
-test('getImageManifestDigest should return digest for application/vnd.docker.distribution.manifest.v2+json', async () => {
+test('getImageManifestDigest should return the manifest digest (not the config digest) for a single-platform application/vnd.docker.distribution.manifest.v2+json response', async () => {
     const registryMocked = new Registry();
     registryMocked.log = log;
+    const urlsCalled: string[] = [];
     registryMocked.callRegistry = (options) => {
+        urlsCalled.push(options.url);
         if (
             options.headers.Accept ===
             'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
         ) {
+            // Realistic single-platform manifest: config.mediaType is a *config*
+            // media type, never the manifest's own media type.
             return {
                 schemaVersion: 2,
                 mediaType:
                     'application/vnd.docker.distribution.manifest.v2+json',
                 config: {
-                    digest: 'digest_x',
-                    mediaType:
-                        'application/vnd.docker.distribution.manifest.v2+json',
+                    digest: 'config_digest',
+                    mediaType: 'application/vnd.docker.container.image.v1+json',
                 },
             };
         }
@@ -190,13 +193,13 @@ test('getImageManifestDigest should return digest for application/vnd.docker.dis
         ) {
             return {
                 headers: {
-                    'docker-content-digest': '123456789',
+                    'docker-content-digest': 'manifest_digest',
                 },
             };
         }
         throw new Error('Boom!');
     };
-    expect(
+    await expect(
         registryMocked.getImageManifestDigest({
             name: 'image',
             architecture: 'amd64',
@@ -210,8 +213,68 @@ test('getImageManifestDigest should return digest for application/vnd.docker.dis
         }),
     ).resolves.toStrictEqual({
         version: 2,
-        digest: '123456789',
+        digest: 'manifest_digest',
     });
+    // The confirmation request must be made against the reference we already
+    // fetched the manifest by (the tag here), never against the config digest.
+    expect(urlsCalled).toStrictEqual([
+        'url/image/manifests/tag',
+        'url/image/manifests/tag',
+    ]);
+});
+
+test('getImageManifestDigest should resolve a manifest fetched directly by its own digest to that same digest', async () => {
+    const registryMocked = new Registry();
+    registryMocked.log = log;
+    const urlsCalled: string[] = [];
+    registryMocked.callRegistry = (options) => {
+        urlsCalled.push(options.url);
+        if (
+            options.headers.Accept ===
+            'application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.manifest.v1+json'
+        ) {
+            return {
+                schemaVersion: 2,
+                mediaType: 'application/vnd.oci.image.manifest.v1+json',
+                config: {
+                    digest: 'config_digest',
+                    mediaType: 'application/vnd.oci.image.config.v1+json',
+                },
+            };
+        }
+        if (
+            options.headers.Accept ===
+            'application/vnd.oci.image.manifest.v1+json'
+        ) {
+            return {
+                headers: {
+                    'docker-content-digest': 'sha256:platformManifestDigest',
+                },
+            };
+        }
+        throw new Error('Boom!');
+    };
+    // This mirrors what Docker.ts does when re-resolving the container's local
+    // RepoDigest: it's already a leaf manifest digest, not a manifest-list digest.
+    await expect(
+        registryMocked.getImageManifestDigest(
+            {
+                name: 'image',
+                architecture: 'arm64',
+                os: 'linux',
+                tag: { value: 'latest' },
+                registry: { url: 'url' },
+            },
+            'sha256:platformManifestDigest',
+        ),
+    ).resolves.toStrictEqual({
+        version: 2,
+        digest: 'sha256:platformManifestDigest',
+    });
+    expect(urlsCalled).toStrictEqual([
+        'url/image/manifests/sha256:platformManifestDigest',
+        'url/image/manifests/sha256:platformManifestDigest',
+    ]);
 });
 
 test('getImageManifestDigest should return digest for application/vnd.docker.container.image.v1+json', async () => {

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -217,11 +217,16 @@ class Registry extends Component {
                     responseManifests.mediaType ===
                         'application/vnd.oci.image.manifest.v1+json'
                 ) {
+                    // Single-platform manifest (no list/index) => the reference
+                    // we already fetched it by (tag or digest) *is* the manifest
+                    // identifier. Do not use responseManifests.config.digest here;
+                    // that's the digest of the config blob, not of the manifest,
+                    // and is not a valid value to re-request a manifest with.
                     log.debug(
-                        `Manifest found with [digest=${responseManifests.config.digest}, mediaType=${responseManifests.config.mediaType}]`,
+                        `Manifest found with [reference=${tagOrDigest}, mediaType=${responseManifests.mediaType}]`,
                     );
-                    manifestDigestFound = responseManifests.config.digest;
-                    manifestMediaType = responseManifests.config.mediaType;
+                    manifestDigestFound = tagOrDigest;
+                    manifestMediaType = responseManifests.mediaType;
                 }
             } else if (responseManifests.schemaVersion === 1) {
                 log.debug('Manifests found with schemaVersion = 1');

--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 import Docker from './Docker';
+import Registry from '../../../registries/Registry';
 import * as event from '../../../event';
 import * as storeContainer from '../../../store/container';
 import * as registry from '../../../registry';
@@ -698,6 +699,123 @@ describe('Docker Watcher', () => {
 
             expect(mockImage.inspect).toHaveBeenCalled();
             expect(container.image.digest.value).toBe('sha256:legacy123');
+        });
+
+        test('should fall back to the image Id when Config.Image is empty for a legacy v1 manifest', async () => {
+            await docker.register('watcher', 'docker', 'test', {});
+            const container = {
+                image: {
+                    id: 'image123',
+                    registry: { name: 'hub' },
+                    tag: { value: '1.0.0' },
+                    digest: { watch: true, repo: 'sha256:abc123' },
+                },
+            };
+            const mockRegistry = {
+                getTags: jest.fn().mockResolvedValue(['1.0.0']),
+                getImageManifestDigest: jest.fn().mockResolvedValue({
+                    digest: 'sha256:def456',
+                    created: '2023-01-01',
+                    version: 1,
+                }),
+            };
+            registry.getState.mockReturnValue({
+                registry: { hub: mockRegistry },
+            });
+            const mockLogChild = { error: jest.fn() };
+            const mockImageInspect = {
+                Config: { Image: '' },
+                Id: 'sha256:local123',
+            };
+            mockImage.inspect.mockResolvedValue(mockImageInspect);
+
+            await docker.findNewVersion(container, mockLogChild);
+
+            expect(container.image.digest.value).toBe('sha256:local123');
+        });
+
+        test('should not flag a false digest update for a multi-arch image whose local RepoDigest is a leaf manifest digest (regression for ghcr.io/tricked-dev/kanidm-oauth2-manager)', async () => {
+            // Reproduces the real-world bug: an OCI index with amd64/arm64 entries,
+            // where Docker recorded the arm64 *manifest* digest (not the index
+            // digest) as the container's RepoDigest. Both the "remote" lookup (by
+            // tag) and the "local" lookup (by RepoDigest) must resolve to the same
+            // manifest digest when nothing changed.
+            const arm64ManifestDigest =
+                'sha256:8f52be5801e341d97f65e9d046d24e37ee980558806127f7c2b2f917670b5332';
+            const configDigest =
+                'sha256:c611bc3dc9d42510c69180b6328ebcb3a93cd9c739f79cc2b8ce17322a8baed5';
+
+            const ghcrRegistry = new Registry();
+            ghcrRegistry.getTags = jest.fn().mockResolvedValue(['latest']);
+            ghcrRegistry.callRegistry = jest.fn((options) => {
+                if (options.method === 'head') {
+                    return Promise.resolve({
+                        headers: {
+                            'docker-content-digest': arm64ManifestDigest,
+                        },
+                    });
+                }
+                if (options.url.endsWith('/manifests/latest')) {
+                    return Promise.resolve({
+                        schemaVersion: 2,
+                        mediaType: 'application/vnd.oci.image.index.v1+json',
+                        manifests: [
+                            {
+                                digest: 'sha256:amd64ManifestDigest',
+                                mediaType:
+                                    'application/vnd.oci.image.manifest.v1+json',
+                                platform: {
+                                    architecture: 'amd64',
+                                    os: 'linux',
+                                },
+                            },
+                            {
+                                digest: arm64ManifestDigest,
+                                mediaType:
+                                    'application/vnd.oci.image.manifest.v1+json',
+                                platform: {
+                                    architecture: 'arm64',
+                                    os: 'linux',
+                                },
+                            },
+                        ],
+                    });
+                }
+                if (options.url.endsWith(`/manifests/${arm64ManifestDigest}`)) {
+                    return Promise.resolve({
+                        schemaVersion: 2,
+                        mediaType: 'application/vnd.oci.image.manifest.v1+json',
+                        config: {
+                            digest: configDigest,
+                            mediaType:
+                                'application/vnd.oci.image.config.v1+json',
+                        },
+                    });
+                }
+                throw new Error(`Unexpected request to ${options.url}`);
+            });
+
+            const container = {
+                image: {
+                    id: 'image123',
+                    registry: { name: 'ghcr' },
+                    name: 'tricked-dev/kanidm-oauth2-manager',
+                    tag: { value: 'latest' },
+                    architecture: 'arm64',
+                    os: 'linux',
+                    digest: { watch: true, repo: arm64ManifestDigest },
+                },
+            };
+            registry.getState.mockReturnValue({
+                registry: { ghcr: ghcrRegistry },
+            });
+            const mockLogChild = { error: jest.fn() };
+
+            const result = await docker.findNewVersion(container, mockLogChild);
+
+            expect(result.digest).toBe(arm64ManifestDigest);
+            expect(container.image.digest.value).toBe(arm64ManifestDigest);
+            expect(container.image.digest.value).toBe(result.digest);
         });
 
         test('should handle tag candidates with semver', async () => {

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -811,14 +811,16 @@ class Docker extends Watcher {
                         );
                     container.image.digest.value = digestV2.digest;
                 } else {
-                    // Legacy v1 image => take Image digest as reference for comparison
+                    // Legacy v1 image => take Image digest as reference for comparison.
+                    // Config.Image is empty on most modern images (deprecated since
+                    // Docker moved to content-addressable image storage), so fall back
+                    // to the local image Id, which is the config digest Docker itself
+                    // uses to identify this image.
                     const image = await this.dockerApi
                         .getImage(container.image.id)
                         .inspect();
                     container.image.digest.value =
-                        image.Config.Image === ''
-                            ? undefined
-                            : image.Config.Image;
+                        image.Config.Image || image.Id;
                 }
             }
 


### PR DESCRIPTION
## Summary

`getImageManifestDigest` (`Registry.ts`) misclassifies a single-platform manifest (schemaVersion 2, not a list/index) as a legacy "version 1" response, because it reads the mediaType of the *config* blob instead of the manifest's own mediaType, then returns the config blob's digest as "the digest" for that manifest.

This exact situation happens whenever Docker.ts re-resolves a container's local `RepoDigest` and that RepoDigest already points directly at a leaf/platform manifest (rather than at the top-level manifest-list digest) — which is common, and depends on the Docker storage driver / containerd snapshotter in use. Instead of re-deriving a real, comparable manifest digest through the same HEAD + `docker-content-digest` confirmation path already used for multi-arch images, the code silently swaps in the config digest.

The result: `container.image.digest.value` (local) ends up being a **config digest**, while `result.digest` (remote) is a **manifest digest** — two different kinds of object that can never be equal — so wud reports a phantom "update available" even when the running image is already current.

### Fix
- `Registry.ts`: for a single-platform manifest response, use the reference it was already fetched by (tag or digest) and the manifest's own `mediaType`, so it flows through the existing HEAD-confirmation branch and returns a genuine, comparable manifest digest (version 2) instead of a config digest mislabeled as version 1.
- `Docker.ts`: for the (now much rarer, genuinely legacy schemaVersion-1) fallback path, use `image.Config.Image || image.Id`, since `Config.Image` is blank on virtually all modern images.

### Reproduction

Confirmed against a real-world report: `ghcr.io/tricked-dev/kanidm-oauth2-manager:latest` on an arm64 host, with `wud.watch.digest` effectively enabled by default (non-semver tag, non-Docker-Hub registry). wud reported a permanent "update available" even though the running container was already on the latest image.

I reproduced this locally with podman (pulling the same public image, amd64 build) and confirmed:
- **Before fix**: local digest resolves to the image's *config* digest (`sha256:37159e9f...`) vs. remote *manifest* digest (`sha256:a8b8c6ed...`) → reported as 1 available update.
- **After fix**: both resolve to the same manifest digest (`sha256:a8b8c6ed867c437afb990988e172958ca0ab0afd892f9d2512f38f4f891046fe`) → 0 available updates.

### Related PRs

- #1079 fixes a different, narrower branch (empty `Config.Image` falling back to `undefined` instead of `image.Id`) — that fix is folded into this PR too, but it doesn't touch the bug above, since it only affects genuinely legacy schemaVersion-1 registries.
- #1038 targets the same root cause (config digest vs. manifest digest confusion) but its fix is incomplete: it corrects the branching condition but still uses `responseManifests.config.digest` as the manifest *reference* for the confirmation request, which is not a valid manifest reference and 404s (`MANIFEST_UNKNOWN`) against a real registry (verified live against GHCR). Its accompanying test doesn't catch this because the mock asserts on the `Accept` header only, never on the requested URL/reference.

### Tests

- `Registry.test.ts`: updated the single-platform-manifest test to use realistic (distinct) config vs. manifest media types, and now asserts on the actual request URLs used, not just the returned digest. Added a test for resolving a manifest fetched directly by its own digest (the RepoDigest-as-leaf-digest case).
- `Docker.test.ts`: added a regression test reproducing the `ghcr.io/tricked-dev/kanidm-oauth2-manager` scenario end-to-end through `findNewVersion` with a real `Registry` instance (mocked HTTP layer), and a test for the `Config.Image` → `image.Id` fallback.

From `app/`:
- `npx jest` — 563/563 tests pass
- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — no new errors/warnings

## Test plan

- [x] `npm test` (from `app/`)
- [x] `npm run build`
- [x] Manual end-to-end reproduction with podman: pulled `ghcr.io/tricked-dev/kanidm-oauth2-manager:latest`, pointed wud's docker watcher at the podman socket (`WUD_WATCHER_LOCAL_SOCKET`), confirmed 1 false "available update" before the fix and 0 after, with identical manifest digests on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)