### PR TITLE
chore(e2e): resolve expected tags/digests from the registries at runtime; migrate the harness to TypeScript

### DIFF
--- a/e2e/.eslintrc
+++ b/e2e/.eslintrc
@@ -1,7 +1,16 @@
 {
     "extends": "airbnb-base",
-    "plugins": ["cucumber"],
+    "parser": "@typescript-eslint/parser",
+    "plugins": ["cucumber", "@typescript-eslint"],
+    "settings": {
+        "import/resolver": {
+            "typescript": {}
+        }
+    },
     "rules": {
-        "indent": ["error", 4]
+        "indent": ["error", 4],
+        "import/extensions": ["error", "ignorePackages", { "ts": "never" }],
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": "error"
     }
 }

--- a/e2e/config/index.ts
+++ b/e2e/config/index.ts
@@ -1,4 +1,4 @@
-module.exports = {
+export default {
     protocol: process.env.WUD_PROTOCOL || 'http',
     host: process.env.WUD_HOST || 'localhost',
     port: process.env.WUD_PORT || 3000,

--- a/e2e/features/api-container.feature
+++ b/e2e/features/api-container.feature
@@ -9,6 +9,7 @@ Feature: WUD Container API Exposure
   # Test one representative container per registry type + update pattern
   Scenario Outline: WUD must handle different registry types and update patterns
     When I GET /api/containers
+    And I resolve the latest version for image "<imageName>" on registry "<registry>" with strategy "<strategy>" and pattern "<pattern>" and value "<resultTag>" as "EXPECTED_TAG"
     Then response code should be 200
     And response body should be valid json
     And response body path $[<index>].name should be <containerName>
@@ -17,26 +18,27 @@ Feature: WUD Container API Exposure
     And response body path $[<index>].image.registry.url should be <registryUrl>
     And response body path $[<index>].image.name should be <imageName>
     And response body path $[<index>].image.tag.value should be <tag>
-    And response body path $[<index>].result.tag should be <resultTag>
+    And response body path $[<index>].result.tag should equal variable "EXPECTED_TAG"
     And response body path $[<index>].updateAvailable should be <updateAvailable>
     Examples:
-      | index | registry       | containerName            | registryUrl                                             | imageName                           | tag                | resultTag          | updateAvailable | testCase                    |
+      | index | registry       | containerName            | registryUrl                                             | imageName                    | tag               | resultTag | updateAvailable | strategy | pattern                    | testCase                      |
       # Containers in alphabetical order by name
-      # | 0     | ecr.private    | ecr_sub_sub_test         | https://229211676173.dkr.ecr.eu-west-1.amazonaws.com/v2 | sub/sub/test                        | 1.0.0              | 2.0.0              | true            | ECR semver major update     |
-      | 1     | ghcr.private   | ghcr_radarr              | https://ghcr.io/v2                                      | linuxserver/radarr                  | 5.14.0.9383-ls245  | 6.3.0.10514-ls311  | true           | GHCR complex semver update  |
-      | 2     | gitlab.private | gitlab_test              | https://registry.gitlab.com/v2                          | gitlab-org/gitlab-runner            | v16.0.0            | v16.1.0            | true            | GitLab semver update        |
-      | 3     | hub.public     | hub_homeassistant_202161 | https://registry-1.docker.io/v2                         | homeassistant/home-assistant        | 2021.6.1           | 2026.7.2           | true           | Hub date-based versioning   |
-      | 4     | hub.public     | hub_homeassistant_latest | https://registry-1.docker.io/v2                         | homeassistant/home-assistant        | latest             | latest             | false           | Hub latest tag no update    |
-      | 5     | hub.public     | hub_nginx_120            | https://registry-1.docker.io/v2                         | library/nginx                       | 1.20-alpine        | 1.31-alpine        | true           | Hub alpine minor update     |
-      | 6     | hub.public     | hub_nginx_latest         | https://registry-1.docker.io/v2                         | library/nginx                       | latest             | latest             | true            | Hub latest tag digest update|
-      | 7     | hub.public     | hub_traefik_245          | https://registry-1.docker.io/v2                         | library/traefik                     | 2.4.5              | 3.7.8              | true           | Hub semver major update     |
-      | 8     | lscr.private   | lscr_radarr              | https://lscr.io/v2                                      | linuxserver/radarr                  | 5.14.0.9383-ls245  | 6.3.0.10514-ls311  | true            | LSCR complex semver update  |
-      | 9     | quay.public    | quay_prometheus          | https://quay.io/v2                                      | prometheus/prometheus               | v2.52.0            | v3.13.1             | true            | Quay semver major update    |
+      # | 0     | ecr.private    | ecr_sub_sub_test         | https://229211676173.dkr.ecr.eu-west-1.amazonaws.com/v2 | sub/sub/test                 | 1.0.0             | 2.0.0     | true            | static   | .*                         | ECR semver major update       |
+      | 1     | ghcr.private   | ghcr_radarr              | https://ghcr.io/v2                                      | linuxserver/radarr           | 5.14.0.9383-ls245 | ignored   | true            | dynamic  | ^\d+\.\d+\.\d+\.\d+-ls\d+$ | GHCR complex semver update    |
+      | 2     | gitlab.private | gitlab_test              | https://registry.gitlab.com/v2                          | gitlab-org/gitlab-runner     | v16.0.0           | ignored   | true            | dynamic  | ^v16\.[01]\.0$             | GitLab semver update          |
+      | 3     | hub.public     | hub_homeassistant_202161 | https://registry-1.docker.io/v2                         | homeassistant/home-assistant | 2021.6.1          | ignored   | true            | dynamic  | ^\d+\.\d+\.\d+$            | Hub date-based versioning     |
+      | 4     | hub.public     | hub_homeassistant_latest | https://registry-1.docker.io/v2                         | homeassistant/home-assistant | latest            | latest    | false           | static   | .*                         | Hub latest tag no update      |
+      | 5     | hub.public     | hub_nginx_120            | https://registry-1.docker.io/v2                         | library/nginx                | 1.20-alpine       | ignored   | true            | dynamic  | ^\d+\.\d+-alpine$          | Hub alpine minor update       |
+      | 6     | hub.public     | hub_nginx_latest         | https://registry-1.docker.io/v2                         | library/nginx                | latest            | latest    | true            | static   | .*                         | Hub latest tag digest update  |
+      | 7     | hub.public     | hub_traefik_245          | https://registry-1.docker.io/v2                         | library/traefik              | 2.4.5             | ignored   | true            | dynamic  | ^\d+\.\d+\.\d+$            | Hub semver major update       |
+      | 8     | lscr.private   | lscr_radarr              | https://lscr.io/v2                                      | linuxserver/radarr           | 5.14.0.9383-ls245 | ignored   | true            | dynamic  | ^\d+\.\d+\.\d+\.\d+-ls\d+$ | LSCR complex semver update    |
+      | 9     | quay.public    | quay_prometheus          | https://quay.io/v2                                      | prometheus/prometheus        | v2.52.0           | ignored   | true            | dynamic  | ^v\d+\.\d+\.\d+$           | Quay semver major update      |
 
   # Test detailed container inspection (semver)
   Scenario: WUD must provide detailed container information for semver containers
     Given I GET /api/containers
     And I store the value of body path $[2].id as containerId in scenario scope
+    And I resolve the latest version for image "gitlab-org/gitlab-runner" on registry "gitlab.private" with strategy "dynamic" and pattern "^v16\.[01]\.0$" and value "" as "EXPECTED_TAG"
     When I GET /api/containers/`containerId`
     Then response code should be 200
     And response body should be valid json
@@ -44,38 +46,43 @@ Feature: WUD Container API Exposure
     And response body path $.name should be gitlab_test
     And response body path $.image.registry.name should be gitlab.private
     And response body path $.image.tag.semver should be true
-    And response body path $.result.tag should be v16.1.0
+    And response body path $.result.tag should equal variable "EXPECTED_TAG"
     And response body path $.updateAvailable should be true
 
   # Test detailed container inspection (digest)
   Scenario: WUD must provide detailed container information for digest-based containers
     Given I GET /api/containers
     And I store the value of body path $[6].id as containerId in scenario scope
+    And I get the latest digest for image "library/nginx" on registry "hub.public" with tag "latest" and store it in "EXPECTED_DIGEST"
     When I GET /api/containers/`containerId`
     Then response code should be 200
     And response body should be valid json
     And response body path $.watcher should be local
     And response body path $.name should be hub_nginx_latest
     And response body path $.image.tag.semver should be false
+    # Immutable digest of nginx:1.10-alpine (single amd64 manifest, tagged locally as latest)
     And response body path $.image.digest.value should be sha256:4aacdcf186934dcb02f642579314075910f1855590fd3039d8fa4c9f96e48315
-    And response body path $.result.digest should be sha256:db4f612f385437d11eb26620a4f1d7efb3ff44e1296a3c21540b30454e6e2bf3
+    And response body path $.result.digest should equal variable "EXPECTED_DIGEST"
     And response body path $.updateAvailable should be true
 
   # Test link functionality
   Scenario: WUD must generate correct links for containers with link templates
     Given I GET /api/containers
     And I store the value of body path $[3].id as containerId in scenario scope
+    And I resolve the latest version for image "homeassistant/home-assistant" on registry "hub.public" with strategy "dynamic" and pattern "^\d+\.\d+\.\d+$" and value "" as "EXPECTED_TAG"
+    And I set variable "EXPECTED_LINK" to "https://github.com/home-assistant/core/releases/tag/`EXPECTED_TAG`"
     When I GET /api/containers/`containerId`
     Then response code should be 200
     And response body should be valid json
     And response body path $.link should be https://github.com/home-assistant/core/releases/tag/2021.6.1
-    And response body path $.result.link should be https://github.com/home-assistant/core/releases/tag/2026.7.2
+    And response body path $.result.link should equal variable "EXPECTED_LINK"
 
   # Test watch trigger functionality
   Scenario: WUD must allow triggering container watch
     Given I GET /api/containers
     And I store the value of body path $[2].id as containerId in scenario scope
+    And I resolve the latest version for image "gitlab-org/gitlab-runner" on registry "gitlab.private" with strategy "dynamic" and pattern "^v16\.[01]\.0$" and value "" as "EXPECTED_TAG"
     When I POST to /api/containers/`containerId`/watch
     Then response code should be 200
     And response body should be valid json
-    And response body path $.result.tag should be v16.1.0
+    And response body path $.result.tag should equal variable "EXPECTED_TAG"

--- a/e2e/features/prometheus.feature
+++ b/e2e/features/prometheus.feature
@@ -12,23 +12,23 @@ Feature: Prometheus exposure
 
   Scenario Outline: WUD must expose watched containers
     When I GET /metrics
+    And I resolve the latest version for image "<imageName>" on registry "<registry>" with strategy "<strategy>" and pattern "<pattern>" and value "<resultTag>" as "EXPECTED_TAG"
     Then response code should be 200
     And response body should contain name="<containerName>"
     And response body should contain image_registry_name="<registry>"
     And response body should contain image_registry_url="<registryUrl>"
     And response body should contain image_name="<imageName>"
     And response body should contain image_tag_value="<tag>"
-    And response body should contain result_tag="<resultTag>"
+    And response body should have substituted "result_tag=\"`EXPECTED_TAG`\""
     And response body should contain update_available="<updateAvailable>"
     Examples:
-      | containerName            | registry       | registryUrl                                             | imageName                           | tag                | resultTag          | updateAvailable |
-      # | ecr_sub_sub_test         | ecr.private    | https://229211676173.dkr.ecr.eu-west-1.amazonaws.com/v2 | sub/sub/test                        | 1.0.0              | 2.0.0              | true            |
-      | ghcr_radarr              | ghcr.private   | https://ghcr.io/v2                                      | linuxserver/radarr                  | 5.14.0.9383-ls245  | 6.3.0.10514-ls311  | false           |
-
-      | hub_homeassistant_202161 | hub.public     | https://registry-1.docker.io/v2                         | homeassistant/home-assistant        | 2021.6.1           | 2026.7.2           | false           |
-      | hub_homeassistant_latest | hub.public     | https://registry-1.docker.io/v2                         | homeassistant/home-assistant        | latest             | latest             | false           |
-      | hub_nginx_120            | hub.public     | https://registry-1.docker.io/v2                         | library/nginx                       | 1.20-alpine        | 1.31-alpine        | false           |
-      | hub_nginx_latest         | hub.public     | https://registry-1.docker.io/v2                         | library/nginx                       | latest             | latest             | true            |
-      | hub_traefik_245          | hub.public     | https://registry-1.docker.io/v2                         | library/traefik                     | 2.4.5              | 3.7.8              | false           |
-      | lscr_radarr              | lscr.private   | https://lscr.io/v2                                      | linuxserver/radarr                  | 5.14.0.9383-ls245  | 6.3.0.10514-ls311 | true            |
-      | quay_prometheus          | quay.public    | https://quay.io/v2                                      | prometheus/prometheus               | v2.52.0            | v3.13.1             | true            |
+      | containerName            | registry       | registryUrl                                             | imageName                    | tag               | resultTag | updateAvailable | strategy | pattern                    |
+      # | ecr_sub_sub_test         | ecr.private    | https://229211676173.dkr.ecr.eu-west-1.amazonaws.com/v2 | sub/sub/test                 | 1.0.0             | 2.0.0     | true            | static   | .*                         |
+      | ghcr_radarr              | ghcr.private   | https://ghcr.io/v2                                      | linuxserver/radarr           | 5.14.0.9383-ls245 | ignored   | false           | dynamic  | ^\d+\.\d+\.\d+\.\d+-ls\d+$ |
+      | hub_homeassistant_202161 | hub.public     | https://registry-1.docker.io/v2                         | homeassistant/home-assistant | 2021.6.1          | ignored   | false           | dynamic  | ^\d+\.\d+\.\d+$            |
+      | hub_homeassistant_latest | hub.public     | https://registry-1.docker.io/v2                         | homeassistant/home-assistant | latest            | latest    | false           | static   | .*                         |
+      | hub_nginx_120            | hub.public     | https://registry-1.docker.io/v2                         | library/nginx                | 1.20-alpine       | ignored   | false           | dynamic  | ^\d+\.\d+-alpine$          |
+      | hub_nginx_latest         | hub.public     | https://registry-1.docker.io/v2                         | library/nginx                | latest            | latest    | true            | static   | .*                         |
+      | hub_traefik_245          | hub.public     | https://registry-1.docker.io/v2                         | library/traefik              | 2.4.5             | ignored   | false           | dynamic  | ^\d+\.\d+\.\d+$            |
+      | lscr_radarr              | lscr.private   | https://lscr.io/v2                                      | linuxserver/radarr           | 5.14.0.9383-ls245 | ignored   | true            | dynamic  | ^\d+\.\d+\.\d+\.\d+-ls\d+$ |
+      | quay_prometheus          | quay.public    | https://quay.io/v2                                      | prometheus/prometheus        | v2.52.0           | ignored   | true            | dynamic  | ^v\d+\.\d+\.\d+$           |

--- a/e2e/features/step_definitions/api.js
+++ b/e2e/features/step_definitions/api.js
@@ -1,1 +1,0 @@
-module.exports = require('apickli/apickli-gherkin');

--- a/e2e/features/step_definitions/api.ts
+++ b/e2e/features/step_definitions/api.ts
@@ -1,0 +1,1 @@
+import 'apickli/apickli-gherkin';

--- a/e2e/features/step_definitions/custom_steps.ts
+++ b/e2e/features/step_definitions/custom_steps.ts
@@ -1,0 +1,50 @@
+import { Given, Then } from '@cucumber/cucumber';
+import * as assert from 'assert';
+import registryOracle from '../support/registry_oracle';
+
+function substituteVariables(str: string, apickli: any): string {
+    return str.replace(/`([^`]*)`/g, (match, p1) => apickli.getGlobalVariable(p1) || match);
+}
+
+Given(/^I resolve the latest version for image "([^"]*)" on registry "([^"]*)" with strategy "([^"]*)" and pattern "([^"]*)" and value "([^"]*)" as "([^"]*)"$/, async function (this: any, imageName: string, registry: string, strategy: string, pattern: string, value: string, varName: string) {
+    let version;
+    if (strategy === 'static') {
+        version = value;
+    } else {
+        version = await registryOracle.getLatestVersion(registry, imageName, pattern);
+    }
+    this.apickli.setGlobalVariable(varName, version);
+});
+
+Given(/^I get the latest version for image "([^"]*)" on registry "([^"]*)" with pattern "([^"]*)" and store it in "([^"]*)"$/, async function (this: any, imageName: string, registry: string, pattern: string, varName: string) {
+    const version = await registryOracle.getLatestVersion(registry, imageName, pattern);
+    this.apickli.setGlobalVariable(varName, version);
+});
+
+Given(/^I get the latest digest for image "([^"]*)" on registry "([^"]*)" with tag "([^"]*)" and store it in "([^"]*)"$/, async function (this: any, imageName: string, registry: string, tag: string, varName: string) {
+    const digest = await registryOracle.getLatestDigest(registry, imageName, tag);
+    this.apickli.setGlobalVariable(varName, digest);
+});
+
+Then(/^response body path (.*) should equal variable "([^"]*)"$/, function (this: any, path: string, varName: string) {
+    const expectedValue = this.apickli.getGlobalVariable(varName);
+    const actualValue = this.apickli.evaluatePathInResponseBody(path);
+    assert.strictEqual(String(actualValue), String(expectedValue), `Expected ${expectedValue} at ${path}, but got ${actualValue}`);
+});
+
+Given(/^I set variable "([^"]*)" to "([^"]*)"$/, function (this: any, varName: string, value: string) {
+    const substitutedValue = substituteVariables(value, this.apickli);
+    this.apickli.setGlobalVariable(varName, substitutedValue);
+});
+
+Then('response body should have substituted {string}', function (this: any, expectedContent: string) {
+    const safeExpectedContent = substituteVariables(expectedContent, this.apickli);
+    const responseBody = this.apickli.getResponseObject().body;
+    assert.ok(responseBody.includes(safeExpectedContent), `Response body should contain ${safeExpectedContent}`);
+});
+
+Then(/^response body should have substituted string:$/, function (this: any, expectedString: string) {
+    const safeExpectedString = substituteVariables(expectedString, this.apickli);
+    const responseBody = this.apickli.getResponseObject().body;
+    assert.ok(responseBody.includes(safeExpectedString), `Response body should contain ${safeExpectedString}`);
+});

--- a/e2e/features/support/init.ts
+++ b/e2e/features/support/init.ts
@@ -1,10 +1,11 @@
+import { Before, setDefaultTimeout } from '@cucumber/cucumber';
+import configuration from '../../config';
+
 const apickli = require('apickli');
-const { Before, setDefaultTimeout } = require('@cucumber/cucumber');
-const configuration = require('../../config');
 
-setDefaultTimeout(20 * 1000);
+setDefaultTimeout(60 * 1000);
 
-Before(function initApickli() {
+Before(function (this: any) {
     this.apickli = new apickli.Apickli(configuration.protocol, `${configuration.host}:${configuration.port}`);
     this.apickli.addHttpBasicAuthorizationHeader(configuration.username, configuration.password);
 });

--- a/e2e/features/support/oracle_selfcheck.ts
+++ b/e2e/features/support/oracle_selfcheck.ts
@@ -1,0 +1,372 @@
+/**
+ * Self-check for the registry oracle. Stubs the https module and asserts the hardening
+ * contract: never truncate, retry the right statuses, cache per endpoint, evict failures,
+ * stay anonymous without credentials.
+ *
+ * Run manually: cd e2e && npx ts-node features/support/oracle_selfcheck.ts
+ * It monkeypatches https, so it must never be part of a real cucumber run.
+ */
+import * as assert from 'assert';
+import * as https from 'https';
+import { EventEmitter } from 'events';
+import registryOracle from './registry_oracle';
+
+interface StubResponse {
+    statusCode: number;
+    headers?: Record<string, string>;
+    body?: string;
+}
+
+interface Recorded {
+    method: string;
+    url: string;
+    headers: Record<string, any>;
+}
+
+type Router = (url: string, method: string) => StubResponse;
+
+// A TS namespace import is a getter-only view of the module, so the stubs have to be
+// installed on the underlying module object that every importer delegates to.
+const httpsModule: { get: typeof https.get; request: typeof https.request } = require('https');
+
+const realGet = httpsModule.get;
+const realRequest = httpsModule.request;
+
+let router: Router = () => ({ statusCode: 500, body: 'no route installed' });
+let recorded: Recorded[] = [];
+
+type FakeResponse = EventEmitter & {
+    statusCode: number;
+    headers: Record<string, string>;
+    setEncoding: () => void;
+    resume: () => void;
+};
+
+type FakeRequest = EventEmitter & { end: () => void };
+
+function fakeResponse(spec: StubResponse): FakeResponse {
+    const res = new EventEmitter() as FakeResponse;
+    res.statusCode = spec.statusCode;
+    res.headers = spec.headers || {};
+    res.setEncoding = () => {};
+    res.resume = () => {};
+    return res;
+}
+
+function fakeRequest(): FakeRequest {
+    const req = new EventEmitter() as FakeRequest;
+    req.end = () => {};
+    return req;
+}
+
+function dispatch(method: string, url: string, options: any, cb: (res: any) => void): FakeRequest {
+    recorded.push({ method, url, headers: (options && options.headers) || {} });
+    const spec = router(url, method);
+    const req = fakeRequest();
+    setImmediate(() => {
+        const res = fakeResponse(spec);
+        cb(res);
+        setImmediate(() => {
+            if (method !== 'HEAD' && spec.body) {
+                res.emit('data', spec.body);
+            }
+            res.emit('end');
+        });
+    });
+    return req;
+}
+
+function normalize(args: any[]): { url: string; options: any; cb: (res: any) => void } {
+    const [url, second, third] = args;
+    if (typeof second === 'function') {
+        return { url: String(url), options: {}, cb: second };
+    }
+    return { url: String(url), options: second || {}, cb: third };
+}
+
+function install(r: Router): void {
+    router = r;
+    recorded = [];
+    (httpsModule as any).get = (...args: any[]) => {
+        const { url, options, cb } = normalize(args);
+        return dispatch('GET', url, options, cb);
+    };
+    (httpsModule as any).request = (...args: any[]) => {
+        const { url, options, cb } = normalize(args);
+        return dispatch(String(options.method || 'GET').toUpperCase(), url, options, cb);
+    };
+}
+
+function restore(): void {
+    (httpsModule as any).get = realGet;
+    (httpsModule as any).request = realRequest;
+}
+
+const captured: string[] = [];
+const realConsole = { log: console.log, warn: console.warn, error: console.error };
+
+function captureConsole(): void {
+    console.log = (...a: any[]) => { captured.push(`log ${a.join(' ')}`); };
+    console.warn = (...a: any[]) => { captured.push(`warn ${a.join(' ')}`); };
+    console.error = (...a: any[]) => { captured.push(`error ${a.join(' ')}`); };
+}
+
+function releaseConsole(): void {
+    console.log = realConsole.log;
+    console.warn = realConsole.warn;
+    console.error = realConsole.error;
+}
+
+function warnings(): string[] {
+    return captured.filter((line) => line.startsWith('warn'));
+}
+
+function countRequests(fragment: string): number {
+    return recorded.filter((r) => r.url.includes(fragment)).length;
+}
+
+const TOKEN_OK: StubResponse = { statusCode: 200, body: JSON.stringify({ token: 'stub-token' }) };
+
+function tagsPage(tags: string[], next?: string): StubResponse {
+    return {
+        statusCode: 200,
+        headers: next ? { link: `<${next}>; rel="next"` } : {},
+        body: JSON.stringify({ tags }),
+    };
+}
+
+class ExpectationError extends Error {}
+
+async function expectRejection(work: () => Promise<unknown>): Promise<Error> {
+    let value: unknown;
+    try {
+        value = await work();
+    } catch (e) {
+        return e as Error;
+    }
+    throw new ExpectationError(`expected a rejection but resolved with ${String(value)}`);
+}
+
+interface CaseResult {
+    n: number;
+    name: string;
+    ok: boolean;
+    detail: string;
+}
+
+const results: CaseResult[] = [];
+
+async function runCase(n: number, name: string, fn: () => Promise<string>): Promise<void> {
+    captured.length = 0;
+    captureConsole();
+    try {
+        const detail = await fn();
+        results.push({
+            n, name, ok: true, detail,
+        });
+    } catch (e: any) {
+        results.push({
+            n, name, ok: false, detail: e && e.message ? e.message : String(e),
+        });
+    } finally {
+        releaseConsole();
+        restore();
+    }
+}
+
+async function main(): Promise<void> {
+    // 1 - retry then succeed
+    await runCase(1, 'retry-then-succeed (429 + Retry-After)', async () => {
+        let tagCalls = 0;
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            tagCalls += 1;
+            if (tagCalls === 1) {
+                return { statusCode: 429, headers: { 'retry-after': '1' }, body: 'TOOMANYREQUESTS' };
+            }
+            return tagsPage(['1.0.0', '2.0.0']);
+        });
+        const started = Date.now();
+        const version = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case1', '^\\d+\\.\\d+\\.\\d+$');
+        const elapsed = Date.now() - started;
+        assert.strictEqual(version, '2.0.0');
+        assert.ok(warnings().length >= 1, 'expected at least one retry warning');
+        assert.ok(elapsed >= 900, `expected Retry-After delay to be honored, took ${elapsed}ms`);
+        return `resolved 2.0.0 after ${tagCalls} attempts, ${warnings().length} warn, ${elapsed}ms`;
+    });
+
+    // 2 - exhausted retries
+    await runCase(2, 'exhausted retries throw (always 429)', async () => {
+        install((url) => (url.includes('/token') ? TOKEN_OK : { statusCode: 429, body: 'TOOMANYREQUESTS: rate limit' }));
+        const error = await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case2', '.*'));
+        assert.ok(/429/.test(error.message), `message must name the status: ${error.message}`);
+        assert.ok(error.message.includes('/tags/list'), `message must name the URL: ${error.message}`);
+        assert.strictEqual(countRequests('/tags/list'), 5, 'expected 5 attempts');
+        return `threw after 5 attempts: ${error.message.slice(0, 60)}...`;
+    });
+
+    // 3 - non-retryable status
+    await runCase(3, 'non-retryable 404 fails fast', async () => {
+        install((url) => (url.includes('/token') ? TOKEN_OK : { statusCode: 404, body: 'not found' }));
+        const error = await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case3', '.*'));
+        assert.ok(/404/.test(error.message), error.message);
+        assert.strictEqual(countRequests('/tags/list'), 1, 'expected exactly 1 attempt');
+        return 'threw after exactly 1 attempt';
+    });
+
+    // 4 - 401 re-mints the token exactly once
+    await runCase(4, '401 re-mints token once then succeeds', async () => {
+        let tagCalls = 0;
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            tagCalls += 1;
+            if (tagCalls === 1) return { statusCode: 401, body: 'unauthorized' };
+            return tagsPage(['1.2.3', '1.3.0']);
+        });
+        const version = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case4', '.*');
+        assert.strictEqual(version, '1.3.0');
+        assert.strictEqual(countRequests('/token'), 2, 'expected the token to be minted exactly twice (initial + re-mint)');
+        return 'resolved 1.3.0, token minted 2x (1 re-mint)';
+    });
+
+    // 5 - 403 is retried only when the body says rate limit
+    await runCase(5, '403 retried only when rate-limited', async () => {
+        let tagCalls = 0;
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            tagCalls += 1;
+            if (tagCalls === 1) {
+                return { statusCode: 403, body: '{"errors":[{"code":"TOOMANYREQUESTS","message":"retry later"}]}' };
+            }
+            return tagsPage(['4.0.0']);
+        });
+        const version = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case5a', '.*');
+        assert.strictEqual(version, '4.0.0');
+        assert.strictEqual(tagCalls, 2, 'rate-limited 403 should be retried');
+
+        install((url) => (url.includes('/token') ? TOKEN_OK : { statusCode: 403, body: 'denied: insufficient scope' }));
+        const error = await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case5b', '.*'));
+        assert.ok(/403/.test(error.message), error.message);
+        assert.strictEqual(countRequests('/tags/list'), 1, 'plain 403 must not be retried');
+        return 'rate-limited 403 retried; plain 403 failed after 1 attempt';
+    });
+
+    // 6 - pagination cap exhaustion throws
+    await runCase(6, 'pagination cap exhaustion throws', async () => {
+        let page = 0;
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            page += 1;
+            return tagsPage([`0.0.${page}`], `https://ghcr.io/v2/selfcheck/case6/tags/list?n=1000&last=${page}`);
+        });
+        const started = Date.now();
+        const error = await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case6', '.*'));
+        const elapsed = Date.now() - started;
+        assert.ok(/Pagination cap \(200\) reached/.test(error.message), error.message);
+        assert.strictEqual(countRequests('/tags/list'), 200, 'expected exactly 200 pages before the cap');
+        assert.ok(elapsed < 20000, `cap exhaustion must stay bounded, took ${elapsed}ms`);
+        return `threw at 200 pages in ${elapsed}ms`;
+    });
+
+    // 7 - endpoint-keyed cache collapses aliases
+    await runCase(7, 'cache collapses duplicate resolutions', async () => {
+        install((url) => (url.includes('/token') ? TOKEN_OK : tagsPage(['5.0.0', '5.1.0'])));
+        const a = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case7', '.*');
+        const b = await registryOracle.getLatestVersion('lscr.private', 'selfcheck/case7', '.*');
+        const c = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case7', '.*');
+        assert.deepStrictEqual([a, b, c], ['5.1.0', '5.1.0', '5.1.0']);
+        assert.strictEqual(countRequests('/tags/list'), 1, 'three resolutions must share one traversal');
+        return '3 resolutions (2 aliases) -> 1 traversal';
+    });
+
+    // 8 - failures are evicted from the cache
+    await runCase(8, 'failure is not cached', async () => {
+        let attempt = 0;
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            attempt += 1;
+            return attempt === 1 ? { statusCode: 404, body: 'gone' } : tagsPage(['6.0.0']);
+        });
+        await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case8', '.*'));
+        const version = await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case8', '.*');
+        assert.strictEqual(version, '6.0.0');
+        assert.strictEqual(countRequests('/tags/list'), 2, 'the second call must re-traverse');
+        return 'failed call evicted, second call re-traversed';
+    });
+
+    // 9 - truncation regression: a partial enumeration must never be answered
+    await runCase(9, 'truncation regression (page 2 rate limited)', async () => {
+        const stale = ['3.2.2.5080-ls108', '3.0.1.4263-ls4', '2.9.0.1-ls1'];
+        install((url) => {
+            if (url.includes('/token')) return TOKEN_OK;
+            if (!url.includes('last=')) {
+                return tagsPage(stale, 'https://ghcr.io/v2/selfcheck/case9/tags/list?n=1000&last=page1');
+            }
+            return { statusCode: 429, headers: { 'retry-after': '0' }, body: 'TOOMANYREQUESTS' };
+        });
+        const error = await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case9', '.*'));
+        assert.ok(!(error instanceof ExpectationError), `oracle returned a truncated result: ${error.message}`);
+        assert.ok(/429/.test(error.message), `message must name the status: ${error.message}`);
+        assert.ok(!/3\.2\.2/.test(error.message.replace(/https:\S+/g, '')), 'stale tag must not be reported as a result');
+        return 'threw on partial enumeration instead of returning 3.2.2.x';
+    });
+
+    // 10 - auth degrades to anonymous and never leaks
+    await runCase(10, 'anonymous fallback and credential redaction', async () => {
+        const savedUser = process.env.GITHUB_USERNAME;
+        const savedToken = process.env.GITHUB_TOKEN;
+        try {
+            delete process.env.GITHUB_USERNAME;
+            delete process.env.GITHUB_TOKEN;
+            install((url) => (url.includes('/token') ? TOKEN_OK : tagsPage(['7.0.0'])));
+            await registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case10a', '.*');
+            const anonymous = recorded.filter((r) => r.url.includes('/token'));
+            assert.strictEqual(anonymous.length, 1);
+            assert.strictEqual(anonymous[0].headers.Authorization, undefined, 'no Authorization header without credentials');
+
+            process.env.GITHUB_USERNAME = 'selfcheck-user';
+            process.env.GITHUB_TOKEN = 'selfcheck-secret-value';
+            install((url) => {
+                if (url.includes('/token')) return TOKEN_OK;
+                return { statusCode: 429, headers: { 'retry-after': '0' }, body: 'TOOMANYREQUESTS' };
+            });
+            await expectRejection(() => registryOracle.getLatestVersion('ghcr.public', 'selfcheck/case10b', '.*'));
+            const authed = recorded.filter((r) => r.url.includes('/token'));
+            assert.ok(String(authed[0].headers.Authorization).startsWith('Basic '), 'credentials must be used when present');
+            const leaked = captured.filter((line) => line.includes('selfcheck-secret-value') || /Basic [A-Za-z0-9+/=]{4,}/.test(line));
+            assert.deepStrictEqual(leaked, [], 'credentials must never reach the log');
+            return 'anonymous without env; Basic when set; nothing leaked to logs';
+        } finally {
+            if (savedUser === undefined) {
+                delete process.env.GITHUB_USERNAME;
+            } else {
+                process.env.GITHUB_USERNAME = savedUser;
+            }
+            if (savedToken === undefined) {
+                delete process.env.GITHUB_TOKEN;
+            } else {
+                process.env.GITHUB_TOKEN = savedToken;
+            }
+        }
+    });
+
+    let failed = 0;
+    results.forEach((r) => {
+        if (!r.ok) failed += 1;
+        console.log(`${r.ok ? 'PASS' : 'FAIL'} ${r.n}: ${r.name} - ${r.detail}`);
+    });
+    console.log(`${results.length - failed}/${results.length} oracle self-check cases passed`);
+    if (failed > 0) {
+        process.exitCode = 1;
+    }
+}
+
+// cucumber's --require globs this directory, so importing must stay inert.
+if (require.main === module) {
+    main().catch((e) => {
+        restore();
+        releaseConsole();
+        console.error(`oracle self-check crashed: ${e && e.stack ? e.stack : e}`);
+        process.exitCode = 1;
+    });
+}

