### PR TITLE
Preserve update results across registry errors

### DIFF
--- a/app/triggers/providers/Trigger.test.ts
+++ b/app/triggers/providers/Trigger.test.ts
@@ -105,6 +105,15 @@ const handleContainerReportTestCases = [
         updateAvailable: false,
         semverDiff: 'major',
     },
+    {
+        shouldTrigger: false,
+        threshold: 'all',
+        once: false,
+        changed: false,
+        updateAvailable: true,
+        semverDiff: 'major',
+        error: { message: 'Registry error' },
+    },
 ];
 
 test.each(handleContainerReportTestCases)(
@@ -127,6 +136,7 @@ test.each(handleContainerReportTestCases)(
                     kind: 'tag',
                     semverDiff: item.semverDiff,
                 },
+                ...(item.error && { error: item.error }),
             },
         });
         if (item.shouldTrigger) {
@@ -205,6 +215,15 @@ const handleContainerReportsTestCases = [
         updateAvailable: false,
         semverDiff: 'major',
     },
+    {
+        shouldTrigger: false,
+        threshold: 'all',
+        once: false,
+        changed: false,
+        updateAvailable: true,
+        semverDiff: 'major',
+        error: { message: 'Registry error' },
+    },
 ];
 
 test.each(handleContainerReportsTestCases)(
@@ -228,6 +247,7 @@ test.each(handleContainerReportsTestCases)(
                         kind: 'tag',
                         semverDiff: item.semverDiff,
                     },
+                    ...(item.error && { error: item.error }),
                 },
             },
         ]);

