### PR TITLE
Improve Prometheus metrics CPU usage

### DIFF
--- a/app/prometheus/container.test.ts
+++ b/app/prometheus/container.test.ts
@@ -1,45 +1,73 @@
 // @ts-nocheck
 jest.mock('../store/container');
 jest.mock('../log');
+jest.mock('../event', () => ({
+    registerContainerAdded: jest.fn(),
+    registerContainerUpdated: jest.fn(),
+    registerContainerRemoved: jest.fn(),
+}));
 
 import * as store from '../store/container';
+import * as event from '../event';
 import * as container from './container';
 import log from '../log';
 
-test('gauge must be populated when containers are in the store', async () => {
-    jest.useFakeTimers();
-    store.getContainers = () => [
-        {
-            id: 'container-123456789',
-            name: 'test',
-            watcher: 'test',
-            image: {
-                id: 'image-123456789',
-                registry: {
-                    name: 'registry',
-                    url: 'https://hub',
-                },
-                name: 'organization/image',
-                tag: {
-                    value: 'version',
-                    semver: false,
-                },
-                digest: {
-                    watch: false,
-                    repo: undefined,
-                },
-                architecture: 'arch',
-                os: 'os',
-                created: '2021-06-12T05:33:38.440Z',
+const sampleContainers = [
+    {
+        id: 'container-123456789',
+        name: 'test',
+        watcher: 'test',
+        image: {
+            id: 'image-123456789',
+            registry: {
+                name: 'registry',
+                url: 'https://hub',
             },
-            result: {
-                tag: 'version',
+            name: 'organization/image',
+            tag: {
+                value: 'version',
+                semver: false,
             },
+            digest: {
+                watch: false,
+                repo: undefined,
+            },
+            architecture: 'arch',
+            os: 'os',
+            created: '2021-06-12T05:33:38.440Z',
         },
-    ];
+        result: {
+            tag: 'version',
+        },
+    },
+];
+
+beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllMocks();
+    store.getContainers = jest.fn(() => sampleContainers);
+});
+
+afterEach(() => {
+    jest.useRealTimers();
+});
+
+test('gauge must be populated on init when containers are in the store', async () => {
+    let onAdded;
+    event.registerContainerAdded.mockImplementation((handler) => {
+        onAdded = handler;
+        return jest.fn();
+    });
+    event.registerContainerUpdated.mockImplementation(() => jest.fn());
+    event.registerContainerRemoved.mockImplementation(() => jest.fn());
+
     const gauge = container.init();
     const spySet = jest.spyOn(gauge, 'set');
-    jest.runOnlyPendingTimers();
+    spySet.mockClear();
+
+    onAdded(sampleContainers[0]);
+    jest.advanceTimersByTime(5000);
+
     expect(spySet).toHaveBeenCalledWith(
         {
             id: 'container-123456789',
@@ -63,12 +91,51 @@ test('gauge must be populated when containers are in the store', async () => {
 });
 
 test("gauge must warn when data don't match expected labels", async () => {
-    store.getContainers = () => [
+    event.registerContainerAdded.mockImplementation(() => jest.fn());
+    event.registerContainerUpdated.mockImplementation(() => jest.fn());
+    event.registerContainerRemoved.mockImplementation(() => jest.fn());
+    store.getContainers = jest.fn(() => [
         {
             extra: 'extra',
         },
-    ];
+    ]);
     const spyLog = jest.spyOn(log, 'warn');
     container.init();
     expect(spyLog).toHaveBeenCalled();
+});
+
+test('interval tick should skip full rebuild when metrics are clean', async () => {
+    event.registerContainerAdded.mockImplementation(() => jest.fn());
+    event.registerContainerUpdated.mockImplementation(() => jest.fn());
+    event.registerContainerRemoved.mockImplementation(() => jest.fn());
+
+    const gauge = container.init();
+    const spyReset = jest.spyOn(gauge, 'reset');
+    const spySet = jest.spyOn(gauge, 'set');
+
+    spyReset.mockClear();
+    spySet.mockClear();
+    jest.advanceTimersByTime(5000);
+
+    expect(spyReset).not.toHaveBeenCalled();
+    expect(spySet).not.toHaveBeenCalled();
+});
+
+test('container event should mark metrics dirty and rebuild on next interval', async () => {
+    let onAdded;
+    event.registerContainerAdded.mockImplementation((handler) => {
+        onAdded = handler;
+        return jest.fn();
+    });
+    event.registerContainerUpdated.mockImplementation(() => jest.fn());
+    event.registerContainerRemoved.mockImplementation(() => jest.fn());
+
+    const gauge = container.init();
+    const spySet = jest.spyOn(gauge, 'set');
+    spySet.mockClear();
+
+    onAdded(sampleContainers[0]);
+    jest.advanceTimersByTime(5000);
+
+    expect(spySet).toHaveBeenCalledTimes(1);
 });

--- a/app/prometheus/container.ts
+++ b/app/prometheus/container.ts
@@ -1,15 +1,24 @@
-// @ts-nocheck
 import { Gauge, register } from 'prom-client';
 import * as storeContainer from '../store/container';
 import log from '../log';
 import { flatten } from '../model/container';
+import {
+    registerContainerAdded,
+    registerContainerUpdated,
+    registerContainerRemoved,
+} from '../event';
 
 let gaugeContainer;
+let metricsDirty = true;
 
 /**
  * Populate gauge.
  */
 function populateGauge() {
+    if (!metricsDirty) {
+        return;
+    }
+
     gaugeContainer.reset();
     storeContainer.getContainers().forEach((container) => {
         try {
@@ -28,11 +37,11 @@ function populateGauge() {
             log.debug(e);
         }
     });
+    metricsDirty = false;
 }
 
 /**
  * Init Container prometheus gauge.
- * @returns {Gauge<string>}
  */
 export function init() {
     // Replace gauge if init is called more than once
@@ -83,6 +92,16 @@ export function init() {
         ],
     });
     log.debug('Start container metrics interval');
+    metricsDirty = true;
+    registerContainerAdded(() => {
+        metricsDirty = true;
+    });
+    registerContainerUpdated(() => {
+        metricsDirty = true;
+    });
+    registerContainerRemoved(() => {
+        metricsDirty = true;
+    });
     setInterval(populateGauge, 5000);
     populateGauge();
     return gaugeContainer;


### PR DESCRIPTION
Reduce CPU usage when Prometheus metrics are enabled by avoiding unnecessary container metric rebuilds.

Track whether container metrics are dirty by listening to the containers add, update, and remove events.
When no events are processed, skip processing all containers again.