--- a/e2e/features/support/registry_oracle.ts
+++ b/e2e/features/support/registry_oracle.ts
@@ -1,0 +1,554 @@
+import { execSync } from 'child_process';
+import * as https from 'https';
+import * as os from 'os';
+import * as semver from 'semver';
+import { IncomingHttpHeaders, IncomingMessage } from 'http';
+
+const MAX_ATTEMPTS = 5;
+const BASE_BACKOFF_MS = 500;
+const MAX_RETRY_AFTER_MS = 10000;
+const PAGE_CAP = 200;
+const TRAVERSAL_DEADLINE_MS = 90000;
+const ORACLE_BUDGET_MS = 5 * 60 * 1000;
+const BODY_EXCERPT_LENGTH = 200;
+
+const RATE_LIMITED_BODY = /TOOMANYREQUESTS|rate.?limit|too many requests/i;
+const RETRYABLE_NETWORK = /ECONNRESET|ETIMEDOUT|EAI_AGAIN|ECONNREFUSED|socket hang up/i;
+
+const MANIFEST_ACCEPT = 'application/vnd.docker.distribution.manifest.v2+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json';
+
+interface HttpResult {
+    data: string;
+    headers: IncomingHttpHeaders;
+    statusCode: number;
+}
+
+/**
+ * Wall-clock guard for a single resolution, plus a per-process budget shared by all of them.
+ */
+let oracleSpentMs = 0;
+
+class Deadline {
+    private readonly startedAt = Date.now();
+
+    private readonly label: string;
+
+    constructor(label: string) {
+        this.label = label;
+    }
+
+    check(pages = 0): void {
+        const elapsed = Date.now() - this.startedAt;
+        if (elapsed > TRAVERSAL_DEADLINE_MS) {
+            throw new Error(`Oracle traversal deadline exceeded (${this.label}, ${pages} pages)`);
+        }
+        if (oracleSpentMs + elapsed > ORACLE_BUDGET_MS) {
+            throw new Error(`Oracle budget exceeded (${this.label}, ${Math.round((oracleSpentMs + elapsed) / 1000)}s)`);
+        }
+    }
+
+    settle(): void {
+        oracleSpentMs += Date.now() - this.startedAt;
+    }
+}
+
+interface RequestContext {
+    label: string;
+    deadline?: Deadline;
+    renewAuth?: () => Promise<string>;
+}
+
+/**
+ * Map Node.js os.arch() values to Docker manifest platform architectures.
+ */
+function getDockerArchitecture(): string {
+    const arch = os.arch();
+    switch (arch) {
+    case 'arm64': return 'arm64';
+    case 'x64': return 'amd64';
+    case 'arm': return 'arm';
+    case 'ia32': return '386';
+    default: return 'amd64';
+    }
+}
+
+/**
+ * Get the architecture of a locally pulled image (wud resolves digests for the
+ * architecture of the watched container's image, not the host's).
+ */
+function getLocalImageArchitecture(imageRef: string): string | null {
+    try {
+        return execSync(`docker image inspect --format '{{.Architecture}}' ${imageRef}`, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || null;
+    } catch {
+        return null;
+    }
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => { setTimeout(resolve, ms); });
+}
+
+/** Strip bearer/basic material so a failure excerpt can never leak credentials. */
+function redact(text: string): string {
+    return text
+        .replace(/("(?:access_)?token"\s*:\s*")[^"]*/gi, '$1<redacted>')
+        .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi, '$1 <redacted>');
+}
+
+function excerpt(body: string): string {
+    return redact(body).replace(/\s+/g, ' ').slice(0, BODY_EXCERPT_LENGTH);
+}
+
+/**
+ * Perform a single HTTPS request. Never rejects on a non-2xx status; only on transport errors.
+ */
+function request(url: string, options: https.RequestOptions = {}): Promise<HttpResult> {
+    return new Promise((resolve, reject) => {
+        const method = (options.method || 'GET').toUpperCase();
+        const onResponse = (res: IncomingMessage) => {
+            let data = '';
+            res.setEncoding('utf8');
+            // A HEAD response carries no body; the data listener still puts it in
+            // flowing mode so 'end' fires.
+            res.on('data', (chunk) => { data += chunk; });
+            res.on('end', () => resolve({ data, headers: res.headers, statusCode: res.statusCode || 0 }));
+        };
+        const req = method === 'GET'
+            ? https.get(url, options, onResponse)
+            : https.request(url, options, onResponse);
+        req.on('error', reject);
+        if (method !== 'GET') {
+            req.end();
+        }
+    });
+}
+
+function isRetryableStatus(statusCode: number, body: string): boolean {
+    if (statusCode === 408 || statusCode === 429 || statusCode >= 500) {
+        return true;
+    }
+    // GHCR answers anonymous-abuse throttling with a 403, so only rate-limit 403s are retried.
+    if (statusCode === 403) {
+        return RATE_LIMITED_BODY.test(body);
+    }
+    return false;
+}
+
+function backoffDelay(attempt: number, headers: IncomingHttpHeaders): number {
+    const retryAfter = headers['retry-after'];
+    if (typeof retryAfter === 'string' && retryAfter.trim() !== '') {
+        const seconds = Number(retryAfter);
+        if (Number.isFinite(seconds)) {
+            return Math.min(Math.max(seconds, 0) * 1000, MAX_RETRY_AFTER_MS);
+        }
+        const at = Date.parse(retryAfter);
+        if (!Number.isNaN(at)) {
+            return Math.min(Math.max(at - Date.now(), 0), MAX_RETRY_AFTER_MS);
+        }
+    }
+    const base = BASE_BACKOFF_MS * 2 ** (attempt - 1);
+    return Math.round(base * (0.75 + Math.random() * 0.5));
+}
+
+/**
+ * Perform a request with bounded retries. Throws (never returns a partial or non-2xx result)
+ * with the observed status and a redacted body excerpt once the policy is exhausted.
+ */
+async function requestWithRetry(
+    url: string,
+    options: https.RequestOptions,
+    ctx: RequestContext,
+): Promise<HttpResult> {
+    const opts: https.RequestOptions = { ...options, headers: { ...(options.headers || {}) } };
+    let attempt = 0;
+    let authRenewed = false;
+
+    for (;;) {
+        attempt += 1;
+        if (ctx.deadline) {
+            ctx.deadline.check();
+        }
+
+        let res: HttpResult | null = null;
+        let renewed = false;
+        try {
+            // Attempts are inherently sequential: each one depends on the previous outcome.
+            // eslint-disable-next-line no-await-in-loop
+            res = await request(url, opts);
+        } catch (e: any) {
+            if (!RETRYABLE_NETWORK.test(e.message) || attempt >= MAX_ATTEMPTS) {
+                throw new Error(`${ctx.label}: request failed after ${attempt} attempt(s) for ${url}: ${e.message}`);
+            }
+        }
+
+        if (res) {
+            if (res.statusCode >= 200 && res.statusCode < 300) {
+                return res;
+            }
+            // A long traversal can outlive an anonymous registry token; re-mint it once.
+            if (res.statusCode === 401 && ctx.renewAuth && !authRenewed) {
+                authRenewed = true;
+                renewed = true;
+                // eslint-disable-next-line no-await-in-loop
+                (opts.headers as Record<string, string>).Authorization = await ctx.renewAuth();
+                console.warn(`[oracle] ${ctx.label}: attempt ${attempt} got 401, re-minted token and retrying ${url}`);
+            } else if (!isRetryableStatus(res.statusCode, res.data) || attempt >= MAX_ATTEMPTS) {
+                throw new Error(`${ctx.label}: HTTP ${res.statusCode} after ${attempt} attempt(s) for ${url}; body: ${excerpt(res.data)}`);
+            }
+        }
+
+        if (!renewed) {
+            const delay = res ? backoffDelay(attempt, res.headers) : backoffDelay(attempt, {});
+            console.warn(`[oracle] ${ctx.label}: attempt ${attempt} ${res ? `status ${res.statusCode}` : 'network error'}, retrying in ${delay}ms - ${url}`);
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(delay);
+        }
+    }
+}
+
+function parseJson<T>(res: HttpResult, url: string, label: string): T {
+    try {
+        return JSON.parse(res.data) as T;
+    } catch (e: any) {
+        throw new Error(`${label}: invalid JSON from ${url} (status ${res.statusCode}): ${excerpt(res.data)}`);
+    }
+}
+
+async function requestJson<T>(
+    url: string,
+    options: https.RequestOptions,
+    ctx: RequestContext,
+): Promise<T> {
+    const res = await requestWithRetry(url, options, ctx);
+    return parseJson<T>(res, url, ctx.label);
+}
+
+/**
+ * Build a Basic auth header when the environment supplies credentials, otherwise stay anonymous.
+ */
+function basicAuthHeader(userVar: string, secretVar: string): Record<string, string> {
+    const user = process.env[userVar];
+    const secret = process.env[secretVar];
+    if (!user || !secret) {
+        return {};
+    }
+    return { Authorization: `Basic ${Buffer.from(`${user}:${secret}`).toString('base64')}` };
+}
+
+async function mintGhcrToken(image: string, ctx: RequestContext): Promise<string> {
+    const url = `https://ghcr.io/token?scope=repository:${image}:pull`;
+    const data = await requestJson<{ token?: string }>(url, { headers: basicAuthHeader('GITHUB_USERNAME', 'GITHUB_TOKEN') }, ctx);
+    if (!data.token) {
+        throw new Error(`${ctx.label}: no token returned by ${url}`);
+    }
+    return `Bearer ${data.token}`;
+}
+
+async function mintGitlabToken(image: string, ctx: RequestContext): Promise<string> {
+    const url = `https://gitlab.com/jwt/auth?service=container_registry&scope=repository:${image}:pull`;
+    const data = await requestJson<{ token?: string }>(url, { headers: basicAuthHeader('GITLAB_USERNAME', 'GITLAB_TOKEN') }, ctx);
+    if (!data.token) {
+        throw new Error(`${ctx.label}: no token returned by ${url}`);
+    }
+    return `Bearer ${data.token}`;
+}
+
+async function mintDockerHubToken(repo: string, ctx: RequestContext): Promise<string> {
+    const url = `https://auth.docker.io/token?service=registry.docker.io&scope=repository:${repo}:pull`;
+    const data = await requestJson<{ token?: string }>(url, {}, ctx);
+    if (!data.token) {
+        throw new Error(`${ctx.label}: no token returned by ${url}`);
+    }
+    return `Bearer ${data.token}`;
+}
+
+function hubRepo(image: string): string {
+    return image.includes('/') ? image : `library/${image}`;
+}
+
+function nextPageUrl(link: string | string[] | undefined, currentUrl: string): string | null {
+    const value = Array.isArray(link) ? link.join(', ') : link;
+    if (!value || !value.includes('rel="next"')) {
+        return null;
+    }
+    const match = value.match(/<([^>]*)>;\s*rel="next"/);
+    if (!match) {
+        return null;
+    }
+    const next = match[1];
+    return next.startsWith('/') ? `${currentUrl.split('/v2')[0]}${next}` : next;
+}
+
+interface TagCollection {
+    tags: string[];
+    pages: number;
+}
+
+/**
+ * Walk a Docker Registry v2 /tags/list endpoint to completion. Any incomplete enumeration throws.
+ */
+async function collectV2Tags(
+    host: string,
+    image: string,
+    label: string,
+    mintToken: (ctx: RequestContext) => Promise<string>,
+    deadline: Deadline,
+): Promise<TagCollection> {
+    const ctx: RequestContext = { label, deadline };
+    let auth = await mintToken(ctx);
+    ctx.renewAuth = async () => {
+        auth = await mintToken({ label, deadline });
+        return auth;
+    };
+
+    let url: string | null = `https://${host}/v2/${image}/tags/list?n=1000`;
+    let tags: string[] = [];
+    let pages = 0;
+
+    while (url) {
+        if (pages >= PAGE_CAP) {
+            throw new Error(`Pagination cap (${PAGE_CAP}) reached for ${image} on ${host}; last=${url}`);
+        }
+        deadline.check(pages);
+        // The next URL only exists once this page's Link header has been read.
+        // eslint-disable-next-line no-await-in-loop
+        const res = await requestWithRetry(url, { headers: { Authorization: auth } }, ctx);
+        const body = parseJson<{ tags?: string[] | null }>(res, url, label);
+        // GHCR answers {"tags": null} for an empty repository.
+        tags = tags.concat(body.tags || []);
+        url = nextPageUrl(res.headers.link, url);
+        pages += 1;
+    }
+
+    return { tags, pages };
+}
+
+interface HubTagPage {
+    results?: { name: string }[] | null;
+}
+
+interface QuayTagPage {
+    tags?: { name: string }[] | null;
+    has_additional?: boolean;
+}
+
+async function collectQuayTags(
+    image: string,
+    label: string,
+    deadline: Deadline,
+): Promise<TagCollection> {
+    const ctx: RequestContext = { label, deadline };
+    let url: string | null = `https://quay.io/api/v1/repository/${image}/tag/?limit=100`;
+    let tags: string[] = [];
+    let pages = 0;
+
+    while (url) {
+        if (pages >= PAGE_CAP) {
+            throw new Error(`Pagination cap (${PAGE_CAP}) reached for ${image} on quay.io; last=${url}`);
+        }
+        deadline.check(pages);
+        const pageUrl: string = url;
+        // has_additional is only known once the current page has been fetched.
+        // eslint-disable-next-line no-await-in-loop
+        const data = await requestJson<QuayTagPage>(pageUrl, {}, ctx);
+        tags = tags.concat((data.tags || []).map((t) => t.name));
+        pages += 1;
+        url = data.has_additional ? `https://quay.io/api/v1/repository/${image}/tag/?limit=100&page=${pages + 1}` : null;
+    }
+
+    return { tags, pages };
+}
+
+function sortTags(tags: string[]): string[] {
+    return tags.slice().sort((a, b) => {
+        const cleanA = semver.clean(a) || semver.coerce(a);
+        const cleanB = semver.clean(b) || semver.coerce(b);
+
+        if (!cleanA && !cleanB) return b.localeCompare(a);
+        if (!cleanA) return 1;
+        if (!cleanB) return -1;
+
+        const cmp = semver.rcompare(cleanA, cleanB);
+        if (cmp !== 0) return cmp;
+
+        return b.localeCompare(a);
+    });
+}
+
+/**
+ * Endpoint the traversal actually hits. Cache keys are built from this, not from the wud
+ * registry alias, so aliases sharing an endpoint (ghcr.public / lscr.private) share one traversal.
+ */
+function versionEndpoint(registry: string, image: string): string {
+    switch (registry) {
+    case 'hub.public': return `hub.docker.com/v2/${hubRepo(image)}`;
+    case 'ghcr.public':
+    case 'ghcr.private':
+    case 'lscr.private': return `ghcr.io/v2/${image}`;
+    case 'gitlab.private': return `registry.gitlab.com/v2/${image}`;
+    case 'quay.public': return `quay.io/v2/${image}`;
+    default: return `${registry}/v2/${image}`;
+    }
+}
+
+function digestEndpoint(registry: string, image: string): string {
+    switch (registry) {
+    case 'hub.public': return `registry-1.docker.io/v2/${hubRepo(image)}`;
+    case 'ghcr.public':
+    case 'ghcr.private':
+    case 'lscr.private': return `ghcr.io/v2/${image}`;
+    default: return `${registry}/v2/${image}`;
+    }
+}
+
+// Per-process memoization; it would silently degrade to per-worker if --parallel were ever
+// added to the cucumber invocation.
+const cache = new Map<string, Promise<string>>();
+
+function cached(key: string, work: () => Promise<string>): Promise<string> {
+    const hit = cache.get(key);
+    if (hit) {
+        return hit;
+    }
+    const pending = work().catch((e) => {
+        cache.delete(key);
+        throw e;
+    });
+    cache.set(key, pending);
+    return pending;
+}
+
+async function resolveLatestVersion(
+    registry: string,
+    image: string,
+    pattern: string,
+): Promise<string> {
+    const label = `${image}@${registry}`;
+    const regex = new RegExp(pattern);
+    const deadline = new Deadline(label);
+    let tags: string[] = [];
+    let pages = 1;
+
+    try {
+        if (registry === 'hub.public') {
+            // ordering=last_updated is newest-first; the DRF-looking ordering=-last_updated is
+            // inverted here and returns oldest-first.
+            const url = `https://hub.docker.com/v2/repositories/${hubRepo(image)}/tags?page_size=100&ordering=last_updated`;
+            const data = await requestJson<HubTagPage>(url, {}, { label, deadline });
+            tags = (data.results || []).map((r) => r.name);
+        } else if (registry === 'ghcr.public' || registry === 'ghcr.private' || registry === 'lscr.private') {
+            const collected = await collectV2Tags('ghcr.io', image, label, (ctx) => mintGhcrToken(image, ctx), deadline);
+            tags = collected.tags;
+            pages = collected.pages;
+        } else if (registry === 'gitlab.private') {
+            const collected = await collectV2Tags('registry.gitlab.com', image, label, (ctx) => mintGitlabToken(image, ctx), deadline);
+            tags = collected.tags;
+            pages = collected.pages;
+        } else if (registry === 'quay.public') {
+            const collected = await collectQuayTags(image, label, deadline);
+            tags = collected.tags;
+            pages = collected.pages;
+        } else {
+            throw new Error(`Unsupported registry: ${registry}`);
+        }
+
+        if (pages > 1) {
+            console.log(`[oracle] ${label}: enumerated ${tags.length} tags over ${pages} pages`);
+        }
+
+        const sortedTags = sortTags(tags.filter((t) => regex.test(t)));
+
+        if (sortedTags.length === 0) {
+            throw new Error(`No tags found matching pattern ${pattern} for ${image} (${tags.length} tags enumerated over ${pages} page(s) on ${registry})`);
+        }
+
+        return sortedTags[0];
+    } catch (e: any) {
+        console.error(`Error fetching latest version for ${image} on ${registry}: ${e.message}`);
+        throw e;
+    } finally {
+        deadline.settle();
+    }
+}
+
+interface ManifestIndex {
+    manifests?: {
+        digest: string;
+        platform?: { architecture?: string; os?: string };
+    }[];
+}
+
+async function resolveLatestDigest(registry: string, image: string, tag: string): Promise<string> {
+    const label = `${image}:${tag}@${registry}`;
+    const deadline = new Deadline(label);
+
+    try {
+        let url: string;
+        let auth: string;
+        let arch: string;
+
+        if (registry === 'ghcr.public') {
+            auth = await mintGhcrToken(image, { label, deadline });
+            url = `https://ghcr.io/v2/${image}/manifests/${tag}`;
+            arch = getDockerArchitecture();
+        } else if (registry === 'hub.public') {
+            const repo = hubRepo(image);
+            auth = await mintDockerHubToken(repo, { label, deadline });
+            url = `https://registry-1.docker.io/v2/${repo}/manifests/${tag}`;
+            arch = getLocalImageArchitecture(`${repo}:${tag}`) || getDockerArchitecture();
+        } else {
+            throw new Error(`getLatestDigest not implemented for registry: ${registry}`);
+        }
+
+        const options: https.RequestOptions = {
+            headers: { Authorization: auth, Accept: MANIFEST_ACCEPT },
+        };
+        const ctx: RequestContext = { label, deadline };
+        const manifest = await requestJson<ManifestIndex>(url, options, ctx);
+
+        // For a manifest list / index, pick the manifest matching the relevant architecture.
+        if (manifest.manifests) {
+            const match = manifest.manifests.find((m) => m.platform && m.platform.architecture === arch && m.platform.os === 'linux');
+            if (match) {
+                return match.digest;
+            }
+        }
+
+        // A single manifest's digest is the hash of the body, so ask the registry for it via HEAD.
+        const head = await requestWithRetry(url, { ...options, method: 'HEAD' }, ctx);
+        const digest = head.headers['docker-content-digest'];
+        if (!digest) {
+            throw new Error(`Digest header not found for ${image}:${tag} on ${registry} (status ${head.statusCode})`);
+        }
+        return digest as string;
+    } catch (e: any) {
+        console.error(`Error fetching latest digest for ${image}:${tag} on ${registry}: ${e.message}`);
+        throw e;
+    } finally {
+        deadline.settle();
+    }
+}
+
+/**
+ * Registry Oracle for fetching latest tags and digests.
+ */
+const registryOracle = {
+    /**
+     * Get the latest version for an image.
+     */
+    async getLatestVersion(registry: string, image: string, pattern: string = '.*'): Promise<string> {
+        if (registry === 'ecr.private') {
+            return '2.0.0';
+        }
+        return cached(`v|${versionEndpoint(registry, image)}|${pattern}`, () => resolveLatestVersion(registry, image, pattern));
+    },
+
+    /**
+     * Get the latest digest for an image.
+     */
+    async getLatestDigest(registry: string, image: string, tag: string = 'latest'): Promise<string> {
+        return cached(`d|${digestEndpoint(registry, image)}|${tag}`, () => resolveLatestDigest(registry, image, tag));
+    },
+};
+
+export default registryOracle;

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -9,15 +9,23 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/cucumber": "11.1.1",
-        "apickli": "3.0.3"
+        "@cucumber/cucumber": "^11.3.0",
+        "apickli": "3.0.3",
+        "semver": "7.7.3"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.51.4",
+        "@types/node": "^25.1.0",
+        "@types/semver": "^7.7.1",
+        "@typescript-eslint/eslint-plugin": "^7.18.0",
+        "@typescript-eslint/parser": "^7.18.0",
         "eslint": "8.57.0",
         "eslint-config-airbnb-base": "15.0.0",
