### PR TITLE
fix(http): mask sensitive trigger configuration

### DIFF
--- a/app/triggers/providers/http/Http.test.ts
+++ b/app/triggers/providers/http/Http.test.ts
@@ -36,6 +36,50 @@ describe('HTTP Trigger', () => {
         expect(() => http.validateConfiguration(config)).toThrow();
     });
 
+    test('should mask sensitive configuration data', async () => {
+        http.configuration = {
+            url: 'https://example.com/hooks/http-url-canary',
+            auth: {
+                type: 'BEARER',
+                user: 'http-user-canary',
+                password: 'http-password-canary',
+                bearer: 'http-bearer-canary',
+            },
+            proxy: 'https://http-proxy-canary@example.com:8080',
+        };
+
+        const masked = http.maskConfiguration();
+
+        expect(masked).toEqual({
+            url: Http.mask(http.configuration.url),
+            auth: {
+                type: 'BEARER',
+                user: Http.mask(http.configuration.auth.user),
+                password: Http.mask(http.configuration.auth.password),
+                bearer: Http.mask(http.configuration.auth.bearer),
+            },
+            proxy: Http.mask(http.configuration.proxy),
+        });
+        const serialized = JSON.stringify(masked);
+        expect(serialized).not.toContain('http-url-canary');
+        expect(serialized).not.toContain('http-user-canary');
+        expect(serialized).not.toContain('http-password-canary');
+        expect(serialized).not.toContain('http-bearer-canary');
+        expect(serialized).not.toContain('http-proxy-canary');
+    });
+
+    test('should mask configuration without optional authentication', async () => {
+        http.configuration = {
+            url: 'https://example.com/hooks/secret',
+        };
+
+        expect(http.maskConfiguration()).toEqual({
+            url: Http.mask(http.configuration.url),
+            auth: undefined,
+            proxy: undefined,
+        });
+    });
+
     test('should trigger with container', async () => {
         const { default: axios } = await import('axios');
         axios.mockResolvedValue({ data: {} });

--- a/app/triggers/providers/http/Http.ts
+++ b/app/triggers/providers/http/Http.ts
@@ -39,6 +39,28 @@ class Http extends Trigger {
     }
 
     /**
+     * Sanitize sensitive data.
+     *
+     * HTTP endpoints and proxy URLs can embed credentials in addition to the
+     * explicit authentication fields, so mask every potentially secret value.
+     */
+    maskConfiguration() {
+        return {
+            ...this.configuration,
+            url: Http.mask(this.configuration.url),
+            auth: this.configuration.auth
+                ? {
+                      ...this.configuration.auth,
+                      user: Http.mask(this.configuration.auth.user),
+                      password: Http.mask(this.configuration.auth.password),
+                      bearer: Http.mask(this.configuration.auth.bearer),
+                  }
+                : undefined,
+            proxy: Http.mask(this.configuration.proxy),
+        };
+    }
+
+    /**
      * Send an HTTP Request with new image version details.
      *
      * @param container the container


### PR DESCRIPTION
## Summary

- mask HTTP trigger URLs and proxy values before component registration logs them
- mask nested Basic and Bearer authentication fields
- add regression coverage for configurations with and without optional authentication

## Why

`Component.register()` logs each provider's configuration at INFO after calling `maskConfiguration()`. The base implementation returns the configuration unchanged, and the HTTP trigger did not override it.

Because `__FILE` values are resolved before component registration, an HTTP trigger configured with a file-backed password or bearer token could therefore write the resolved credential to the startup log. URLs and proxy values may also contain embedded credentials.

This change follows the masking pattern already used by other trigger and registry providers.

## Verification

- `npx jest triggers/providers/http/Http.test.ts --runInBand`
- `npx eslint triggers/providers/http/Http.ts triggers/providers/http/Http.test.ts` (existing `@ts-nocheck` warnings only)
- `npx tsc --noEmit`
- full app test suite: 62 suites / 605 tests passed
