### PR TITLE
Improve OIDC discovery

### DIFF
--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -14,6 +14,7 @@ const configurationValid = {
     discovery: 'https://idp/.well-known/openid-configuration',
     redirect: false,
     timeout: 5000,
+    ttl: 60,
     usernameclaim: 'email',
 };
 
@@ -31,6 +32,7 @@ beforeEach(async () => {
     oidc.configuration = configurationValid;
     // Access private config property for testing
     (oidc as any).config = mockConfig;
+    (oidc as any).discoveryCachedAt = Date.now();
 });
 
 test('validateConfiguration should return validated configuration when valid', async () => {
@@ -58,6 +60,7 @@ test('maskConfiguration should mask configuration secrets', async () => {
         discovery: 'https://idp/.well-known/openid-configuration',
         redirect: false,
         timeout: 5000,
+        ttl: 60,
         usernameclaim: 'email',
     });
 });
@@ -71,6 +74,65 @@ test('getStrategyDescription should return strategy description', async () => {
         redirect: false,
         logoutUrl: 'https://idp/logout',
     });
+});
+
+test('initAuthentication should not throw when discovery fails', async () => {
+    (oidc as any).config = undefined;
+    (client.discovery as jest.Mock).mockRejectedValue(
+        new Error('Authority unavailable'),
+    );
+    oidc.log = { debug: jest.fn(), warn: jest.fn() };
+
+    await expect(oidc.initAuthentication()).resolves.toBeUndefined();
+    expect(client.discovery).toHaveBeenCalledTimes(1);
+});
+
+test('getUserFromAccessToken should retry discovery after initial failure', async () => {
+    (oidc as any).config = undefined;
+    (client.discovery as jest.Mock)
+        .mockRejectedValueOnce(new Error('Authority unavailable'))
+        .mockResolvedValueOnce(mockConfig);
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'retry@example.com',
+    });
+    oidc.log = { debug: jest.fn(), warn: jest.fn() };
+
+    await oidc.initAuthentication();
+    const user = await oidc.getUserFromAccessToken('token');
+
+    expect(client.discovery).toHaveBeenCalledTimes(2);
+    expect(user).toEqual({ username: 'retry@example.com' });
+});
+
+test('getUserFromAccessToken should rediscover when cache ttl expires', async () => {
+    (oidc as any).config = undefined;
+    (client.discovery as jest.Mock).mockResolvedValue(mockConfig);
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'ttl@example.com',
+    });
+
+    await oidc.initAuthentication();
+    (oidc as any).discoveryCachedAt =
+        Date.now() - configurationValid.ttl * 60_000 - 1;
+
+    const user = await oidc.getUserFromAccessToken('token');
+
+    expect(client.discovery).toHaveBeenCalledTimes(2);
+    expect(user).toEqual({ username: 'ttl@example.com' });
+});
+
+test('getUserFromAccessToken should keep discovery cache when ttl is unlimited', async () => {
+    oidc.configuration = { ...configurationValid, ttl: -1 };
+    (oidc as any).cachedConfig = mockConfig;
+    (oidc as any).discoveryCachedAt = 0;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'unlimited@example.com',
+    });
+
+    const user = await oidc.getUserFromAccessToken('token');
+
+    expect(client.discovery).not.toHaveBeenCalled();
+    expect(user).toEqual({ username: 'unlimited@example.com' });
 });
 
 test('verify should return user on valid token', async () => {

--- a/app/authentications/providers/oidc/Oidc.ts
+++ b/app/authentications/providers/oidc/Oidc.ts
@@ -28,6 +28,7 @@ class Oidc extends Authentication {
             clientsecret: this.joi.string().required(),
             redirect: this.joi.boolean().default(false),
             timeout: this.joi.number().greater(500).default(5000),
+            ttl: this.joi.number().min(-1).default(60),
             usernameclaim: this.joi.string().default('email'),
         });
     }
@@ -43,15 +44,17 @@ class Oidc extends Authentication {
         };
     }
 
-    private config: client.Configuration | undefined;
+    private cachedConfig: client.Configuration | undefined;
+    private discoveryCachedAt: number | undefined;
     private logoutUrl: string | undefined;
+    private discoveryPromise: Promise<void> | undefined;
 