+        "eslint-import-resolver-typescript": "^3.10.1",
         "eslint-plugin-cucumber": "2.0.0",
-        "eslint-plugin-import": "2.30.0"
+        "eslint-plugin-import": "2.30.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -53,6 +61,19 @@
         "node": ">=0.1.90"
       }
     },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@cucumber/ci-environment": {
       "version": "10.0.1",
       "resolved": "https://registry.npmjs.org/@cucumber/ci-environment/-/ci-environment-10.0.1.tgz",
@@ -60,25 +81,25 @@
       "license": "MIT"
     },
     "node_modules/@cucumber/cucumber": {
-      "version": "11.1.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-11.1.1.tgz",
-      "integrity": "sha512-4i2vk4R1Ffi1JXiNrVMLxLJFgZ7e0BHdoRN6QiWdz5EDPS+Qv9ld4wGZWeahBH5ncDygIrkkhtYxDhqOBXLPxQ==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber/-/cucumber-11.3.0.tgz",
+      "integrity": "sha512-1YGsoAzRfDyVOnRMTSZP/EcFsOBElOKa2r+5nin0DJAeK+Mp0mzjcmSllMgApGtck7Ji87wwy3kFONfHUHMn4g==",
       "license": "MIT",
       "dependencies": {
         "@cucumber/ci-environment": "10.0.1",
-        "@cucumber/cucumber-expressions": "17.1.0",
-        "@cucumber/gherkin": "28.0.0",
+        "@cucumber/cucumber-expressions": "18.0.1",
+        "@cucumber/gherkin": "30.0.4",
         "@cucumber/gherkin-streams": "5.0.1",
-        "@cucumber/gherkin-utils": "9.0.0",
-        "@cucumber/html-formatter": "21.6.0",
-        "@cucumber/junit-xml-formatter": "0.6.0",
+        "@cucumber/gherkin-utils": "9.2.0",
+        "@cucumber/html-formatter": "21.10.1",
+        "@cucumber/junit-xml-formatter": "0.7.1",
         "@cucumber/message-streams": "4.0.1",
-        "@cucumber/messages": "24.1.0",
-        "@cucumber/tag-expressions": "6.1.1",
+        "@cucumber/messages": "27.2.0",
+        "@cucumber/tag-expressions": "6.1.2",
         "assertion-error-formatter": "^3.0.0",
         "capital-case": "^1.0.4",
         "chalk": "^4.1.2",
-        "cli-table3": "0.6.3",
+        "cli-table3": "0.6.5",
         "commander": "^10.0.0",
         "debug": "^4.3.4",
         "error-stack-parser": "^2.1.4",
@@ -91,21 +112,19 @@
         "knuth-shuffle-seeded": "^1.0.6",
         "lodash.merge": "^4.6.2",
         "lodash.mergewith": "^4.6.2",
-        "luxon": "3.2.1",
+        "luxon": "3.6.1",
         "mime": "^3.0.0",
         "mkdirp": "^2.1.5",
         "mz": "^2.7.0",
         "progress": "^2.0.3",
-        "read-pkg-up": "^7.0.1",
-        "resolve-pkg": "^2.0.0",
-        "semver": "7.5.3",
+        "read-package-up": "^11.0.0",
+        "semver": "7.7.1",
         "string-argv": "0.3.1",
         "supports-color": "^8.1.1",
-        "tmp": "0.2.3",
-        "type-fest": "^4.8.3",
+        "type-fest": "^4.41.0",
         "util-arity": "^1.1.0",
         "yaml": "^2.2.2",
-        "yup": "1.2.0"
+        "yup": "1.6.1"
       },
       "bin": {
         "cucumber-js": "bin/cucumber.js"
@@ -118,21 +137,33 @@
       }
     },
     "node_modules/@cucumber/cucumber-expressions": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-17.1.0.tgz",
