### PR TITLE
Add nomad trigger: safely update HashiCorp Nomad-managed containers

### DIFF
--- a/app/triggers/providers/nomad/Nomad.test.ts
+++ b/app/triggers/providers/nomad/Nomad.test.ts
@@ -1,0 +1,166 @@
+// @ts-nocheck
+import axios from 'axios';
+import Nomad from './Nomad';
+import log from '../../../log';
+
+jest.mock('axios');
+
+const configurationValid = {
+    address: 'http://127.0.0.1:4646',
+    alloclabel: 'com.hashicorp.nomad.alloc_id',
+    tasklabel: 'com.hashicorp.nomad.task_name',
+    alltasks: false,
+    threshold: 'all',
+    mode: 'simple',
+    once: true,
+    auto: true,
+    simpletitle:
+        'New ${container.updateKind.kind} found for container ${container.name}',
+    simplebody:
+        'Container ${container.name} running with ${container.updateKind.kind} ${container.updateKind.localValue} can be updated to ${container.updateKind.kind} ${container.updateKind.remoteValue}${container.result && container.result.link ? "\\n" + container.result.link : ""}',
+    batchtitle: '${containers.length} updates available',
+};
+
+let nomad;
+
+beforeEach(() => {
+    nomad = new Nomad();
+    nomad.configuration = configurationValid;
+    nomad.log = log;
+    jest.resetAllMocks();
+});
+
+test('validateConfiguration should apply defaults', () => {
+    const validated = nomad.validateConfiguration({});
+    expect(validated.address).toEqual('http://127.0.0.1:4646');
+    expect(validated.alloclabel).toEqual('com.hashicorp.nomad.alloc_id');
+    expect(validated.tasklabel).toEqual('com.hashicorp.nomad.task_name');
+    expect(validated.alltasks).toEqual(false);
+});
+
+test('validateConfiguration should throw when address is not a valid uri', () => {
+    expect(() =>
+        nomad.validateConfiguration({ address: 'not-a-url' }),
+    ).toThrow();
+});
+
+test('maskConfiguration should hide the token', () => {
+    const masked = nomad.maskConfiguration({
+        ...configurationValid,
+        token: 'super-secret',
+    });
+    expect(masked.token).toEqual('_****_');
+});
+
+test('trigger should restart the allocation using the alloc/task labels', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    const container = {
+        name: 'romm',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+            'com.hashicorp.nomad.task_name': 'romm',
+        },
+    };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).toHaveBeenCalledWith(
+        'http://127.0.0.1:4646/v1/client/allocation/alloc-123/restart',
+        { TaskName: 'romm' },
+        { headers: {} },
+    );
+});
+
+test('trigger should send AllTasks when alltasks is enabled', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+    nomad.configuration = { ...configurationValid, alltasks: true };
+
+    const container = {
+        name: 'romm',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+            'com.hashicorp.nomad.task_name': 'romm',
+        },
+    };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).toHaveBeenCalledWith(
+        'http://127.0.0.1:4646/v1/client/allocation/alloc-123/restart',
+        { AllTasks: true },
+        { headers: {} },
+    );
+});
+
+test('trigger should send the X-Nomad-Token header when a token is configured', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+    nomad.configuration = { ...configurationValid, token: 'secret-token' };
+
+    const container = {
+        name: 'romm',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+            'com.hashicorp.nomad.task_name': 'romm',
+        },
+    };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).toHaveBeenCalledWith(
+        'http://127.0.0.1:4646/v1/client/allocation/alloc-123/restart',
+        { TaskName: 'romm' },
+        { headers: { 'X-Nomad-Token': 'secret-token' } },
+    );
+});
+
+test('trigger should skip containers with no Nomad alloc label', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    const container = { name: 'not-nomad', labels: {} };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).not.toHaveBeenCalled();
+});
+
+test('trigger should propagate errors from the Nomad API', async () => {
+    axios.post.mockRejectedValue(new Error('connection refused'));
+
+    const container = {
+        name: 'romm',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+            'com.hashicorp.nomad.task_name': 'romm',
+        },
+    };
+
+    await expect(nomad.trigger(container)).rejects.toThrow(
+        'connection refused',
+    );
+});
+
+test('triggerBatch should restart every container allocation', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    const containers = [
+        {
+            name: 'romm',
+            labels: {
+                'com.hashicorp.nomad.alloc_id': 'alloc-123',
+                'com.hashicorp.nomad.task_name': 'romm',
+            },
+        },
+        {
+            name: 'guacamole',
+            labels: {
+                'com.hashicorp.nomad.alloc_id': 'alloc-456',
+                'com.hashicorp.nomad.task_name': 'guacamole',
+            },
+        },
+    ];
+
+    await nomad.triggerBatch(containers);
+
+    expect(axios.post).toHaveBeenCalledTimes(2);
+});