-    async initAuthentication() {
+    private async discoverConfiguration() {
         this.log.debug(
             `Discovering configuration from ${this.configuration.discovery}`,
         );
 
-        this.config = await client.discovery(
+        this.cachedConfig = await client.discovery(
             new URL(this.configuration.discovery),
             this.configuration.clientid,
             this.configuration.clientsecret,
@@ -60,12 +63,81 @@ class Oidc extends Authentication {
                 timeout: this.configuration.timeout,
             },
         );
+        this.discoveryCachedAt = Date.now();
 
         try {
-            this.logoutUrl = client.buildEndSessionUrl(this.config).toString();
+            this.logoutUrl = client
+                .buildEndSessionUrl(this.cachedConfig)
+                .toString();
         } catch (e) {
             this.log.warn(` End session url is not supported (${e.message})`);
         }
+    }
+
+    private isDiscoveryCacheValid() {
+        if (!this.cachedConfig || this.discoveryCachedAt === undefined) {
+            return false;
+        }
+
+        if (this.configuration.ttl === -1) {
+            return true;
+        }
+
+        return (
+            Date.now() - this.discoveryCachedAt <
+            this.configuration.ttl * 60_000
+        );
+    }
+
+    private async ensureDiscovered(): Promise<client.Configuration>;
+    private async ensureDiscovered(
+        throwOnError: true,
+    ): Promise<client.Configuration>;
+    private async ensureDiscovered(
+        throwOnError: false,
+    ): Promise<client.Configuration | undefined>;
+    private async ensureDiscovered(
+        throwOnError = true,
+    ): Promise<client.Configuration | undefined> {
+        if (this.isDiscoveryCacheValid()) {
+            return this.cachedConfig;
+        }
+
+        if (this.cachedConfig) {
+            this.log.debug(
+                `OIDC discovery cache expired after ${this.configuration.ttl} minute(s) => refresh configuration`,
+            );
+            this.cachedConfig = undefined;
+            this.discoveryCachedAt = undefined;
+            this.logoutUrl = undefined;
+        }
+
+        if (!this.discoveryPromise) {
+            this.discoveryPromise = this.discoverConfiguration().finally(() => {
+                this.discoveryPromise = undefined;
+            });
+        }
+
+        try {
+            await this.discoveryPromise;
+        } catch (e) {
+            if (throwOnError) {
+                throw e;
+            }
+            this.log.warn(
+                `Unable to discover OIDC authority (${(e as Error).message})`,
+            );
+            return undefined;
+        }
+
+        if (!this.cachedConfig && throwOnError) {
+            throw new Error('OIDC configuration is not available');
+        }
+        return this.cachedConfig;
+    }
+
+    async initAuthentication() {
+        await this.ensureDiscovered(false);
     }
 
     /**
@@ -81,7 +153,7 @@ class Oidc extends Authentication {
         );
         const strategy = new OidcStrategy(
             {
-                config: this.config,
+                config: this.cachedConfig,
                 params: {
                     scope: 'openid email profile',
                 },
@@ -103,6 +175,7 @@ class Oidc extends Authentication {
     }
 
     async redirect(req: Request, res: Response) {
+        const config = await this.ensureDiscovered();
         const codeVerifier = client.randomPKCECodeVerifier();
         const codeChallenge =
             await client.calculatePKCECodeChallenge(codeVerifier);
@@ -121,7 +194,7 @@ class Oidc extends Authentication {
             state,
         };
 
-        const authUrl = client.buildAuthorizationUrl(this.config, parameters);
+        const authUrl = client.buildAuthorizationUrl(config, parameters);
         this.log.debug(`Build redirection url [${authUrl}]`);
         res.json({
             url: authUrl,
@@ -130,6 +203,7 @@ class Oidc extends Authentication {
 
     async callback(req: Request, res: Response) {
         try {
+            const config = await this.ensureDiscovered();
             this.log.debug('Validate callback data');
 
             const oidcChecks = req.session.oidc;
@@ -148,7 +222,7 @@ class Oidc extends Authentication {
             };
 
             const tokenSet = await client.authorizationCodeGrant(
-                this.config,
+                config,
                 currentUrl,
                 check,
             );
@@ -193,8 +267,9 @@ class Oidc extends Authentication {
     }
 
     async getUserFromAccessToken(accessToken: string, claim?: client.IDToken) {
+        const config = await this.ensureDiscovered();
         const userInfo = await client.fetchUserInfo(
-            this.config,
+            config,
             accessToken,
             claim?.sub,
         );

--- a/docs/configuration/authentications/oidc/README.md
+++ b/docs/configuration/authentications/oidc/README.md
@@ -13,6 +13,7 @@ The `oidc` authentication lets you protect WUD access using the [Openid Connect 
 | `WUD_AUTH_OIDC_{auth_name}_DISCOVERY`     |  :red_circle:  | Oidc discovery URL                                                     |                  |                            |
 | `WUD_AUTH_OIDC_{auth_name}_REDIRECT`      | :white_circle: | Skip internal login page & automatically redirect to the OIDC provider | `true`, `false`  | `false`                    |
 | `WUD_AUTH_OIDC_{auth_name}_TIMEOUT`       | :white_circle: | Timeout (in ms) when calling the OIDC provider                         | Minimum is 500   | `5000`                     |
+| `WUD_AUTH_OIDC_{auth_name}_TTL`           | :white_circle: | Cache TTL (in minutes) for OIDC discovery metadata; use `-1` for unlimited validity | `-1` or minimum is 0 | `60` (1 hour)              |
 | `WUD_AUTH_OIDC_{auth_name}_USERNAMECLAIM` | :white_circle: | The user claim to use as the username                                  |                  | `email`                    |
 
 ?> The callback URL (to configure in the IDP is built as `${wud_public_url}/auth/oidc/${auth_name}/cb`


### PR DESCRIPTION
This makes OIDC authentication more resilient by allowing WUD to start even when the OIDC authority is temporarily unavailable. 
Discovery metadata is now loaded lazily, retried when needed, and cached for a configurable period instead of being fetched only once at startup. 
The new TTL setting defaults to one hour, while TTL=-1 keeps the discovery metadata cached indefinitely.

- Prevent WUD startup failure when the OIDC authority is temporarily unavailable.
- Add lazy OIDC discovery with automatic retry on subsequent requests.
- Cache OIDC discovery metadata with a configurable TTL.
  - -1 for unlimited validity
  - 0 for no caching
  - \> 0 in minutes 
- Refresh cached discovery metadata when the TTL expires.

Added tests and updated documentation

Should fix 
* #424 
* #1039