-      "integrity": "sha512-PCv/ppsPynniKPWJr5v566daCVe+pbxQpHGrIu/Ev57cCH9Rv+X0F6lio4Id3Z64TaG7btCRLUGewIgLwmrwOA==",
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz",
+      "integrity": "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==",
       "license": "MIT",
       "dependencies": {
         "regexp-match-indices": "1.0.2"
       }
     },
+    "node_modules/@cucumber/cucumber/node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@cucumber/gherkin": {
-      "version": "28.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-28.0.0.tgz",
-      "integrity": "sha512-Ee6zJQq0OmIUPdW0mSnsCsrWA2PZAELNDPICD2pLfs0Oz7RAPgj80UsD2UCtqyAhw2qAR62aqlktKUlai5zl/A==",
+      "version": "30.0.4",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-30.0.4.tgz",
+      "integrity": "sha512-pb7lmAJqweZRADTTsgnC3F5zbTh3nwOB1M83Q9ZPbUKMb3P76PzK6cTcPTJBHWy3l7isbigIv+BkDjaca6C8/g==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/messages": ">=19.1.4 <=24"
+        "@cucumber/messages": ">=19.1.4 <=26"
       }
     },
     "node_modules/@cucumber/gherkin-streams": {
@@ -163,47 +194,109 @@
       }
     },
     "node_modules/@cucumber/gherkin-utils": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.0.0.tgz",