--- a/app/triggers/providers/nomad/Nomad.test.ts
+++ b/app/triggers/providers/nomad/Nomad.test.ts
@@ -114,6 +114,40 @@ test('trigger should send the X-Nomad-Token header when a token is configured', 
     );
 });
 
+test('trigger should fall back to parsing the task name from the container name when the label is missing', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    const container = {
+        name: 'audiobookshelf-alloc-123',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+        },
+    };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).toHaveBeenCalledWith(
+        'http://127.0.0.1:4646/v1/client/allocation/alloc-123/restart',
+        { TaskName: 'audiobookshelf' },
+        { headers: {} },
+    );
+});
+
+test('trigger should refuse to restart implicitly when the task name cannot be determined', async () => {
+    axios.post.mockResolvedValue({ data: {} });
+
+    const container = {
+        name: 'some-unrelated-container-name',
+        labels: {
+            'com.hashicorp.nomad.alloc_id': 'alloc-123',
+        },
+    };
+
+    await nomad.trigger(container);
+
+    expect(axios.post).not.toHaveBeenCalled();
+});
+
 test('trigger should skip containers with no Nomad alloc label', async () => {
     axios.post.mockResolvedValue({ data: {} });
 

--- a/app/triggers/providers/nomad/Nomad.ts
+++ b/app/triggers/providers/nomad/Nomad.ts
@@ -1,0 +1,125 @@
+import axios from 'axios';
+import Trigger from '../Trigger';
+import { ComponentConfiguration } from '../../../registry/Component';
+import { Container, fullName } from '../../../model/container';
+
+/**
+ * Restart the HashiCorp Nomad allocation/task backing a watched container.
+ *
+ * Unlike the `docker`/`dockercompose` triggers, this never touches the
+ * Docker API to stop/remove/create a container directly. Containers
+ * started by Nomad are supervised by it (service registration, health
+ * checks, template-rendered secrets, restart policy) and deleting one
+ * out from under Nomad causes it to treat the disappearance as a task
+ * failure and reconcile independently, fighting whatever just replaced
+ * it. Instead, this trigger asks Nomad itself to restart the task,
+ * which re-runs the driver's image pull (when `force_pull = true` is
+ * set on the task, image pulls are not cached) and keeps the
+ * allocation under Nomad's normal supervision throughout.
+ *
+ * Nomad stamps every container it creates with a fixed set of labels
+ * (see hashicorp/nomad drivers/docker/driver.go):
+ *   - com.hashicorp.nomad.alloc_id
+ *   - com.hashicorp.nomad.task_name
+ *   - com.hashicorp.nomad.job_name
+ *   - com.hashicorp.nomad.job_id
+ *   - com.hashicorp.nomad.task_group_name
+ * This trigger reads the first two to target the restart.
+ */
+class Nomad extends Trigger {
+    /**
+     * Get the Trigger configuration schema.
+     */
+    getConfigurationSchema() {
+        return this.joi.object().keys({
+            address: this.joi
+                .string()
+                .uri({ scheme: ['http', 'https'] })
+                .default('http://127.0.0.1:4646'),
+            token: this.joi.string(),
+            alloclabel: this.joi
+                .string()
+                .default('com.hashicorp.nomad.alloc_id'),
+            tasklabel: this.joi
+                .string()
+                .default('com.hashicorp.nomad.task_name'),
+            alltasks: this.joi.boolean().default(false),
+        });
+    }
+
+    /**
+     * Mask the token when logging configuration.
+     */
+    maskConfiguration(
+        configuration?: ComponentConfiguration,
+    ): ComponentConfiguration {
+        const config = configuration || this.configuration;
+        return {
+            ...config,
+            token: config.token ? '_****_' : undefined,
+        };
+    }
+
+    /**
+     * Restart the Nomad allocation (or a single task within it) backing
+     * this container.
+     */
+    async trigger(container: Container) {
+        const logContainer = this.log.child({
+            container: fullName(container),
+        });
+
+        const allocId = container.labels?.[this.configuration.alloclabel];
+        if (!allocId) {
+            logContainer.warn(
+                `Container has no ${this.configuration.alloclabel} label; not a Nomad-managed container, skipping`,
+            );
+            return;
+        }
+
+        const body: { TaskName?: string; AllTasks?: boolean } = {};
+        if (this.configuration.alltasks) {
+            body.AllTasks = true;
+        } else {
+            const taskName = container.labels?.[this.configuration.tasklabel];
+            if (taskName) {
+                body.TaskName = taskName;
+            }
+        }
+
+        const headers: Record<string, string> = {};
+        if (this.configuration.token) {
+            headers['X-Nomad-Token'] = this.configuration.token;
+        }
+
+        logContainer.info(
+            `Restart Nomad allocation ${allocId}${body.TaskName ? ` (task ${body.TaskName})` : ''}`,
+        );
+        try {
+            await axios.post(
+                `${this.configuration.address}/v1/client/allocation/${allocId}/restart`,
+                body,
+                { headers },
+            );
+            logContainer.info(
+                `Nomad allocation ${allocId} restarted with success`,
+            );
+        } catch (e: any) {
+            logContainer.warn(
+                `Error when restarting Nomad allocation ${allocId} (${e.message})`,
+            );
+            throw e;
+        }
+    }
+
+    /**
+     * Restart the Nomad allocations backing these containers.
+     */
+    async triggerBatch(containers: Container[]) {
+        await Promise.all(
+            containers.map((container) => this.trigger(container)),
+        );
+    }
+}
+
+export default Nomad;

--- a/app/triggers/providers/nomad/Nomad.ts
+++ b/app/triggers/providers/nomad/Nomad.ts
@@ -24,7 +24,14 @@ import { Container, fullName } from '../../../model/container';
  *   - com.hashicorp.nomad.job_name
  *   - com.hashicorp.nomad.job_id
  *   - com.hashicorp.nomad.task_group_name
- * This trigger reads the first two to target the restart.
+ * This trigger reads the first two to target the restart. Not every
+ * Nomad version sets the task_name label (observed missing entirely
+ * on v2.0.4 while alloc_id was present), so as a fallback it also
+ * derives the task name from the container name itself, which Nomad's
+ * Docker driver always builds as "<task_name>-<alloc_id>"
+ * (drivers/docker/driver.go: `fmt.Sprintf("%s-%s", task.Name,
+ * task.AllocID)`) -- stripping the trailing "-<alloc_id>" recovers the
+ * task name reliably without depending on that label existing.
  */
 class Nomad extends Trigger {
     /**
@@ -61,6 +68,23 @@ class Nomad extends Trigger {
     }
 
     /**
+     * Derive the task name for this container, falling back to parsing
+     * it from the container name (Nomad always names containers
+     * "<task_name>-<alloc_id>") when the task_name label is absent.
+     */
+    getTaskName(container: Container, allocId: string): string | undefined {
+        const labeled = container.labels?.[this.configuration.tasklabel];
+        if (labeled) {
+            return labeled;
+        }
+        const suffix = `-${allocId}`;
+        if (container.name && container.name.endsWith(suffix)) {
+            return container.name.slice(0, -suffix.length);
+        }
+        return undefined;
+    }
+
+    /**
      * Restart the Nomad allocation (or a single task within it) backing
      * this container.
      */
@@ -81,9 +105,15 @@ class Nomad extends Trigger {
         if (this.configuration.alltasks) {
             body.AllTasks = true;
         } else {
-            const taskName = container.labels?.[this.configuration.tasklabel];
+            const taskName = this.getTaskName(container, allocId);
             if (taskName) {
                 body.TaskName = taskName;
+            } else {
+                logContainer.warn(
+                    `Could not determine task name for allocation ${allocId} (no ${this.configuration.tasklabel} label and container name did not match "<task>-${allocId}"); ` +
+                        'refusing to restart the whole allocation implicitly -- set alltasks=true if that is what you want',
+                );
+                return;
             }
         }
 

--- a/docs/configuration/triggers/nomad/README.md
+++ b/docs/configuration/triggers/nomad/README.md
@@ -10,6 +10,8 @@ Instead, the `nomad` trigger calls [Nomad's own HTTP API](https://developer.hash
 
 Nomad stamps every container it creates with a fixed set of labels (`com.hashicorp.nomad.alloc_id`, `com.hashicorp.nomad.task_name`, ...). This trigger reads those labels to know which allocation/task to restart, so no extra container labeling is required on your end -- it works out of the box against any container Nomad's Docker driver created.
 
+!> Not every Nomad version sets the `com.hashicorp.nomad.task_name` label (observed missing on Nomad v2.0.4 while `alloc_id` was still present). When it's missing, this trigger falls back to parsing the task name out of the container's own name, since Nomad's Docker driver always names containers `<task_name>-<alloc_id>`. If that also fails to resolve a task name, the trigger logs a warning and does **not** restart anything -- it will never silently fall back to restarting every task in the allocation (which could mean restarting a database sidecar you didn't intend to touch). Set `alltasks=true` explicitly if restarting the whole allocation is actually what you want.
+
 ### Variables
 
 | Env var                                       |    Required    | Description                                                   | Supported values             | Default value when missing      |

--- a/docs/configuration/triggers/nomad/README.md
+++ b/docs/configuration/triggers/nomad/README.md
@@ -1,0 +1,81 @@
+# Nomad
+
+The `nomad` trigger lets you update containers that are managed by [HashiCorp Nomad](https://www.nomadproject.io/) without fighting Nomad for ownership of the container.
+
+Nomad supervises the containers it creates (service registration, health checks, template-rendered secrets, restart policy). The `docker` and `dockercompose` triggers work by stopping, removing and recreating the container directly through the Docker API -- when the container is Nomad-managed, Nomad notices its container disappeared and reconciles independently, which fights whatever the trigger just created and can leave the replacement running without its Nomad-managed configuration.
+
+Instead, the `nomad` trigger calls [Nomad's own HTTP API](https://developer.hashicorp.com/nomad/api-docs/allocations#restart-allocation) to restart the allocation (or a single task within it), letting Nomad's Docker driver handle the actual image pull and container recreation the same way it would for any other restart. The allocation stays under Nomad's normal supervision throughout.
+
+?> For this to actually pick up a new image, the target task must have `force_pull = true` set in its Nomad job spec -- otherwise Nomad's Docker driver reuses whatever image is already cached locally, same as a manual restart would.
+
+Nomad stamps every container it creates with a fixed set of labels (`com.hashicorp.nomad.alloc_id`, `com.hashicorp.nomad.task_name`, ...). This trigger reads those labels to know which allocation/task to restart, so no extra container labeling is required on your end -- it works out of the box against any container Nomad's Docker driver created.
+
+### Variables
+
+| Env var                                       |    Required    | Description                                                   | Supported values             | Default value when missing      |
+| --------------------------------------------- | :------------: | ------------------------------------------------------------- | ---------------------------- | ------------------------------- |
+| `WUD_TRIGGER_NOMAD_{trigger_name}_ADDRESS`    | :white_circle: | The base URL of the Nomad HTTP API                            | Valid http or https endpoint | `http://127.0.0.1:4646`         |
+| `WUD_TRIGGER_NOMAD_{trigger_name}_TOKEN`      | :white_circle: | ACL token sent as `X-Nomad-Token`, if ACLs are enabled        |                              |                                 |
+| `WUD_TRIGGER_NOMAD_{trigger_name}_ALLOCLABEL` | :white_circle: | Container label holding the Nomad allocation ID               |                              | `com.hashicorp.nomad.alloc_id`  |
+| `WUD_TRIGGER_NOMAD_{trigger_name}_TASKLABEL`  | :white_circle: | Container label holding the Nomad task name                   |                              | `com.hashicorp.nomad.task_name` |
+| `WUD_TRIGGER_NOMAD_{trigger_name}_ALLTASKS`   | :white_circle: | Restart every task in the allocation instead of just this one | `true`, `false`              | `false`                         |
+
+?> This trigger also supports the [common configuration variables](configuration/triggers/?id=common-trigger-configuration).
+
+!> Containers with no `com.hashicorp.nomad.alloc_id` label are not managed by Nomad's Docker driver -- the trigger logs a warning and skips them rather than guessing.
+
+### Examples
+
+#### Restart the task backing an update-available container
+
+<!-- tabs:start -->
+
+#### **Docker Compose**
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    ...
+    environment:
+      - WUD_TRIGGER_NOMAD_LOCAL_ADDRESS=http://127.0.0.1:4646
+```
+
+#### **Docker**
+
+```bash
+docker run \
+  -e WUD_TRIGGER_NOMAD_LOCAL_ADDRESS="http://127.0.0.1:4646" \
+  ...
+  getwud/wud
+```
+
+<!-- tabs:end -->
+
+#### Restart against an ACL-enabled Nomad cluster
+
+<!-- tabs:start -->
+
+#### **Docker Compose**
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    ...
+    environment:
+      - WUD_TRIGGER_NOMAD_LOCAL_ADDRESS=https://nomad.internal:4646
+      - WUD_TRIGGER_NOMAD_LOCAL_TOKEN=00000000-0000-0000-0000-000000000000
+```
+
+#### **Docker**
+
+```bash
+docker run \
+  -e WUD_TRIGGER_NOMAD_LOCAL_ADDRESS="https://nomad.internal:4646" \
+  -e WUD_TRIGGER_NOMAD_LOCAL_TOKEN="00000000-0000-0000-0000-000000000000" \
+  ...
+  getwud/wud
+```
+
+<!-- tabs:end -->

--- a/docs/configuration/triggers/sidebar.md
+++ b/docs/configuration/triggers/sidebar.md
@@ -17,6 +17,7 @@
         - [Ifttt](configuration/triggers/ifttt/)
         - [Kafka](configuration/triggers/kafka/)
         - [Mqtt](configuration/triggers/mqtt/)
+        - [Nomad](configuration/triggers/nomad/)
         - [Ntfy](configuration/triggers/ntfy/)
         - [Pushover](configuration/triggers/pushover/)
         - [Rocket.Chat](configuration/triggers/rocketchat/)


### PR DESCRIPTION
## Summary

Adds a `nomad` trigger provider for containers whose lifecycle is managed by [HashiCorp Nomad](https://www.nomadproject.io/) rather than plain Docker/Compose.

### Why not the existing `docker`/`dockercompose` triggers?

Those triggers update a container by stopping it, removing it, and creating a replacement directly through the Docker API. That's the right approach when WUD (or the operator) is the sole owner of the container's lifecycle.

It breaks down when something else is supervising the container -- Nomad included. Nomad's client continuously reconciles the containers backing its allocations against what it expects to be running. If a `docker`/`dockercompose` trigger deletes and recreates a Nomad-managed container out from under it, Nomad sees its tracked container disappear, treats it as a task failure, and reconciles independently -- fighting whatever the trigger just created. The replacement container also isn't part of any allocation Nomad knows about, so it loses Nomad's service registration, health checks, and template-rendered secrets/config.

### What this trigger does instead

It calls [Nomad's own allocation restart API](https://developer.hashicorp.com/nomad/api-docs/allocations#restart-allocation) (`POST /v1/client/allocation/:alloc_id/restart`) and lets Nomad's own Docker driver handle the pull and recreation, the same way it would for any other restart. The allocation stays under Nomad's normal supervision throughout -- no fighting, no orphaned containers.

Nomad stamps every container it creates with a `com.hashicorp.nomad.alloc_id` label (and, on at least some versions, `com.hashicorp.nomad.task_name`) -- see `drivers/docker/driver.go` in the Nomad source. This trigger reads those to target the restart, with a fallback to parsing the task name out of the container's own name (Nomad always names containers `<task_name>-<alloc_id>`) for the Nomad versions/setups where the `task_name` label isn't present -- I observed it missing entirely on Nomad v2.0.4 while `alloc_id` was still set. If neither source yields a task name, the trigger logs a warning and does not restart anything, rather than silently falling back to restarting every task in the allocation (which could mean restarting an unrelated database sidecar in the same task group).

For the restart to actually pick up a new image, the target Nomad task needs `force_pull = true` set in its job spec -- otherwise Nomad's driver reuses whatever's already cached locally, same as any other restart would.

## Testing done

- New unit tests (`Nomad.test.ts`), 11 passing, 100% line coverage on the new file
- `npm run lint`, `npm run build` (`tsc --noEmit`), and the full existing suite (63 suites / 612 tests) all pass with no regressions
- Built the image from this branch and smoke-tested it standalone (registers correctly, respects `AUTO=false` for manual-only execution via the existing "run trigger" UI/API)
- Live end-to-end test against a real 3-node Nomad v2.0.4 cluster: opted a running container into the trigger via `wud.trigger.include`, invoked it through WUD's `/api/triggers/nomad/:name` endpoint, and confirmed via `nomad alloc status` that the *same* allocation ID restarted cleanly (0 → 1 restarts) with no duplicate/orphaned containers, and the service was healthy again afterward

## Docs

Added `docs/configuration/triggers/nomad/README.md` following the existing per-trigger doc convention, and registered it in `docs/configuration/triggers/sidebar.md`.

Happy to adjust naming/config shape if it doesn't match where you'd want this to land -- this is my first contribution here, so let me know if there's anything I should do differently.