### PR TITLE
Prevent the up-to-date status label from overflowing its card

### DIFF
--- a/ui/src/views/HomeView.vue
+++ b/ui/src/views/HomeView.vue
@@ -12,6 +12,7 @@
           >
           <br />
           <v-btn
+            class="update-status"
             size="small"
             variant="plain"
             :color="containersToUpdateCount > 0 ? 'warning' : 'success'"
@@ -59,11 +60,29 @@
 
 <script lang="ts" src="./HomeView.ts"></script>
 <style scoped>
+/* height: 100% makes each card fill its column. Since v-row stretches
+   columns to match the tallest one, all four cards end up the same
+   height as whichever card needs the most room. */
 .home-card {
-  height: 160px;
+  height: 100%;
+  min-height: 160px;
 }
 
 .home-icon {
   font-size: 80px;
+}
+
+/* Let the status label wrap instead of overflowing the card.
+   Vuetify sets white-space: nowrap on .v-btn__content and a fixed
+   height on .v-btn, so both have to be relaxed. */
+.update-status {
+  height: auto;
+  min-height: 28px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+}
+
+.update-status :deep(.v-btn__content) {
+  white-space: normal;
 }
 </style>


### PR DESCRIPTION
At screen widths at or above 1280, the container card's status button uses Vuetify's default white-space: nowrap plus a fixed button height, so the longer "all containers are up-to-date" label was clipped by the card.

<img width="3840" height="2622" alt="uncorrected" src="https://github.com/user-attachments/assets/2ad133fe-f029-4984-b198-c7c885680af1" />

Allow that one label to wrap, let the button grow to fit, and make the home cards fill their column so all four are equal height with 100%. It actually needs 170, but 100% is more future-proof. 

<img width="3840" height="2622" alt="corrected" src="https://github.com/user-attachments/assets/0535f40a-3f00-4c4e-9df3-a702de7cb6e8" />

Fixes #760
Fixes #851
Fixes #571