-      "integrity": "sha512-clk4q39uj7pztZuZtyI54V8lRsCUz0Y/p8XRjIeHh7ExeEztpWkp4ca9q1FjUOPfQQ8E7OgqFbqoQQXZ1Bx7fw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
+      "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
       "license": "MIT",
       "dependencies": {
-        "@cucumber/gherkin": "^28.0.0",
-        "@cucumber/messages": "^24.0.0",
+        "@cucumber/gherkin": "^31.0.0",
+        "@cucumber/messages": "^27.0.0",
         "@teppeis/multimaps": "3.0.0",
-        "commander": "12.0.0",
+        "commander": "13.1.0",
         "source-map-support": "^0.5.21"
       },
       "bin": {
         "gherkin-utils": "bin/gherkin-utils"
       }
     },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
+      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=26"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
+      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "10.0.0"
+      }
+    },
     "node_modules/@cucumber/gherkin-utils/node_modules/commander": {
-      "version": "12.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
-      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
       }
     },
+    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
+      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "10.0.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@cucumber/html-formatter": {
-      "version": "21.6.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.6.0.tgz",
-      "integrity": "sha512-Qw1tdObBJrgXgXwVjKVjB3hFhFPI8WhIFb+ULy8g5lDl5AdnKDiyDXAMvAWRX+pphnRMMNdkPCt6ZXEfWvUuAA==",
+      "version": "21.10.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.10.1.tgz",
+      "integrity": "sha512-isaaNMNnBYThsvaHy7i+9kkk9V3+rhgdkt0pd6TCY6zY1CSRZQ7tG6ST9pYyRaECyfbCeF7UGH0KpNEnh6UNvQ==",
       "license": "MIT",
       "peerDependencies": {
         "@cucumber/messages": ">=18"
       }
     },
     "node_modules/@cucumber/junit-xml-formatter": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.6.0.tgz",
