### PR TITLE
Add deviceid and devicename to MQTT HASS

### DIFF
--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -41,6 +41,8 @@ beforeEach(async () => {
             hass: {
                 discovery: true,
                 prefix: 'homeassistant',
+                devicename: 'wud',
+                deviceid: 'wud',
             },
         },
         log,
@@ -79,6 +81,41 @@ test('publishDiscoveryMessage must publish a discovery message expected by HA', 
         }),
         { retain: true },
     );
+});
+
+test('publishDiscoveryMessage must use the configured device id and name', async () => {
+    const configuredHass = new Hass({
+        configuration: {
+            topic: 'topic',
+            hass: {
+                discovery: true,
+                prefix: 'homeassistant',
+                deviceid: 'custom-device-id',
+                devicename: 'Custom Device Name',
+            },
+        },
+        log,
+    });
+    await configuredHass.init(mqttClientMock);
+
+    await configuredHass.publishDiscoveryMessage({
+        discoveryTopic: 'my/discovery',
+        stateTopic: 'my/state',
+        kind: 'sensor',
+        name: 'My state',
+    });
+
+    const discoveryPayload = JSON.parse(
+        mqttClientMock.publish.mock.calls[0][1],
+    );
+    expect(discoveryPayload.device).toEqual({
+        identifiers: ['custom-device-id'],
+        manufacturer: 'wud',
+        model: 'custom-device-id',
+        name: 'Custom Device Name',
+        sw_version: 'unknown',
+    });
+    configuredHass.deregister();
 });
 
 test('addContainerSensor must publish sensor discovery message expected by HA', async () => {

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+import mqtt from 'mqtt/*';
 import { getVersion } from '../../../configuration';
 import {
     registerContainerAdded,
@@ -7,44 +7,82 @@ import {
     registerWatcherStart,
     registerWatcherStop,
 } from '../../../event';
+import { Container } from '../../../model/container';
 import * as containerStore from '../../../store/container';
+import Watcher from '../../../watchers/Watcher';
+import {
+    MqqtConfiguration,
+    MqqtConfiguration as MqttConfiguration,
+} from './Mqtt';
+import Logger from 'bunyan';
 
-const HASS_DEVICE_ID = 'wud';
-const HASS_DEVICE_NAME = 'wud';
 const HASS_MANUFACTURER = 'wud';
 const HASS_ENTITY_VALUE_TEMPLATE = '{{ value_json.image_tag_value }}';
 const HASS_LATEST_VERSION_TEMPLATE =
     '{% if value_json.update_kind_kind == "digest" %}{{ value_json.result_digest[:15] }}{% elif value_json.result_tag is defined %}{{ value_json.result_tag }}{% elif value_json.result_digest is defined %}{{ value_json.result_digest[:15] }}{% else %}{{ value_json.image_tag_value }}{% endif %}';
+const HASS_BOOLEAN_OPTIONS = {
+    payload_on: true.toString(),
+    payload_off: false.toString(),
+};
+
+type HassSensorKind = 'sensor' | 'binary_sensor' | 'update';
+type HassSensorValue = string | number | boolean;
+type HassDiscoveryOptions = Record<string, HassSensorValue | undefined>;
+
+interface HassSensor {
+    kind: HassSensorKind;
+    topic: string;
+}
+
+interface HassDiscoverySensor extends HassSensor {
+    name?: string;
+    options?: HassDiscoveryOptions;
+}
+
+interface HassNamedSensor {
+    sensor: HassSensor;
+    name: string;
+    options?: HassDiscoveryOptions;
+}
+
+interface HassSensorUpdate {
+    sensor: HassSensor;
+    value: HassSensorValue;
+}
+
+interface HassDiscoveryMessage {
+    discoveryTopic: string;
+    stateTopic: string;
+    kind: HassSensorKind;
+    name?: string;
+    icon?: string;
+    options?: HassDiscoveryOptions;
+}
 
 /**
  * Get hass entity unique id.
- * @param topic
- * @return {*}
  */
-function getHassEntityId(topic) {
+function getHassEntityId(topic: string) {
     return topic.replace(/\//g, '_');
 }
 
 /**
  * Get HA wud device info.
- * @returns {*}
  */
-function getHaDevice() {
+function getHaDevice(configuration: MqqtConfiguration) {
     return {
-        identifiers: [HASS_DEVICE_ID],
+        identifiers: [configuration.hass.deviceid],
         manufacturer: HASS_MANUFACTURER,
-        model: HASS_DEVICE_ID,
-        name: HASS_DEVICE_NAME,
+        model: configuration.hass.deviceid,
+        name: configuration.hass.devicename,
         sw_version: getVersion(),
     };
 }
 
 /**
  * Sanitize icon to meet hass requirements.
- * @param icon
- * @return {*}
  */
-function sanitizeIcon(icon) {
+function sanitizeIcon(icon: string) {
     return icon
         .replace('mdi-', 'mdi:')
         .replace('fa-', 'fa:')
@@ -55,7 +93,17 @@ function sanitizeIcon(icon) {
 }
 
 class Hass {
-    constructor({ configuration, log }) {
+    log: Logger;
+    client!: mqtt.MqttClient;
+    configuration: MqttConfiguration;
+
+    constructor({
+        configuration,
+        log,
+    }: {
+        configuration: MqttConfiguration;
+        log: Logger;
+    }) {
         this.configuration = configuration;
         this.log = log;
     }
@@ -64,10 +112,8 @@ class Hass {
      * Initialize the component.
      *
      * Set connection status sensor to online and subscribe to container and watcher events.
-     *
-     * @param client - MQTT client
      */
-    async init(client) {
+    async init(client: mqtt.MqttClient) {
         this.client = client;
 
         // Subscribe to container events to sync HA
@@ -80,7 +126,6 @@ class Hass {
         registerContainerRemoved((container) =>
             this.removeContainerSensor(container),
         );
-
         // Subscribe to watcher events to sync HA
         registerWatcherStart((watcher) =>
             this.updateWatcherSensors({ watcher, isRunning: true }),
@@ -90,13 +135,29 @@ class Hass {
         );
     }
 
+    async publishDiscoveryMessages(sensors: HassDiscoverySensor[]) {
+        for (const sensor of sensors) {
+            await this.publishDiscoveryMessage({
+                discoveryTopic: this.getDiscoveryTopic(sensor),
+                stateTopic: sensor.topic,
+                kind: sensor.kind,
+                name: sensor.name,
+                options: sensor.options,
+            });
+        }
+    }
+
+    async updateSensors(sensors: HassSensorUpdate[]) {
+        for (const { sensor, value } of sensors) {
+            await this.updateSensor({ topic: sensor.topic, value });
+        }
+    }
+
     /**
      * Add container sensor.
-     * @param container
-     * @returns {Promise<void>}
      */
-    async addContainerSensor(container) {
-        const containerStateSensor = {
+    async addContainerSensor(container: Container) {
+        const containerStateSensor: HassSensor = {
             kind: 'update',
             topic: this.getContainerStateTopic({ container }),
         };
@@ -105,10 +166,7 @@ class Hass {
         );
         if (this.configuration.hass.discovery) {
             await this.publishDiscoveryMessage({
-                discoveryTopic: this.getDiscoveryTopic({
-                    kind: containerStateSensor.kind,
-                    topic: containerStateSensor.topic,
-                }),
+                discoveryTopic: this.getDiscoveryTopic(containerStateSensor),
                 kind: containerStateSensor.kind,
                 stateTopic: containerStateSensor.topic,
                 name: container.displayName,
@@ -130,11 +188,9 @@ class Hass {
 
     /**
      * Remove container sensor.
-     * @param container
-     * @returns {Promise<void>}
      */
-    async removeContainerSensor(container) {
-        const containerStateSensor = {
+    async removeContainerSensor(container: Container) {
+        const containerStateSensor: HassSensor = {
             kind: 'update',
             topic: this.getContainerStateTopic({ container }),
         };
@@ -143,114 +199,77 @@ class Hass {
         );
         if (this.configuration.hass.discovery) {
             await this.removeSensor({
-                discoveryTopic: this.getDiscoveryTopic({
-                    kind: containerStateSensor.kind,
-                    topic: containerStateSensor.topic,
-                }),
+                discoveryTopic: this.getDiscoveryTopic(containerStateSensor),
             });
         }
         await this.updateContainerSensors(container);
     }
 
-    async updateContainerSensors(container) {
-        // Sensor topics and kinds
-        const totalCountSensor = {
-            kind: 'sensor',
-            topic: `${this.configuration.topic}/total_count`,
+    async updateContainerSensors(container: Container) {
+        const sensors: Record<
+            | 'totalCount'
+            | 'totalUpdateCount'
+            | 'totalUpdateStatus'
+            | 'watcherTotalCount'
+            | 'watcherUpdateCount'
+            | 'watcherUpdateStatus',
+            HassNamedSensor
+        > = {
+            totalCount: {
+                sensor: {
+                    kind: 'sensor',
+                    topic: `${this.configuration.topic}/total_count`,
+                },
+                name: 'Total container count',
+            },
+            totalUpdateCount: {
+                sensor: {
+                    kind: 'sensor',
+                    topic: `${this.configuration.topic}/update_count`,
+                },
+                name: 'Total container update count',
+            },
+            totalUpdateStatus: {
+                sensor: {
+                    kind: 'binary_sensor',
+                    topic: `${this.configuration.topic}/update_status`,
+                },
+                name: 'Total container update status',
+                options: HASS_BOOLEAN_OPTIONS,
+            },
+            watcherTotalCount: {
+                sensor: {
+                    kind: 'sensor',
+                    topic: `${this.configuration.topic}/${container.watcher}/total_count`,
+                },
+                name: `Watcher ${container.watcher} container count`,
+            },
+            watcherUpdateCount: {
+                sensor: {
+                    kind: 'sensor',
+                    topic: `${this.configuration.topic}/${container.watcher}/update_count`,
+                },
+                name: `Watcher ${container.watcher} container update count`,
+            },
+            watcherUpdateStatus: {
+                sensor: {
+                    kind: 'binary_sensor',
+                    topic: `${this.configuration.topic}/${container.watcher}/update_status`,
+                },
+                name: `Watcher ${container.watcher} container update status`,
+                options: HASS_BOOLEAN_OPTIONS,
+            },
         };
-        const totalUpdateCountSensor = {
-            kind: 'sensor',
-            topic: `${this.configuration.topic}/update_count`,
-        };
-        const totalUpdateStatusSensor = {
-            kind: 'binary_sensor',
-            topic: `${this.configuration.topic}/update_status`,
-        };
-        const watcherTotalCountSensor = {
-            kind: 'sensor',
-            topic: `${this.configuration.topic}/${container.watcher}/total_count`,
-        };
-        const watcherUpdateCountSensor = {
-            kind: 'sensor',
-            topic: `${this.configuration.topic}/${container.watcher}/update_count`,
-        };
-        const watcherUpdateStatusSensor = {
-            kind: 'binary_sensor',
-            topic: `${this.configuration.topic}/${container.watcher}/update_status`,
-        };
-
-        // Discovery topics
-        const totalCountDiscoveryTopic = this.getDiscoveryTopic({
-            kind: totalCountSensor.kind,
-            topic: totalCountSensor.topic,
-        });
-        const totalUpdateCountDiscoveryTopic = this.getDiscoveryTopic({
-            kind: totalUpdateCountSensor.kind,
-            topic: totalUpdateCountSensor.topic,
-        });
-        const totalUpdateStatusDiscoveryTopic = this.getDiscoveryTopic({
-            kind: totalUpdateStatusSensor.kind,
-            topic: totalUpdateStatusSensor.topic,
-        });
-        const watcherTotalCountDiscoveryTopic = this.getDiscoveryTopic({
-            kind: watcherTotalCountSensor.kind,
-            topic: watcherTotalCountSensor.topic,
-        });
-        const watcherUpdateCountDiscoveryTopic = this.getDiscoveryTopic({
-            kind: watcherUpdateCountSensor.kind,
-            topic: watcherUpdateCountSensor.topic,
-        });
-        const watcherUpdateStatusDiscoveryTopic = this.getDiscoveryTopic({
-            kind: watcherUpdateStatusSensor.kind,
-            topic: watcherUpdateStatusSensor.topic,
-        });
 
         // Publish discovery messages
         if (this.configuration.hass.discovery) {
-            await this.publishDiscoveryMessage({
-                discoveryTopic: totalCountDiscoveryTopic,
-                stateTopic: totalCountSensor.topic,
-                kind: totalCountSensor.kind,
-                name: 'Total container count',
-            });
-            await this.publishDiscoveryMessage({
-                discoveryTopic: totalUpdateCountDiscoveryTopic,
-                stateTopic: totalUpdateCountSensor.topic,
-                kind: totalUpdateCountSensor.kind,
-                name: 'Total container update count',
-            });
-            await this.publishDiscoveryMessage({
-                discoveryTopic: totalUpdateStatusDiscoveryTopic,
-                stateTopic: totalUpdateStatusSensor.topic,
-                kind: totalUpdateStatusSensor.kind,
-                name: 'Total container update status',
-                options: {
-                    payload_on: true.toString(),
-                    payload_off: false.toString(),
-                },
-            });
-            await this.publishDiscoveryMessage({
-                discoveryTopic: watcherTotalCountDiscoveryTopic,
-                stateTopic: watcherTotalCountSensor.topic,
-                kind: watcherTotalCountSensor.kind,
-                name: `Watcher ${container.watcher} container count`,
-            });
-            await this.publishDiscoveryMessage({
-                discoveryTopic: watcherUpdateCountDiscoveryTopic,
-                stateTopic: watcherUpdateCountSensor.topic,
-                kind: watcherUpdateCountSensor.kind,
-                name: `Watcher ${container.watcher} container update count`,
-            });
-            await this.publishDiscoveryMessage({
-                discoveryTopic: watcherUpdateStatusDiscoveryTopic,
-                stateTopic: watcherUpdateStatusSensor.topic,
-                kind: watcherUpdateStatusSensor.kind,
-                name: `Watcher ${container.watcher} container update status`,
-                options: {
-                    payload_on: true.toString(),
-                    payload_off: false.toString(),
-                },
-            });
+            await this.publishDiscoveryMessages(
+                Object.values(sensors).map(({ sensor, name, options }) => ({
+                    ...sensor,
+                    name,
+                    options,
+                })),
+            );
         }
 
         // Count all containers
@@ -268,66 +287,63 @@ class Hass {
             updateAvailable: true,
         }).length;
 
-        // Publish sensors
-        await this.updateSensor({
-            topic: totalCountSensor.topic,
-            value: totalCount,
-        });
-        await this.updateSensor({
-            topic: totalUpdateCountSensor.topic,
-            value: updateCount,
-        });
-        await this.updateSensor({
-            topic: totalUpdateStatusSensor.topic,
-            value: updateCount > 0,
-        });
-        await this.updateSensor({
-            topic: watcherTotalCountSensor.topic,
-            value: watcherTotalCount,
-        });
-        await this.updateSensor({
-            topic: watcherUpdateCountSensor.topic,
-            value: watcherUpdateCount,
-        });
-        await this.updateSensor({
-            topic: watcherUpdateStatusSensor.topic,
-            value: watcherUpdateCount > 0,
-        });
+        await this.updateSensors([
+            { sensor: sensors.totalCount.sensor, value: totalCount },
+            {
+                sensor: sensors.totalUpdateCount.sensor,
+                value: updateCount,
+            },
+            {
+                sensor: sensors.totalUpdateStatus.sensor,
+                value: updateCount > 0,
+            },
+            {
+                sensor: sensors.watcherTotalCount.sensor,
+                value: watcherTotalCount,
+            },
+            {
+                sensor: sensors.watcherUpdateCount.sensor,
+                value: watcherUpdateCount,
+            },
+            {
+                sensor: sensors.watcherUpdateStatus.sensor,
+                value: watcherUpdateCount > 0,
+            },
+        ]);
 
         // Delete watcher sensors when watcher does not exist anymore
         if (watcherTotalCount === 0 && this.configuration.hass.discovery) {
-            await this.removeSensor({
-                discoveryTopic: watcherTotalCountDiscoveryTopic,
-            });
-            await this.removeSensor({
-                discoveryTopic: watcherUpdateCountDiscoveryTopic,
-            });
-            await this.removeSensor({
-                discoveryTopic: watcherUpdateStatusDiscoveryTopic,
-            });
+            for (const sensor of [
+                sensors.watcherTotalCount,
+                sensors.watcherUpdateCount,
+                sensors.watcherUpdateStatus,
+            ]) {
+                await this.removeSensor({
+                    discoveryTopic: this.getDiscoveryTopic(sensor.sensor),
+                });
+            }
         }
     }
 
-    async updateWatcherSensors({ watcher, isRunning }) {
-        const watcherStatusSensor = {
+    async updateWatcherSensors({
+        watcher,
+        isRunning,
+    }: {
+        watcher: Pick<Watcher, 'name'>;
+        isRunning: boolean;
+    }) {
+        const watcherStatusSensor: HassSensor = {
             kind: 'binary_sensor',
             topic: `${this.configuration.topic}/${watcher.name}/running`,
         };
-        const watcherStatusDiscoveryTopic = this.getDiscoveryTopic({
-            kind: watcherStatusSensor.kind,
-            topic: watcherStatusSensor.topic,
-        });
 
         // Publish discovery messages
         if (this.configuration.hass.discovery) {
             await this.publishDiscoveryMessage({
-                discoveryTopic: watcherStatusDiscoveryTopic,
+                discoveryTopic: this.getDiscoveryTopic(watcherStatusSensor),
                 stateTopic: watcherStatusSensor.topic,
                 kind: watcherStatusSensor.kind,
-                options: {
-                    payload_on: true.toString(),
-                    payload_off: false.toString(),
-                },
+                options: HASS_BOOLEAN_OPTIONS,
                 name: `Watcher ${watcher.name} running status`,
             });
         }
@@ -341,13 +357,6 @@ class Hass {
 
     /**
      * Publish a discovery message.
-     * @param discoveryTopic
-     * @param stateTopic
-     * @param kind
-     * @param name
-     * @param icon
-     * @param options
-     * @returns {Promise<*>}
      */
     async publishDiscoveryMessage({
         discoveryTopic,
@@ -356,7 +365,7 @@ class Hass {
         name,
         icon,
         options = {},
-    }) {
+    }: HassDiscoveryMessage) {
         const entityId = getHassEntityId(stateTopic);
         return this.client.publish(
             discoveryTopic,
@@ -364,7 +373,7 @@ class Hass {
                 unique_id: entityId,
                 default_entity_id: `${kind}.${entityId}`,
                 name: name || entityId,
-                device: getHaDevice(),
+                device: getHaDevice(this.configuration),
                 icon: icon || sanitizeIcon('mdi:docker'),
                 entity_picture:
                     'https://github.com/getwud/wud/raw/main/docs/assets/wud-logo-256.png',
@@ -379,10 +388,8 @@ class Hass {
 
     /**
      * Publish an empty message to discovery topic to remove the sensor.
-     * @param discoveryTopic
-     * @returns {Promise<*>}
      */
-    async removeSensor({ discoveryTopic }) {
+    async removeSensor({ discoveryTopic }: { discoveryTopic: string }) {
         return this.client.publish(discoveryTopic, JSON.stringify({}), {
             retain: true,
         });
@@ -390,37 +397,35 @@ class Hass {
 
     /**
      * Publish a sensor message.
-     * @param topic
-     * @param value
-     * @returns {Promise<*>}
      */
-    async updateSensor({ topic, value }) {
+    async updateSensor({
+        topic,
+        value,
+    }: {
+        topic: string;
+        value: HassSensorValue;
+    }) {
         return this.client.publish(topic, value.toString(), { retain: true });
     }
 
     /**
      * Get container state topic.
-     * @param container
-     * @return {string}
      */
-    getContainerStateTopic({ container }) {
+    getContainerStateTopic({ container }: { container: Container }) {
         const containerName = container.name.replace(/\./g, '-');
         return `${this.configuration.topic}/${container.watcher}/${containerName}`;
     }
 
     /**
      * Get discovery topic for an entity topic.
-     * @param kind
-     * @param topic
-     * @returns {string}
      */
-    getDiscoveryTopic({ kind, topic }) {
+    getDiscoveryTopic({ kind, topic }: HassSensor) {
         return `${this.configuration.hass.prefix}/${kind}/${getHassEntityId(topic)}/config`;
     }
 
     /**
      * Get WUD state topic.
-     * @return {string} WUD state topic
+     * @return WUD state topic
      */
     getStateTopic() {
         return `${this.configuration.topic}/status`;
@@ -431,7 +436,7 @@ class Hass {
      *
      * Allows MQTT broker to set WUD status to offline when WUD disconnects unexpectedly.
      *
-     * @returns {Object} The will message object with topic, payload, and retain properties
+     * @returns The will message object with topic, payload, and retain properties
      */
     getWill() {
         return {
@@ -443,18 +448,17 @@ class Hass {
 
     /**
      * Update the connection status sensor.
-     * @param connected - Whether WUD is currently connected to the MQTT broker
+     * @param connected Whether WUD is currently connected to the MQTT broker
      */
     async updateConnectionStatusSensor(connected: boolean) {
-        const connectionStatusSensor = {
+        const connectionStatusSensor: HassSensor = {
             kind: 'binary_sensor',
             topic: this.getStateTopic(),
         };
 
-        const connectionStatusDiscoveryTopic = this.getDiscoveryTopic({
-            kind: connectionStatusSensor.kind,
-            topic: connectionStatusSensor.topic,
-        });
+        const connectionStatusDiscoveryTopic = this.getDiscoveryTopic(
+            connectionStatusSensor,
+        );
 
         // Publish discovery message
         if (this.configuration.hass.discovery) {

--- a/app/triggers/providers/mqtt/Mqtt.test.ts
+++ b/app/triggers/providers/mqtt/Mqtt.test.ts
@@ -1,4 +1,4 @@
-// @ts-nocheck
+//@ts-nocheck
 import { ValidationError } from 'joi';
 import mqttClient from 'mqtt';
 import log from '../../../log';
@@ -18,6 +18,8 @@ const configurationValid = {
         discovery: false,
         enabled: false,
         prefix: 'homeassistant',
+        deviceid: 'wud',
+        devicename: 'wud',
     },
     tls: {
         clientkey: undefined,

--- a/app/triggers/providers/mqtt/Mqtt.ts
+++ b/app/triggers/providers/mqtt/Mqtt.ts
@@ -1,13 +1,12 @@
-// @ts-nocheck
 import fs from 'fs/promises';
-import mqtt from 'mqtt';
-import Trigger from '../Trigger';
+import mqtt, { IClientOptions, MqttClient } from 'mqtt';
+import Trigger, { TriggerConfiguration } from '../Trigger';
 import Hass from './Hass';
 import {
     registerContainerAdded,
     registerContainerUpdated,
 } from '../../../event';
-import { flatten } from '../../../model/container';
+import { Container, flatten } from '../../../model/container';
 
 const containerDefaultTopic = 'wud/container';
 const hassDefaultPrefix = 'homeassistant';
@@ -21,6 +20,27 @@ const hassDefaultPrefix = 'homeassistant';
 function getContainerTopic({ baseTopic, container }) {
     const containerName = container.name.replace(/\./g, '-');
     return `${baseTopic}/${container.watcher}/${containerName}`;
+}
+
+export interface MqqtConfiguration extends TriggerConfiguration {
+    url: string;
+    topic: string;
+    clientid: string;
+    user: string;
+    password: string;
+    hass: {
+        enabled: boolean;
+        prefix: string;
+        discovery: boolean;
+        deviceid: string;
+        devicename: string;
+    };
+    tls: {
+        clientkey: string;
+        clientcert: string;
+        cachain: string;
+        rejectunauthorized: boolean;
+    };
 }
 
 /**
@@ -53,11 +73,15 @@ class Mqtt extends Trigger {
                         is: true,
                         then: this.joi.boolean().default(true),
                     }),
+                    deviceid: this.joi.string().default('wud'),
+                    devicename: this.joi.string().default('wud'),
                 })
                 .default({
                     enabled: false,
                     prefix: hassDefaultPrefix,
                     discovery: false,
+                    deviceid: 'wud',
+                    devicename: 'wud',
                 }),
             tls: this.joi
                 .object({
@@ -75,6 +99,8 @@ class Mqtt extends Trigger {
         });
     }
 
+    declare configuration: MqqtConfiguration;
+
     /**
      * Sanitize sensitive data
      * @returns {*}
@@ -90,6 +116,9 @@ class Mqtt extends Trigger {
         };
     }
 
+    private hass: Hass;
+    private client: MqttClient;
+
     async initTrigger() {
         // Enforce simple mode
         this.configuration.mode = 'simple';
@@ -102,7 +131,7 @@ class Mqtt extends Trigger {
         }
 
         // Set MQTT connection options and create client
-        const options = {
+        const options: IClientOptions = {
             clientId: this.configuration.clientid,
         };
         if (this.configuration.user) {
@@ -150,7 +179,7 @@ class Mqtt extends Trigger {
             );
         });
 
-        this.client.on('error', (error) => {
+        this.client.on('error', (error: mqtt.ErrorWithReasonCode) => {
             this.log.debug(`MQTT client error ${error.code}`);
         });
 
@@ -171,16 +200,15 @@ class Mqtt extends Trigger {
      * Send an MQTT message with new image version details.
      *
      * @param container the container
-     * @returns {Promise}
      */
-    async trigger(container) {
+    async trigger(container: Container) {
         const containerTopic = getContainerTopic({
             baseTopic: this.configuration.topic,
             container,
         });
 
         this.log.debug(`Publish container result to ${containerTopic}`);
-        return this.client.publish(
+        this.client.publish(
             containerTopic,
             JSON.stringify(flatten(container)),
             {
@@ -191,7 +219,6 @@ class Mqtt extends Trigger {
 
     /**
      * Mqtt trigger does not support batch mode.
-     * @returns {Promise<void>}
      */
 
     async triggerBatch() {
@@ -200,14 +227,12 @@ class Mqtt extends Trigger {
 
     /**
      * Deregister the component
-     * @returns {Promise<void>}
      */
-
     async deregisterComponent(): Promise<void> {
         if (this.hass) {
             this.hass.updateConnectionStatusSensor(false);
         }
-        return this.client.end(true);
+        this.client.end(true);
     }
 }
 

--- a/docs/configuration/triggers/mqtt/README.md
+++ b/docs/configuration/triggers/mqtt/README.md
@@ -15,6 +15,8 @@ The `mqtt` trigger lets you send container update notifications to an MQTT broke
 | `WUD_TRIGGER_MQTT_{trigger_name}_HASS_ENABLED`           | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration and deliver additional topics   | `true`, `false`                     | `false`                    |
 | `WUD_TRIGGER_MQTT_{trigger_name}_HASS_DISCOVERY`         | :white_circle: | Enable [Home-assistant](https://www.home-assistant.io/) integration including discovery             | `true`, `false`                     | `false`                    |
 | `WUD_TRIGGER_MQTT_{trigger_name}_HASS_PREFIX`            | :white_circle: | Base topic for hass entity discovery                                                                |                                     | `homeassistant`            |
+| `WUD_TRIGGER_MQTT_{trigger_name}_HASS_DEVICEID`           | :white_circle: | The Home Assistant device identifier                                                               |                                     | `wud`                      |
+| `WUD_TRIGGER_MQTT_{trigger_name}_HASS_DEVICENAME`         | :white_circle: | The Home Assistant device name                                                                     |                                     | `wud`                      |
 | `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CACHAIN`            | :white_circle: | The path to the file containing the server CA chain (when TLS with a private Certificate Authority) | Any valid file path                 |                            |
 | `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTCERT`         | :white_circle: | The path to the file containing the client public certificate (when TLS mutual authzentication)     | Any valid file path                 |                            |
 | `WUD_TRIGGER_MQTT_{trigger_name}_TLS_CLIENTKEY`          | :white_circle: | The path to the file containing the client private key (when TLS mutual authzentication)            | Any valid file path                 |                            |
@@ -135,6 +137,9 @@ docker run \
 ![logo](hass.png)
 
 WUD can be easily integrated into [Home-Assistant](https://www.home-assistant.io/) using [MQTT Discovery](https://www.home-assistant.io/docs/mqtt/discovery/).
+
+By default, WUD registers itself as the Home Assistant device `wud`. Use `HASS_DEVICEID` and
+`HASS_DEVICENAME` to customize the device identifier and display name.
 
 <!-- tabs:start -->
 #### **Docker Compose**


### PR DESCRIPTION
I added device id and device name as optional configurable options, it still defaults to wud

I don't use hass or mqtt locally, but the changes are minimal, however I did rework the whole hass file implementation to reuse code instead of having everything duplicated, so it should be easier to maintain. The tests back up that nothing changed. 
As usual I also added typescript typings.

Added a feature to add
- #615