--- a/app/triggers/providers/Trigger.ts
+++ b/app/triggers/providers/Trigger.ts
@@ -162,6 +162,7 @@ class Trigger extends Component {
         // Filter on changed containers with update available and passing trigger threshold
         if (
             (containerReport.changed || !this.configuration.once) &&
+            containerReport.container.error === undefined &&
             containerReport.container.updateAvailable
         ) {
             const logContainer =
@@ -221,6 +222,7 @@ class Trigger extends Component {
                 )
                 .filter(
                     (containerReport) =>
+                        containerReport.container.error === undefined &&
                         containerReport.container.updateAvailable,
                 )
                 .filter((containerReport) =>

--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -482,24 +482,38 @@ describe('Docker Watcher', () => {
             expect(event.emitContainerReport).toHaveBeenCalled();
         });
 
-        test('should handle container processing error', async () => {
-            const container = { id: 'test123', name: 'test' };
+        test('should preserve previous result across errors and replace it on recovery', async () => {
+            const previousResult = { tag: '2.0.0' };
+            const container = {
+                id: 'test123',
+                name: 'test',
+                result: previousResult,
+            };
             const mockLogChild = { warn: jest.fn(), debug: jest.fn() };
             const mockLog = { child: jest.fn().mockReturnValue(mockLogChild) };
             docker.log = mockLog;
             docker.findNewVersion = jest
                 .fn()
-                .mockRejectedValue(new Error('Registry error'));
+                .mockRejectedValueOnce(new Error('Registry error'))
+                .mockRejectedValueOnce(new Error('Registry error'))
+                .mockResolvedValueOnce({ tag: '3.0.0' });
             docker.mapContainerToContainerReport = jest
                 .fn()
                 .mockReturnValue({ container, changed: false });
 
             await docker.watchContainer(container);
-
-            expect(mockLogChild.warn).toHaveBeenCalledWith(
-                expect.stringContaining('Registry error'),
-            );
+            expect(container.result).toBe(previousResult);
             expect(container.error).toEqual({ message: 'Registry error' });
+
+            await docker.watchContainer(container);
+            expect(container.result).toBe(previousResult);
+            expect(container.error).toEqual({ message: 'Registry error' });
+
+            await docker.watchContainer(container);
+
+            expect(mockLogChild.warn).toHaveBeenCalledTimes(2);
+            expect(container.result).toEqual({ tag: '3.0.0' });
+            expect(container.error).toBeUndefined();
         });
     });
 
@@ -892,11 +906,15 @@ describe('Docker Watcher', () => {
     });
 
     describe('Container Details', () => {
-        test('should return existing container from store', async () => {
+        test('should return existing errored container from store', async () => {
             await docker.register('watcher', 'docker', 'test', {});
             const mockLog = { debug: jest.fn() };
             docker.log = mockLog;
-            const existingContainer = { id: '123', error: undefined };
+            const existingContainer = {
+                id: '123',
+                result: { tag: '2.0.0' },
+                error: { message: 'Registry error' },
+            };
             storeContainer.getContainer.mockReturnValue(existingContainer);
 
             const result = await docker.addImageDetailsToContainer({
@@ -904,6 +922,7 @@ describe('Docker Watcher', () => {
             });
 
             expect(result).toBe(existingContainer);
+            expect(mockDockerApi.getImage).not.toHaveBeenCalled();
         });
 
         test('should add image details to new container', async () => {

--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -482,38 +482,123 @@ describe('Docker Watcher', () => {
             expect(event.emitContainerReport).toHaveBeenCalled();
         });
 
-        test('should preserve previous result across errors and replace it on recovery', async () => {
+        test('should persist the previous result across errors and replace it on recovery', async () => {
             const previousResult = { tag: '2.0.0' };
-            const container = {
+            let persistedContainer = {
                 id: 'test123',
                 name: 'test',
+                status: 'running',
+                watcher: 'docker.test',
+                image: {
+                    id: 'image123',
+                    registry: { name: 'ghcr.old', url: 'ghcr.io' },
+                    name: 'library/nginx',
+                    tag: { value: '1.0.0', semver: true },
+                    digest: { watch: false },
+                    architecture: 'amd64',
+                    os: 'linux',
+                },
                 result: previousResult,
             };
             const mockLogChild = { warn: jest.fn(), debug: jest.fn() };
-            const mockLog = { child: jest.fn().mockReturnValue(mockLogChild) };
+            const mockLog = {
+                child: jest.fn().mockReturnValue(mockLogChild),
+                debug: jest.fn(),
+            };
+            await docker.register('watcher', 'docker', 'test', {});
             docker.log = mockLog;
+
+            const asModel = (container) => ({
+                ...container,
+                result: container.result && { ...container.result },
+                error: container.error && { ...container.error },
+                updateAvailable:
+                    container.result?.tag !== container.image.tag.value,
+                resultChanged: (otherContainer) =>
+                    container.result?.tag !== otherContainer?.result?.tag,
+            });
+            storeContainer.getContainer.mockImplementation(() =>
+                asModel(persistedContainer),
+            );
+            storeContainer.updateContainer.mockImplementation((container) => {
+                persistedContainer = asModel(container);
+                return asModel(persistedContainer);
+            });
+
+            mockImage.inspect.mockResolvedValue({
+                Id: 'image123',
+                Architecture: 'amd64',
+                Os: 'linux',
+                Created: '2023-01-01',
+                RepoDigests: ['ghcr.io/library/nginx@sha256:abc123'],
+            });
+            mockParse.mockReturnValue({
+                domain: 'ghcr.io',
+                path: 'library/nginx',
+                tag: '1.0.0',
+            });
+            const mockRegistry = {
+                normalizeImage: jest.fn((image) => image),
+                getId: () => 'ghcr.new',
+                match: () => true,
+                shouldWatchDigest: jest.fn(() => false),
+            };
+            registry.getState.mockReturnValue({
+                registry: { ghcr: mockRegistry },
+            });
+            docker.normalizeContainer = jest.fn((container) =>
+                asModel({
+                    ...container,
+                    image: {
+                        ...container.image,
+                        registry: {
+                            ...container.image.registry,
+                            name: mockRegistry.getId(),
+                        },
+                    },
+                }),
+            );
             docker.findNewVersion = jest
                 .fn()
                 .mockRejectedValueOnce(new Error('Registry error'))
                 .mockRejectedValueOnce(new Error('Registry error'))
                 .mockResolvedValueOnce({ tag: '3.0.0' });
-            docker.mapContainerToContainerReport = jest
-                .fn()
-                .mockReturnValue({ container, changed: false });
 
-            await docker.watchContainer(container);
-            expect(container.result).toBe(previousResult);
-            expect(container.error).toEqual({ message: 'Registry error' });
+            const runningContainer = {
+                Id: 'test123',
+                Image: 'ghcr.io/library/nginx:1.0.0',
+                Names: ['/test'],
+                State: 'running',
+                Labels: {},
+            };
+            const scan = async () => {
+                const container =
+                    await docker.addImageDetailsToContainer(runningContainer);
+                return docker.watchContainer(container);
+            };
 
-            await docker.watchContainer(container);
-            expect(container.result).toBe(previousResult);
-            expect(container.error).toEqual({ message: 'Registry error' });
+            const firstReport = await scan();
+            expect(firstReport.container.result).toEqual(previousResult);
+            expect(firstReport.container.error).toEqual({
+                message: 'Registry error',
+            });
+            expect(firstReport.changed).toBe(false);
 
-            await docker.watchContainer(container);
+            const secondReport = await scan();
+            expect(secondReport.container.result).toEqual(previousResult);
+            expect(secondReport.container.error).toEqual({
+                message: 'Registry error',
+            });
+            expect(secondReport.container.image.registry.name).toBe('ghcr.new');
+            expect(secondReport.changed).toBe(false);
+
+            const recoveredReport = await scan();
 
             expect(mockLogChild.warn).toHaveBeenCalledTimes(2);
-            expect(container.result).toEqual({ tag: '3.0.0' });
-            expect(container.error).toBeUndefined();
+            expect(mockImage.inspect).toHaveBeenCalledTimes(2);
+            expect(recoveredReport.container.result).toEqual({ tag: '3.0.0' });
+            expect(recoveredReport.container.error).toBeUndefined();
+            expect(recoveredReport.changed).toBe(true);
         });
     });
 
@@ -906,14 +991,14 @@ describe('Docker Watcher', () => {
     });
 
     describe('Container Details', () => {
-        test('should return existing errored container from store', async () => {
+        test('should return existing successful container from store', async () => {
             await docker.register('watcher', 'docker', 'test', {});
             const mockLog = { debug: jest.fn() };
             docker.log = mockLog;
             const existingContainer = {
                 id: '123',
                 result: { tag: '2.0.0' },
-                error: { message: 'Registry error' },
+                error: undefined,
             };
             storeContainer.getContainer.mockReturnValue(existingContainer);
 

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -549,8 +549,7 @@ export class Docker extends Watcher {
         const logContainer = this.log.child({ container: fullName(container) });
         const containerWithResult = container;
 
-        // Reset previous results if so
-        delete containerWithResult.result;
+        // Reset previous error if so
         delete containerWithResult.error;
         logContainer.debug('Start watching');
 
@@ -754,10 +753,7 @@ export class Docker extends Watcher {
 
         // Is container already in store? just return it :)
         const containerInStore = storeContainer.getContainer(containerId);
-        if (
-            containerInStore !== undefined &&
-            containerInStore.error === undefined
-        ) {
+        if (containerInStore !== undefined) {
             this.log.debug(`Container ${containerInStore.id} already in store`);
             return containerInStore;
         }

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -753,7 +753,10 @@ export class Docker extends Watcher {
 
         // Is container already in store? just return it :)
         const containerInStore = storeContainer.getContainer(containerId);
-        if (containerInStore !== undefined) {
+        if (
+            containerInStore !== undefined &&
+            containerInStore.error === undefined
+        ) {
             this.log.debug(`Container ${containerInStore.id} already in store`);
             return containerInStore;
         }
@@ -848,7 +851,7 @@ export class Docker extends Watcher {
                 created,
             },
             labels: container.Labels,
-            result: {
+            result: containerInStore?.result ?? {
                 tag: tagName,
             },
             updateAvailable: false,


### PR DESCRIPTION
Registry failures currently remove a container’s previous update result before persisting the error, making a known available update appear up to date until a later successful scan. This preserves the last-known-good result while continuing to expose the registry error, without changing the API or UI model.

### Changes

- Keep the previous result when a Docker registry request fails
- Rebuild errored cached containers from current Docker and registry metadata while retaining that result across consecutive failures
- Prevent simple and batch triggers from acting on stale errored reports
- Cover repeated failures, metadata recovery, successful recovery, and trigger suppression

### Testing

- `cd app && npm test -- watchers/providers/docker/Docker.test.ts triggers/providers/Trigger.test.ts --runInBand --coverage=false --silent` — 98 tests passed
- `cd app && npm test -- --runInBand --silent --coverage=false` — 605 tests passed
- `cd app && npm run lint` — 0 errors (130 existing warnings)
- `cd app && npm run build`

Fixes #1137