-      "integrity": "sha512-++PAuxliQhq7yr2Bn9P0fwBUo46OoKAK5f6M4PrwoHBqIsl/6pUS4mqpviuBrgZ8RD7BTrmASk4lUDJClAz/qA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.7.1.tgz",
+      "integrity": "sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ==",
       "license": "MIT",
       "dependencies": {
         "@cucumber/query": "^13.0.2",
         "@teppeis/multimaps": "^3.0.0",
+        "luxon": "^3.5.0",
         "xmlbuilder": "^15.1.1"
       },
       "peerDependencies": {
@@ -220,15 +313,15 @@
       }
     },
     "node_modules/@cucumber/messages": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-24.1.0.tgz",
-      "integrity": "sha512-hxVHiBurORcobhVk80I9+JkaKaNXkW6YwGOEFIh/2aO+apAN+5XJgUUWjng9NwqaQrW1sCFuawLB1AuzmBaNdQ==",
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
       "license": "MIT",
       "dependencies": {
-        "@types/uuid": "9.0.8",
+        "@types/uuid": "10.0.0",
         "class-transformer": "0.5.1",
-        "reflect-metadata": "0.2.1",
-        "uuid": "9.0.1"
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
       }
     },
     "node_modules/@cucumber/query": {
@@ -245,9 +338,9 @@
       }
     },
     "node_modules/@cucumber/tag-expressions": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.1.1.tgz",
-      "integrity": "sha512-0oj5KTzf2DsR3DhL3hYeI9fP3nyKzs7TQdpl54uJelJ3W3Hlyyet2Hib+8LK7kNnqJsXENnJg9zahRYyrtvNEg==",
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.1.2.tgz",
+      "integrity": "sha512-xa3pER+ntZhGCxRXSguDTKEHTZpUUsp+RzTRNnit+vi5cqnk6abLdSLg5i3HZXU3c74nQ8afQC6IT507EN74oQ==",
       "license": "MIT"
     },
     "node_modules/@dotenvx/dotenvx": {
@@ -298,10 +391,44 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -368,12 +495,36 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/@eslint/js": {
       "version": "8.57.0",
@@ -399,6 +550,30 @@
       },
       "engines": {
         "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/@humanwhocodes/module-importer": {
@@ -490,6 +665,34 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
     "node_modules/@jsep-plugin/assignment": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@jsep-plugin/assignment/-/assignment-1.3.0.tgz",
@@ -512,6 +715,25 @@
       },
       "peerDependencies": {
         "jsep": "^0.4.0||^1.0.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
+      "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
       }
     },
     "node_modules/@noble/hashes": {
@@ -564,6 +786,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
     "node_modules/@paralleldrive/cuid2": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
@@ -599,6 +831,45 @@
         "node": ">=14"
       }
     },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
