### PR TITLE
Mask http auth password and bearer

### DIFF
--- a/app/triggers/providers/http/Http.test.ts
+++ b/app/triggers/providers/http/Http.test.ts
@@ -36,6 +36,28 @@ describe('HTTP Trigger', () => {
         expect(() => http.validateConfiguration(config)).toThrow();
     });
 
+    test('should mask auth password and bearer token', async () => {
+        http.configuration = {
+            url: 'https://example.com/webhook',
+            method: 'POST',
+            auth: {
+                type: 'BASIC',
+                user: 'user',
+                password: 'pass',
+                bearer: 'token',
+            },
+        };
+
+        expect(http.maskConfiguration()).toEqual({
+            ...http.configuration,
+            auth: {
+                ...http.configuration.auth,
+                password: 'p**s',
+                bearer: 't***n',
+            },
+        });
+    });
+
     test('should trigger with container', async () => {
         const { default: axios } = await import('axios');
         axios.mockResolvedValue({ data: {} });
@@ -135,7 +157,7 @@ describe('HTTP Trigger', () => {
             method: 'POST',
             url: 'https://example.com/webhook',
             data: container,
-            proxy: { host: 'proxy', port: '8080' },
+            proxy: { host: 'proxy', port: 8080 },
         });
     });
 });

--- a/app/triggers/providers/http/Http.ts
+++ b/app/triggers/providers/http/Http.ts
@@ -1,7 +1,7 @@
-// @ts-nocheck
-import axios from 'axios';
-
+import axios, { AxiosRequestConfig } from 'axios';
 import Trigger from '../Trigger';
+import { ComponentConfiguration } from '../../../registry/Component';
+import { Container } from '../../../model/container';
 
 /**
  * HTTP Trigger implementation
@@ -9,7 +9,6 @@ import Trigger from '../Trigger';
 class Http extends Trigger {
     /**
      * Get the Trigger configuration schema.
-     * @returns {*}
      */
     getConfigurationSchema() {
         return this.joi.object().keys({
@@ -38,27 +37,33 @@ class Http extends Trigger {
         });
     }
 
+    maskConfiguration(): ComponentConfiguration {
+        return {
+            ...this.configuration,
+            auth: {
+                ...this.configuration.auth,
+                password: Http.mask(this.configuration.auth?.password),
+                bearer: Http.mask(this.configuration.auth?.bearer),
+            },
+        };
+    }
+
     /**
      * Send an HTTP Request with new image version details.
-     *
-     * @param container the container
-     * @returns {Promise<void>}
      */
-    async trigger(container) {
+    async trigger(container: Container) {
         return this.sendHttpRequest(container);
     }
 
     /**
      * Send an HTTP Request with new image versions details.
-     * @param containers
-     * @returns {Promise<*>}
      */
-    async triggerBatch(containers) {
+    async triggerBatch(containers: Container[]) {
         return this.sendHttpRequest(containers);
     }
 
-    async sendHttpRequest(body) {
-        const options = {
+    async sendHttpRequest(body: Container | Container[]) {
+        const options: AxiosRequestConfig = {
             method: this.configuration.method,
             url: this.configuration.url,
         };
@@ -83,7 +88,7 @@ class Http extends Trigger {
             const proxyUrl = new URL(this.configuration.proxy);
             options.proxy = {
                 host: proxyUrl.hostname,
-                port: proxyUrl.port,
+                port: Number.parseInt(proxyUrl.port),
             };
         }
         const response = await axios(options);


### PR DESCRIPTION
I added masking of password and bearer token in the config of a http trigger. 
I also fixed typescript checking and removed the types from jsdoc as it is inferred from typescript itself

Fixes 
- #1131
