### PR TITLE
compose: prefer trigger-level configuration over automatic labels

### DIFF
--- a/app/triggers/providers/dockercompose/Dockercompose.test.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.test.ts
@@ -76,3 +76,51 @@ test('mapCurrentVersionToUpdateVersion should return undefined when no service m
     );
     expect(mapping).toBeUndefined();
 });
+
+test('configured file takes precedence over automatic compose label', () => {
+    dockercompose.configuration = {
+        file: '/some/path/docker-compose.yml',
+        composeFileLabel: 'wud.compose.file',
+    };
+
+    expect(
+        dockercompose.getComposeFileForContainer({
+            labels: {
+                'com.docker.compose.project.config_files':
+                    '/some/path/automatic-compose.yaml',
+            },
+        }),
+    ).toBe('/some/path/docker-compose.yml');
+});
+
+test('per-container WUD label takes precedence over configured file', () => {
+    dockercompose.configuration = {
+        file: '/some/path/docker-compose.yml',
+        composeFileLabel: 'wud.compose.file',
+    };
+
+    expect(
+        dockercompose.getComposeFileForContainer({
+            labels: {
+                'wud.compose.file': '/some/path/label-compose.yml',
+                'com.docker.compose.project.config_files':
+                    '/some/path/automatic-compose.yaml',
+            },
+        }),
+    ).toBe('/some/path/label-compose.yml');
+});
+
+test('automatic compose label is used without explicit configuration', () => {
+    dockercompose.configuration = {
+        composeFileLabel: 'wud.compose.file',
+    };
+
+    expect(
+        dockercompose.getComposeFileForContainer({
+            labels: {
+                'com.docker.compose.project.config_files':
+                    '/some/path/automatic-compose.yaml',
+            },
+        }),
+    ).toBe('/some/path/automatic-compose.yaml');
+});

--- a/app/triggers/providers/dockercompose/Dockercompose.ts
+++ b/app/triggers/providers/dockercompose/Dockercompose.ts
@@ -79,7 +79,12 @@ class Dockercompose extends Docker {
                 : path.resolve(labelValue);
         }
 
-        // Check if container has automatic compose file label
+        // Prefer an explicitly configured trigger-level compose file
+        if (this.configuration.file) {
+            return this.configuration.file;
+        }
+        
+        // Fall back to Docker Compose's automatically generated label
         if (
             container.labels &&
             container.labels['com.docker.compose.project.config_files']
@@ -87,8 +92,7 @@ class Dockercompose extends Docker {
             return container.labels['com.docker.compose.project.config_files'];
         }
 
-        // Fall back to default configuration file
-        return this.configuration.file || null;
+        return null;
     }
 
     /**


### PR DESCRIPTION
Prefer the explicitly configured Docker Compose file over `com.docker.compose.project.config_files` labels.

This enforces that explicit user configuration should override automatically inferred metadata.

Add regression tests for the precedence order.

Fixes #1108 