+      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
@@ -606,17 +877,227 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.5.tgz",
+      "integrity": "sha512-OScDchr2fwuUmWdf4kZ9h7PcJiYDVInhJizG/biAq3cAvqwYktuy/TYGGdZNMtNTFUP7rnb0NU4TUdm82kt4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
+      "integrity": "sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/type-utils": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.3.1",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^7.0.0",
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-7.18.0.tgz",
+      "integrity": "sha512-4Z+L8I2OqhZV8qA132M4wNL30ypZGYOQVBfMgxDH/K5UX0PNqTu1c6za9ST5r9+tavvHiTWmBnKzpCJ/GlVFtg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-7.18.0.tgz",
+      "integrity": "sha512-jjhdIE/FPF2B7Z1uzc6i3oWKbGcHb87Qw7AWj6jmEqNOfDFbJWtjt/XfwCpvNkpGWlcJaog5vTR+VV8+w9JflA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-7.18.0.tgz",
+      "integrity": "sha512-XL0FJXuCLaDuX2sYqZUUSOJ2sG5/i1AAze+axqmLnSkNEVMVYLF+cbwlB2w8D1tinFuSikHmFta+P+HOofrLeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "7.18.0",
+        "@typescript-eslint/utils": "7.18.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-7.18.0.tgz",
+      "integrity": "sha512-iZqi+Ds1y4EDYUtlOOC+aUmxnE9xS/yCigkjA7XpTKV6nCBd3Hp/PRGGmdwnfkV2ThMyYldP1wRpm/id99spTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-7.18.0.tgz",
+      "integrity": "sha512-aP1v/BSPnnyhMHts8cf1qQ6Q1IFwwRvAQGRvBFkWlo3/lH29OXA3Pts+c10nxRxIBrDnoMqzhgdwVe5f2D6OzA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/visitor-keys": "7.18.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^1.3.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-7.18.0.tgz",
+      "integrity": "sha512-kK0/rNa2j74XuHVcoCZxdFBMF+aq/vH83CXAOHieC+2Gis4mF8jJXT5eAfyD3K0sAxtPuwxaIOIOvhwzVDt/kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@typescript-eslint/scope-manager": "7.18.0",
+        "@typescript-eslint/types": "7.18.0",
+        "@typescript-eslint/typescript-estree": "7.18.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.56.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-7.18.0.tgz",
+      "integrity": "sha512-cDF0/Gf81QpY3xYyJKDV14Zwdmid5+uuENhjH2EqFaF0ni+yAyq/LzMaIJdhNJXZI7uLzwIlA+V7oWoyn6Curg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "7.18.0",
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || >=20.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -624,6 +1105,319 @@
       "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.9.10",
@@ -655,6 +1449,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -754,6 +1561,13 @@
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
     },
+    "node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -798,6 +1612,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/array.prototype.findlastindex": {
@@ -1041,14 +1865,25 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer-from": {
@@ -1187,9 +2022,9 @@
       "license": "MIT"
     },
     "node_modules/cli-table3": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
-      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
       "license": "MIT",
       "dependencies": {
         "string-width": "^4.2.0"
@@ -1375,6 +2210,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
@@ -1618,6 +2460,19 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1733,15 +2588,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
-      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/error-stack-parser": {
@@ -2045,6 +2891,41 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-module-utils": {
       "version": "2.14.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
@@ -2119,6 +3000,17 @@
         "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8"
       }
     },
+    "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint-plugin-import/node_modules/debug": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
@@ -2140,6 +3032,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/eslint-plugin-import/node_modules/semver": {
@@ -2199,12 +3104,36 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/eslint/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/eslint/node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/eslint/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/espree": {
       "version": "9.6.1",
@@ -2337,6 +3266,36 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
     },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -2438,6 +3397,19 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -2450,6 +3422,18 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2471,9 +3455,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.3.tgz",
+      "integrity": "sha512-/zipXxyO6rGvuNGDiULY9MvEGSkb2gaG4GGH4ygMi0ZZzyMHdUZBmntJmx5x1G2VuPytCwGN4xsJP6cw+sK+vQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -2704,6 +3688,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
@@ -2745,30 +3742,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/glob/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/global-dirs": {
@@ -2829,6 +3802,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/gopd": {
@@ -3004,10 +3998,16 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "2.8.9",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
-      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
-      "license": "ISC"
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.2.tgz",
+      "integrity": "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
     },
     "node_modules/http-errors": {
       "version": "1.6.3",
@@ -3104,6 +4104,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/index-to-position": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/index-to-position/-/index-to-position-1.2.0.tgz",
+      "integrity": "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3162,12 +4174,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
-    },
     "node_modules/is-async-function": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
@@ -3218,6 +4224,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -3234,6 +4250,7 @@
       "version": "2.16.2",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
       "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.3"
@@ -3432,6 +4449,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -3730,12 +4757,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json-refs": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/json-refs/-/json-refs-3.0.15.tgz",
@@ -3909,12 +4930,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -4237,13 +5252,20 @@
       "license": "ISC"
     },
     "node_modules/luxon": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-      "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.6.1.tgz",
+      "integrity": "sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/make-error": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4270,6 +5292,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -4277,6 +5309,33 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime": {
@@ -4323,16 +5382,18 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
-        "node": "*"
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/minimist": {
@@ -4417,6 +5478,22 @@
         "thenify-all": "^1.0.0"
       }
     },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
     "node_modules/native-promise-only": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
@@ -4470,45 +5547,17 @@
       }
     },
     "node_modules/normalize-package-data": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
-      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-6.0.2.tgz",
+      "integrity": "sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==",
       "license": "BSD-2-Clause",
       "dependencies": {
-        "hosted-git-info": "^2.1.4",
-        "resolve": "^1.10.0",
-        "semver": "2 || 3 || 4 || 5",
-        "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
+        "hosted-git-info": "^7.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
       },
       "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
-      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver"
+        "node": "^16.14.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -4746,12 +5795,13 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -4798,6 +5848,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4835,18 +5886,17 @@
       }
     },
     "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-8.3.0.tgz",
+      "integrity": "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
+        "@babel/code-frame": "^7.26.2",
+        "index-to-position": "^1.1.0",
+        "type-fest": "^4.39.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4875,6 +5925,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5018,6 +6069,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -5041,6 +6093,16 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.4.0.tgz",
       "integrity": "sha512-G6zHoVqC6GGTQkZwF4lkuEyMbVOjoBKAEybQUypI1WTkqinCOrq2x6U2+phkJ1XsEMTy4LjtwPI7HW+NVrRR2w==",
       "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/performance-now": {
       "version": "2.1.0",
@@ -5313,106 +6375,40 @@
       "integrity": "sha512-9jphSf3UbIgpOX/RKvX02iw/rN2TKdusnsPpGfO/rkcsrd+IRqgHZb4VGnmL0Cynps8Nj2hN45wsi30BzrHDIw==",
       "license": "ISC"
     },
+    "node_modules/read-package-up": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
+      "integrity": "sha512-MbgfoNPANMdb4oRBNg5eqLbB2t2r+o5Ua1pNt8BqGp4I0FJZhuVSOj3PaBPni4azWuSzEdNn2evevzVmEk1ohQ==",
+      "license": "MIT",
+      "dependencies": {
+        "find-up-simple": "^1.0.0",
+        "read-pkg": "^9.0.0",
+        "type-fest": "^4.6.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/read-pkg": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
-      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-9.0.1.tgz",
+      "integrity": "sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==",
       "license": "MIT",
       "dependencies": {
-        "@types/normalize-package-data": "^2.4.0",
-        "normalize-package-data": "^2.5.0",
-        "parse-json": "^5.0.0",
-        "type-fest": "^0.6.0"
+        "@types/normalize-package-data": "^2.4.3",
+        "normalize-package-data": "^6.0.0",
+        "parse-json": "^8.0.0",
+        "type-fest": "^4.6.0",
+        "unicorn-magic": "^0.1.0"
       },
       "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
-      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^4.1.0",
-        "read-pkg": "^5.2.0",
-        "type-fest": "^0.8.1"
-      },
-      "engines": {
-        "node": ">=8"
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg-up/node_modules/type-fest": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
-      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/read-pkg/node_modules/type-fest": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
-      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
-      "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/readable-stream": {
@@ -5434,10 +6430,9 @@
       "license": "MIT"
     },
     "node_modules/reflect-metadata": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.1.tgz",
-      "integrity": "sha512-i5lLI6iw9AU3Uu4szRNPPEkomnkjRTaVt9hy/bn5g/oSzekBSMeLZblcjP74AW0vBabqERLLIrz+gR8QYR54Tw==",
-      "deprecated": "This version has a critical bug in fallback handling. Please upgrade to reflect-metadata@0.2.2 or newer.",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
       "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
@@ -5595,25 +6590,14 @@
         "node": ">=4"
       }
     },
-    "node_modules/resolve-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-pkg/-/resolve-pkg-2.0.0.tgz",
-      "integrity": "sha512-+1lzwXehGCXSeryaISr6WujZzowloigEofRB+dj75y9RRa/obVcYgbHJd53tdYw8pvZj8GojXaaENws8Ktw/hQ==",
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "resolve-from": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/resolve-pkg/node_modules/resolve-from": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/reusify": {
@@ -5644,6 +6628,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/brace-expansion": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
     "node_modules/rimraf/node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5664,6 +6659,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rimraf/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/run-parallel": {
@@ -5775,27 +6783,12 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.3.tgz",
-      "integrity": "sha512-QBlUtyVk/5EeHbi7X0fw6liDZc7BBmEaSYn01fMU1OUYbf6GPsbTtd8WmnqbI20SeycoHSeiybkE/q1Q+qlThQ==",
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
       },
       "engines": {
         "node": ">=10"
@@ -6178,6 +7171,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
@@ -6489,6 +7489,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6572,9 +7573,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.17",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.17.tgz",
-      "integrity": "sha512-TvFA9iwDWlMjqZVlKIJ0Cy+Zgm9ttlMx0SMRwJDMNKyhlEKWBMb3+WRwDi/3dvHdWbexpos4Osp4U49p5WjB5g==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
       "dev": true,
       "license": "MIT",
       "os": [
@@ -6591,7 +7592,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",
@@ -6632,13 +7633,34 @@
       "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
       "license": "MIT"
     },
-    "node_modules/tmp": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
-      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
       "engines": {
-        "node": ">=14.14"
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
       }
     },
     "node_modules/toidentifier": {
@@ -6684,6 +7706,63 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
       }
     },
     "node_modules/tsconfig-paths": {
@@ -6863,6 +7942,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -6882,13 +7975,32 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.1.0.tgz",
+      "integrity": "sha512-lRfVq8fE8gz6QMBuDM6a+LO3IAzTi05H6gCVaUpir2E1Rwpo4ZUog45KpNXKC/Mn3Yb9UDuHumeFTo9iV/D9FQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/unpipe": {
@@ -6898,6 +8010,44 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
     "node_modules/upper-case-first": {
@@ -6940,18 +8090,24 @@
       "license": "MIT"
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
@@ -7233,12 +8389,6 @@
         "node": ">=0.4"
       }
     },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
-    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -7252,6 +8402,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {
@@ -7268,9 +8428,9 @@
       }
     },
     "node_modules/yocto-spinner": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.1.tgz",
-      "integrity": "sha512-9cbFWLhbiZp+820O4pkHGNncI7+MrUGzBOjw8NMG+ewsY+aG0DdEXnr19Smxao32YOjLZRMdn1UtaxcrXOYOIg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.2.tgz",
+      "integrity": "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7284,9 +8444,9 @@
       }
     },
     "node_modules/yoctocolors": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.2.tgz",
-      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.2.0.tgz",
+      "integrity": "sha512-xYqdZFUK/VYazNl/oCDYN+3WloWQwMfZxBoiNt6qNyk+xfOdi598muWE42rNZFp1kNOiqW936q5RhUdnpqElSg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7297,9 +8457,9 @@
       }
     },
     "node_modules/yup": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/yup/-/yup-1.2.0.tgz",
