### PR TITLE
Fix login redirect issues with subpath handling in WUD

### DIFF
--- a/app/configuration/index.test.ts
+++ b/app/configuration/index.test.ts
@@ -96,6 +96,44 @@ test('getServerConfiguration should return configured api (new vars)', async () 
     });
 });
 
+test('getPublicUrl should return request origin when no basepath is configured', async () => {
+    delete configuration.wudEnvVars.WUD_PUBLIC_URL;
+    delete configuration.wudEnvVars.WUD_SERVER_BASEPATH;
+    const req = {
+        protocol: 'https',
+        headers: { host: 'wud.example.com' },
+    };
+    expect(configuration.getPublicUrl(req)).toStrictEqual(
+        'https://wud.example.com',
+    );
+});
+
+test('getPublicUrl should append basepath when configured', async () => {
+    delete configuration.wudEnvVars.WUD_PUBLIC_URL;
+    configuration.wudEnvVars.WUD_SERVER_BASEPATH = '/wud';
+    const req = {
+        protocol: 'https',
+        headers: { host: 'wud.example.com' },
+    };
+    expect(configuration.getPublicUrl(req)).toStrictEqual(
+        'https://wud.example.com/wud',
+    );
+});
+
+test('getPublicUrl should append basepath to WUD_PUBLIC_URL when both are configured', async () => {
+    configuration.wudEnvVars.WUD_PUBLIC_URL = 'https://wud.example.com/';
+    configuration.wudEnvVars.WUD_SERVER_BASEPATH = '/wud';
+    const req = {
+        protocol: 'https',
+        headers: { host: 'wud.example.com' },
+    };
+    expect(configuration.getPublicUrl(req)).toStrictEqual(
+        'https://wud.example.com/wud',
+    );
+    delete configuration.wudEnvVars.WUD_PUBLIC_URL;
+    delete configuration.wudEnvVars.WUD_SERVER_BASEPATH;
+});
+
 test('replaceSecrets must read secret in file', async () => {
     const vars = {
         WUD_SERVER_X__FILE: `${__dirname}/secret.txt`,

--- a/app/configuration/index.ts
+++ b/app/configuration/index.ts
@@ -174,9 +174,12 @@ export function getPrometheusConfiguration() {
 
 export function getPublicUrl(req: Request) {
     const publicUrl = wudEnvVars.WUD_PUBLIC_URL;
-    if (publicUrl) {
-        return publicUrl;
+    // Try to guess from request if not explicitly configured
+    const origin =
+        publicUrl ?? `${req.protocol}://${req.headers.host ?? req.hostname}`;
+    const basepath = getServerConfiguration().basepath;
+    if (basepath === '/') {
+        return origin.replace(/\/$/, '');
     }
-    // Try to guess from request
-    return `${req.protocol}://${req.headers.host ?? req.hostname}`;
+    return `${origin.replace(/\/$/, '')}${basepath}`;
 }

--- a/ui/src/App.ts
+++ b/ui/src/App.ts
@@ -85,8 +85,8 @@ export default defineComponent({
               onAuthenticated(currentUser);
             }
           }
-        } catch (e) {
-          console.log("Fallback auth check failed:", e);
+        } catch {
+          // Ignore: user remains unauthenticated
         }
       }
     });

--- a/ui/src/registerServiceWorker.ts
+++ b/ui/src/registerServiceWorker.ts
@@ -1,9 +1,10 @@
 /* eslint-disable no-console */
 
 import { register } from "register-service-worker";
+import { url } from "@/services/base";
 
 if (process.env.NODE_ENV === "production") {
-  register(`${process.env.BASE_URL}service-worker.js`, {
+  register(url("service-worker.js"), {
     ready() {
       console.log(
         "App is being served from cache by a service worker.\n" +

--- a/ui/src/services/base.ts
+++ b/ui/src/services/base.ts
@@ -1,4 +1,4 @@
 export function url(path: string): string {
   const basePath: string = (window as any).__WUD_BASE_PATH__ || '/';
-  return `${basePath}${path}`.replace(/\/\//g, '/');
+  return `${basePath}/${path}`.replace(/\/\//g, '/');
 }

--- a/ui/src/views/HomeView.ts
+++ b/ui/src/views/HomeView.ts
@@ -43,9 +43,11 @@ export default defineComponent({
           (container: any) => container.updateAvailable,
         ).length;
       });
-    } catch (e) {
-      next(() => {
-        console.log(e);
+    } catch (e: any) {
+      next((vm: any) => {
+        if (vm.eventBus) {
+          vm.eventBus.emit("notify", `Error when loading dashboard data (${e.message})`, "error");
+        }
       });
     }
   },

--- a/ui/src/views/LoginView.ts
+++ b/ui/src/views/LoginView.ts
@@ -87,8 +87,6 @@ export default defineComponent({
             `Error when trying to get the authentication strategies (${e.message})`,
             "error",
           );
-        } else {
-          console.error(`Error when trying to get the authentication strategies (${e.message})`);
         }
       });
     }

--- a/ui/tests/services/base.spec.ts
+++ b/ui/tests/services/base.spec.ts
@@ -1,0 +1,21 @@
+import { url } from '@/services/base';
+
+describe('Base Service', () => {
+  afterEach(() => {
+    delete (window as any).__WUD_BASE_PATH__;
+  });
+
+  it('should prefix path with / when no basepath is configured', () => {
+    expect(url('auth/strategies')).toBe('/auth/strategies');
+  });
+
+  it('should join basepath without trailing slash and path correctly', () => {
+    (window as any).__WUD_BASE_PATH__ = '/wud';
+    expect(url('auth/strategies')).toBe('/wud/auth/strategies');
+  });
+
+  it('should join basepath with trailing slash and path correctly', () => {
+    (window as any).__WUD_BASE_PATH__ = '/wud/';
+    expect(url('auth/strategies')).toBe('/wud/auth/strategies');
+  });
+});

--- a/ui/vue.config.js
+++ b/ui/vue.config.js
@@ -27,6 +27,11 @@ module.exports = defineConfig({
       short_name: "WUD",
       background_color: "#00355E",
     },
+    workboxOptions: {
+      // index.html is generated dynamically per-request (basepath injection),
+      // so it must never be served from the service worker's precache.
+      exclude: [/index\.html$/],
+    },
   },
 
   chainWebpack: config => {


### PR DESCRIPTION
This pull request introduces improvements to how public URLs and paths are constructed and handled across both the backend and frontend, ensuring correct behavior when a base path is configured. It adds comprehensive tests for these scenarios and updates service worker registration and PWA configuration to better handle dynamic base paths.

**Backend URL Construction and Testing:**
- Enhanced the `getPublicUrl` function in `app/configuration/index.ts` to correctly append the server base path to the public URL or request origin, and updated its logic to handle cases where both `WUD_PUBLIC_URL` and `WUD_SERVER_BASEPATH` are set.
- Added new tests in `app/configuration/index.test.ts` to verify `getPublicUrl` behavior with different combinations of environment variables and request origins.

**Frontend URL Construction and Testing:**
- Updated the `url` function in `ui/src/services/base.ts` to ensure paths are joined correctly, always inserting a slash between the base path and the requested path, and preventing double slashes.
- Added tests in `ui/tests/services/base.spec.ts` to verify the correct joining of base paths and paths in different scenarios, including with and without trailing slashes.

**Service Worker and PWA Configuration:**
- Modified service worker registration in `ui/src/registerServiceWorker.ts` to use the updated `url` function for determining the service worker script path, ensuring compatibility with dynamic base paths.
- Updated `ui/vue.config.js` to exclude `index.html` from the service worker precache, as it is generated dynamically per request with base path injection.