### PR TITLE
Add support for GitLab group access tokens in the GitLab registry provider.

### DIFF
--- a/app/registries/providers/gitlab/Gitlab.test.ts
+++ b/app/registries/providers/gitlab/Gitlab.test.ts
@@ -6,6 +6,7 @@ const gitlab = new Gitlab();
 gitlab.configuration = {
     url: 'https://registry.gitlab.com',
     authurl: 'https://gitlab.com',
+    username: '',
     token: 'abcdef',
 };
 
@@ -19,6 +20,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
     ).toStrictEqual({
         url: 'https://registry.gitlab.com',
         authurl: 'https://gitlab.com',
+        username: '',
         token: 'abcdef',
     });
     expect(
@@ -30,6 +32,18 @@ test('validatedConfiguration should initialize when configuration is valid', asy
     ).toStrictEqual({
         url: 'https://registry.custom.com',
         authurl: 'https://custom.com',
+        username: '',
+        token: 'abcdef',
+    });
+    expect(
+        gitlab.validateConfiguration({
+            username: 'custom-user',
+            token: 'abcdef',
+        }),
+    ).toStrictEqual({
+        url: 'https://registry.gitlab.com',
+        authurl: 'https://gitlab.com',
+        username: 'custom-user',
         token: 'abcdef',
     });
 });
@@ -44,6 +58,7 @@ test('maskConfiguration should mask configuration secrets', async () => {
     expect(gitlab.maskConfiguration()).toEqual({
         url: 'https://registry.gitlab.com',
         authurl: 'https://gitlab.com',
+        username: '',
         token: 'a****f',
     });
 });
@@ -90,6 +105,39 @@ test('authenticate should perform authenticate request', async () => {
     ).resolves.toEqual({ headers: { Authorization: 'Bearer token' } });
 });
 