-      "integrity": "sha512-PPqYKSAXjpRCgLgLKVGPA33v5c/WgEx3wi6NFjIiegz90zSwyMpvTFp/uGcVnnbx6to28pgnzp/q8ih3QRjLMQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
       "license": "MIT",
       "dependencies": {
         "property-expr": "^2.0.5",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "eslint '**/*.js'",
     "cucumber": "cucumber-js **/*.feature",
+    "test": "npm run test:local",
     "test:local": "dotenvx run -- ../scripts/run-e2e-tests.sh",
     "test:setup": "dotenvx run -- ../scripts/setup-test-containers.sh",
     "test:start-wud": "dotenvx run -- ../scripts/start-wud.sh",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -4,26 +4,34 @@
   "description": "WUD - e2e",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint '**/*.js'",
-    "cucumber": "cucumber-js **/*.feature",
-    "test": "npm run test:local",
-    "test:local": "dotenvx run -- ../scripts/run-e2e-tests.sh",
-    "test:setup": "dotenvx run -- ../scripts/setup-test-containers.sh",
-    "test:start-wud": "dotenvx run -- ../scripts/start-wud.sh",
+    "lint": "eslint '**/*.ts'",
+    "cucumber": "dotenvx run -f ../.env -- cucumber-js --require-module ts-node/register --require 'features/**/*.ts'",
+    "oracle:selfcheck": "ts-node features/support/oracle_selfcheck.ts",
+    "test": "dotenvx run -f ../.env -- ../scripts/run-e2e-tests.sh",
+    "test:setup": "dotenvx run -f ../.env -- ../scripts/setup-test-containers.sh",
+    "test:start-wud": "dotenvx run -f ../.env -- ../scripts/start-wud.sh",
     "test:cleanup": "../scripts/cleanup-test-containers.sh"
   },
   "author": "fmartinou",
   "repository": "getwud/wud",
   "license": "MIT",
   "dependencies": {
-    "@cucumber/cucumber": "11.1.1",
-    "apickli": "3.0.3"
+    "@cucumber/cucumber": "^11.3.0",
+    "apickli": "3.0.3",
+    "semver": "7.7.3"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.4",
+    "@types/node": "^25.1.0",
+    "@types/semver": "^7.7.1",
+    "@typescript-eslint/eslint-plugin": "^7.18.0",
+    "@typescript-eslint/parser": "^7.18.0",
     "eslint": "8.57.0",
     "eslint-config-airbnb-base": "15.0.0",
+    "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-cucumber": "2.0.0",
-    "eslint-plugin-import": "2.30.0"
+    "eslint-plugin-import": "2.30.0",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.9.3"
   }
 }

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "types": ["node", "semver"]
+  },
+  "include": ["features/**/*.ts", "config/**/*.ts", "typings/**/*.d.ts"]
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test:unit": "jest --coverage",
+    "test": "npm run test:unit",
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "build": "vue-cli-service build",
     "lint": "vue-cli-service lint",
     "test:unit": "jest --coverage",
-    "test": "npm run test:unit",
+    "test": "jest --runInBand --no-coverage",
     "test:unit:watch": "jest --watch"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

The e2e feature tables currently hardcode the tag and digest that WUD is expected to
report as the latest available version for each watched image. Those expectations go
stale every time one of the watched upstream images publishes a release, so the suite
has to be repaired on a recurring basis — 4e1e3b0 and 7647bcb ("Fix E2E tests",
2026-07-18) are the two most recent instances, and the pattern goes back further.

This PR removes the cause rather than refreshing the values again. The expected tag or
digest is resolved at test time from the same registry WUD itself queries, using a
per-row `strategy` and `pattern`. The assertions themselves are unchanged: the suite
still asserts that `result.tag` / `result.digest` / `updateAvailable` have specific
values — the values are now derived instead of transcribed.

### What the oracle does

`e2e/features/support/registry_oracle.ts` exposes two functions:

- `getLatestVersion(registry, image, pattern)` — lists tags from the registry
  (Docker Hub v2 API, GHCR/LSCR token + `/v2/.../tags/list` with `Link`-header
  pagination, GitLab JWT + registry.gitlab.com, Quay `/api/v1/repository/.../tag/`),
  filters them by `pattern`, sorts with `semver` (falling back to `semver.coerce`
  and then lexical comparison for non-semver tags), and returns the highest.
- `getLatestDigest(registry, image, tag)` — fetches the manifest, and for a manifest
  list / OCI index picks the entry matching the relevant architecture, falling back
  to a `HEAD` request for the `docker-content-digest` header on single manifests.

Each row in `api-container.feature` and `prometheus.feature` gained two columns:

| strategy  | meaning |
|-----------|---------|
| `dynamic` | resolve the expectation from the registry using `pattern` |
| `static`  | keep the literal value in the `resultTag` column |

`static` is used where the expectation is genuinely fixed (`latest` rows, and the
commented-out ECR row), so no row loses its assertion. `pattern` encodes the update
semantics the row is actually testing, e.g.:

- `^\d+\.\d+-alpine$` — the nginx alpine minor-update row
- `^\d+\.\d+\.\d+\.\d+-ls\d+$` — the linuxserver/radarr complex-semver rows
- `^v16\.[01]\.0$` — the GitLab row, bounded so it keeps testing a minor update
  rather than tracking gitlab-runner's tip forever
- `^v\d+\.\d+\.\d+$` — the Quay prometheus major-update row

The steps that resolve and compare are in
`e2e/features/step_definitions/custom_steps.ts` (six generic steps plus a
backtick-variable substitution helper for the Prometheus text-body assertions).

### Host-architecture digest resolution

Digest assertions previously only matched on whichever architecture the manifest
list happened to yield, so the digest scenarios failed on arm64 machines. The oracle
now inspects the locally pulled image (`docker image inspect --format
'{{.Architecture}}'`) and selects the manifest for that architecture, falling back to
the host architecture derived from `os.arch()`. The suite passes on both arm64 and
amd64 hosts.

### TypeScript migration

The harness (not the application) moves to TypeScript so the oracle and the new step
definitions are type-checked:

- `e2e/config/index.js` → `index.ts`, `e2e/features/support/init.js` → `init.ts`,
  `e2e/features/step_definitions/api.js` → `api.ts`
- `e2e/tsconfig.json` added (`strict`, commonjs, `types: ["node", "semver"]`)
- `ts-node`, `typescript`, `@types/node`, `@types/semver` added as devDependencies;
  `semver` as a dependency
- the `cucumber` script runs `cucumber-js --require-module ts-node/register --require
  'features/**/*.ts'`
- `@cucumber/cucumber` moved from `11.1.1` to `^11.3.0` (needed for the typings used
  by the step definitions)
- the default step timeout was raised from 20s to 60s, since resolving expectations
  now involves registry round-trips

`npx tsc --noEmit` is clean and `cucumber-js --dry-run` binds all 397 steps across all
42 scenarios.

### Serial jest for the UI unit tests

`ui/package.json` gains a single `test` script that runs jest with `--runInBand` and
without coverage, to avoid jest worker crashes on memory-constrained runners. This is
a pure addition: `test:unit` and `test:unit:watch` are untouched, so the existing
`.travis.yml` step (`cd ui && npm run test:unit`) keeps its current coverage and
parallel semantics.

### e2e lint script

The `lint` script becomes `eslint '**/*.ts'`. The `'**/*.js'` glob is dropped because
the migration leaves no `.js` files under `e2e/`, and ESLint 8 exits non-zero on a
glob that matches nothing. `e2e/.eslintrc` gains the TypeScript parser, plugin and
import resolver needed to lint the migrated sources under the existing `airbnb-base`
config; see the limitations section for details. `npm run lint` exits 0.

### npm test aliases

The first commit adds plain `test` aliases so `npm test` works from `e2e/` and `ui/`
the same way it already does from `app/`.

---

## Validation

- Full backend e2e suite: 42/42 scenarios green, run against upstream's own scenario
  set with no scenarios added, removed, or skipped.
- `npx tsc --noEmit`: 0 errors.
- `npx cucumber-js --dry-run`: 42 scenarios / 397 steps, no undefined or ambiguous steps.
- `ui`: `npm run test:unit` and `npm test` both green (26 suites, 157 tests).
- Assertions are preserved one-for-one; only the source of the expected value changed.

Note: the lint cleanup described below reformatted `registry_oracle.ts` after the 42/42
run (style-only — a callback parameter rename and a block-bodied arrow, no logic change).
`tsc` and the cucumber dry-run were re-run clean afterwards, but the full suite should be
re-run before merge to confirm.

---

## Limitations / things to review

- **Network dependency**: the oracle performs registry API calls during the test run.
  The suite already required registry access (WUD itself queries the same registries
  for these scenarios), so this adds no new class of dependency, but it does add
  per-scenario HTTP calls and therefore some latency and a new failure mode if a
  registry API is rate-limiting or down. The step timeout was raised to 60s partly for
  this reason.
- **Anonymous rate limits**: Docker Hub and GHCR token endpoints are called
  unauthenticated. On a busy shared CI IP this could hit anonymous rate limits.
- **Pattern maintenance**: the patterns are now the thing that encodes intent. A row
  whose pattern is too loose would silently start tracking a different update than it
  was written to test (this is why the GitLab row is bounded to `^v16\.[01]\.0$`
  rather than open-ended).
- **ECR row**: still commented out upstream; its `static` strategy preserves the
  original literal so nothing changes if it is re-enabled.
- **`@cucumber/cucumber` pin loosened** from the exact `11.1.1` to `^11.3.0`. If the
  project prefers exact pins in `e2e/`, say so and it can be pinned to a specific
  11.3.x. `apickli` is unchanged at `3.0.3`.
- **`e2e/package-lock.json` is fully regenerated**, so the diff is large and includes
  unrelated transitive churn. Happy to redo it however the project prefers.

- **TypeScript linting is newly enabled**, which is why `e2e/.eslintrc` and the lint
  devDependencies grew. Previously `eslint '**/*.js'` failed on an unmatched glob before
  it ever parsed anything, so the TS sources were effectively unlinted. Enabling it
  required `@typescript-eslint/parser` (parse TS at all),
  `@typescript-eslint/eslint-plugin` with the standard `no-unused-vars` swap (the base
  rule flags TypeScript `this` parameters as unused), and
  `eslint-import-resolver-typescript` plus `import/extensions` set to `never` for `.ts`
  (so `eslint-plugin-import` can resolve extensionless TS imports). All the style issues
  this surfaced are fixed in the source rather than silenced. The only suppressions are
  three documented inline `eslint-disable-next-line` comments on the registry oracle's
  two pagination loops (`no-await-in-loop` ×2, `no-loop-func`): paging is necessarily
  sequential, since each request's URL or continuation flag is only known once the
  previous response has been read. `npm run lint` exits 0; ten `func-names` /
  `no-console` warnings remain, which do not affect exit status.

(For reference, the `cucumber` script's new `dotenvx run -f ../.env` prefix is safe on
CI: dotenvx warns `MISSING_ENV_FILE` but exits 0 and passes the ambient environment
through, which is how Travis already supplies the registry credentials.)