+test('authenticate should use custom username when configured', async () => {
+    const gitlabCustom = new Gitlab();
+    gitlabCustom.configuration = {
+        url: 'https://registry.gitlab.com',
+        authurl: 'https://gitlab.com',
+        username: 'custom-user',
+        token: 'abcdef',
+    };
+    axios.mockClear();
+    axios.mockImplementation(() => ({
+        data: {
+            token: 'token',
+        },
+    }));
+
+    await expect(
+        gitlabCustom.authenticate(
+            { name: 'test/image' },
+            {
+                headers: {},
+            },
+        ),
+    ).resolves.toEqual({ headers: { Authorization: 'Bearer token' } });
+    expect(axios).toHaveBeenCalledWith({
+        method: 'GET',
+        url: 'https://gitlab.com/jwt/auth?service=container_registry&scope=repository:test/image:pull',
+        headers: {
+            Accept: 'application/json',
+            Authorization: `Basic ${Gitlab.base64Encode('custom-user', 'abcdef')}`,
+        },
+    });
+});
+
 test('normalizeImage should return the proper registry v2 endpoint', async () => {
     expect(
         gitlab.normalizeImage({
@@ -110,5 +158,18 @@ test('getAuthPull should return pam', async () => {
     await expect(gitlab.getAuthPull()).resolves.toEqual({
         username: '',
         password: gitlab.configuration.token,
+    });
+});
+
+test('getAuthPull should return custom username', async () => {
+    const gitlabCustom = new Gitlab();
+    gitlabCustom.configuration = {
+        username: 'custom-user',
+        token: 'abcdef',
+    };
+
+    await expect(gitlabCustom.getAuthPull()).resolves.toEqual({
+        username: 'custom-user',
+        password: 'abcdef',
     });
 });

--- a/app/registries/providers/gitlab/Gitlab.ts
+++ b/app/registries/providers/gitlab/Gitlab.ts
@@ -1,6 +1,6 @@
-// @ts-nocheck
-import axios from 'axios';
+import axios, { AxiosRequestConfig } from 'axios';
 import Registry from '../../Registry';
+import { ContainerImage } from '../../../model/container';
 
 /**
  * Docker Gitlab integration.
@@ -8,19 +8,18 @@ import Registry from '../../Registry';
 class Gitlab extends Registry {
     /**
      * Get the Gitlab configuration schema.
-     * @returns {*}
      */
     getConfigurationSchema() {
         return this.joi.object().keys({
             url: this.joi.string().uri().default('https://registry.gitlab.com'),
             authurl: this.joi.string().uri().default('https://gitlab.com'),
+            username: this.joi.string().optional().default(''),
             token: this.joi.string().required(),
         });
     }
 
     /**
      * Sanitize sensitive data
-     * @returns {*}
      */
     maskConfiguration() {
         return {
@@ -34,7 +33,6 @@ class Gitlab extends Registry {
     /**
      * Return true if image has no registry url.
      * @param image the image
-     * @returns {boolean}
      */
     match(image) {
         return this.configuration.url.indexOf(image.registry.url) !== -1;
@@ -43,10 +41,9 @@ class Gitlab extends Registry {
     /**
      * Normalize images according to Gitlab characteristics.
      * @param image
-     * @returns {*}
      */
 
-    normalizeImage(image) {
+    normalizeImage(image: ContainerImage) {
         const imageNormalized = image;
         if (!imageNormalized.registry.url.startsWith('https://')) {
             imageNormalized.registry.url = `https://${imageNormalized.registry.url}/v2`;
@@ -56,17 +53,17 @@ class Gitlab extends Registry {
 
     /**
      * Authenticate to Gitlab.
-     * @param image
-     * @param requestOptions
-     * @returns {Promise<*>}
      */
-    async authenticate(image, requestOptions) {
+    async authenticate(
+        image: ContainerImage,
+        requestOptions: AxiosRequestConfig,
+    ) {
         const request = {
             method: 'GET',
             url: `${this.configuration.authurl}/jwt/auth?service=container_registry&scope=repository:${image.name}:pull`,
             headers: {
                 Accept: 'application/json',
-                Authorization: `Basic ${Gitlab.base64Encode('', this.configuration.token)}`,
+                Authorization: `Basic ${Gitlab.base64Encode(this.configuration.username, this.configuration.token)}`,
             },
         };
         const response = await axios(request);
@@ -77,11 +74,10 @@ class Gitlab extends Registry {
 
     /**
      * Return empty username and personal access token value.
-     * @returns {{password: (string|undefined|*), username: string}}
      */
     async getAuthPull() {
         return {
-            username: '',
+            username: this.configuration.username,
             password: this.configuration.token,
         };
     }

--- a/docs/configuration/registries/gitlab/README.md
+++ b/docs/configuration/registries/gitlab/README.md
@@ -1,43 +1,52 @@
 # GHCR (Gitlab Container Registry)
+
 ![logo](gitlab.png)
 
 The `gitlab` registry lets you configure [GITLAB](https://docs.gitlab.com/ee/user/packages/container_registry/) integration.
 
 ### Variables
 
-| Env var                                       |   Required   | Description                    | Supported values                         | Default value when missing  |
-|-----------------------------------------------|:------------:|--------------------------------| ---------------------------------------- |-----------------------------| 
-| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_AUTHURL` | :red_circle: | Gitlab Authentication base url |                                          | https://gitlab.com          |
-| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_TOKEN`   | :red_circle: | Gitlab Personal Access Token   |                                          |                             |
-| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_URL`     | :red_circle: | Gitlab Registry base url       |                                          | https://registry.gitlab.com |
+| Env var                                        |    Required    | Description                                         | Supported values | Default value when missing  |
+| ---------------------------------------------- | :------------: | --------------------------------------------------- | ---------------- | --------------------------- |
+| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_AUTHURL`  |  :red_circle:  | Gitlab Authentication base url                      |                  | https://gitlab.com          |
+| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_TOKEN`    |  :red_circle:  | Gitlab Personal Access Token                        |                  |                             |
+| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_USERNAME` | :white_circle: | Username to be used when using a group access token |                  |                             |
+| `WUD_REGISTRY_GITLAB_{REGISTRY_NAME}_URL`      |  :red_circle:  | Gitlab Registry base url                            |                  | https://registry.gitlab.com |
 
 ### Examples
 
 #### Configure to access images from gitlab.com
 
 <!-- tabs:start -->
+
 #### **Docker Compose**
+
 ```yaml
 services:
   whatsupdocker:
     image: getwud/wud
     ...
     environment:
-      - WUD_REGISTRY_GITLAB_PUBLIC_TOKEN=xxxxx 
+      - WUD_REGISTRY_GITLAB_PUBLIC_TOKEN=xxxxx
 ```
+
 #### **Docker**
+
 ```bash
 docker run \
   -e WUD_REGISTRY_GITLAB_PUBLIC_TOKEN="xxxxx" \
   ...
   getwud/wud
 ```
+
 <!-- tabs:end -->
 
 #### Configure to access images from self hosted gitlab instance
 
 <!-- tabs:start -->
+
 #### **Docker Compose**
+
 ```yaml
 services:
   whatsupdocker:
@@ -46,9 +55,11 @@ services:
     environment:
       - WUD_REGISTRY_GITLAB_PRIVATE_URL=https://registry.mygitlab.acme.com
       - WUD_REGISTRY_GITLAB_PRIVATE_AUTHURL=https://mygitlab.acme.com
-      - WUD_REGISTRY_GITLAB_PRIVATE_TOKEN=xxxxx 
+      - WUD_REGISTRY_GITLAB_PRIVATE_TOKEN=xxxxx
 ```
+
 #### **Docker**
+
 ```bash
 docker run \
   -e WUD_REGISTRY_GITLAB_PRIVATE_URL="https://registry.mygitlab.acme.com"
@@ -57,15 +68,20 @@ docker run \
   ...
   getwud/wud
 ```
+
 <!-- tabs:end -->
 
 ### How to create a Gitlab Personal Access Token
+
 #### Go to your Gitlab settings and open the Personal Access Token page
+
 [Click here](https://gitlab.com/-/profile/personal_access_tokens)
 
 #### Enter the details of the token to be created
+
 Choose an expiration time & appropriate scopes (`read_registry` is only needed for wud) and generate.
 ![image](gitlab_01.png)
 
 #### Copy the token & use it as the WUD_REGISTRY_GITLAB_TOKEN value
+
 ![image](gitlab_02.png)


### PR DESCRIPTION
Add support for GitLab group access tokens

Support is added by allowing a configurable username. It defaults to an empty string, preserving the existing behavior:
`WUD_REGISTRY_GITLAB_<NAME>_USERNAME=<group-token-username>`

I have not been able to test this, and GitLab’s documentation is not completely clear on this authentication flow. However, this should enable group access tokens and address #1072. Since the username remains optional, existing configurations should continue to work unchanged.

* #1072