### PR TITLE
fix(docker): skip tag listing for non-semver images

### DIFF
--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -596,7 +596,7 @@ describe('Docker Watcher', () => {
             const container = {
                 image: {
                     registry: { name: 'hub' },
-                    tag: { value: '1.0.0' },
+                    tag: { value: '1.0.0', semver: true },
                     digest: { watch: false },
                 },
             };
@@ -804,7 +804,7 @@ describe('Docker Watcher', () => {
                     id: 'image123',
                     registry: { name: 'ghcr' },
                     name: 'tricked-dev/kanidm-oauth2-manager',
-                    tag: { value: 'latest' },
+                    tag: { value: 'latest', semver: false },
                     architecture: 'arm64',
                     os: 'linux',
                     digest: { watch: true, repo: arm64ManifestDigest },
@@ -817,6 +817,7 @@ describe('Docker Watcher', () => {
 
             const result = await docker.findNewVersion(container, mockLogChild);
 
+            expect(ghcrRegistry.getTags).not.toHaveBeenCalled();
             expect(result.digest).toBe(arm64ManifestDigest);
             expect(container.image.digest.value).toBe(arm64ManifestDigest);
             expect(container.image.digest.value).toBe(result.digest);

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -674,8 +674,10 @@ export class Docker extends Watcher {
                 );
             }
 
-            // Get all available tags
-            const tags = await registryProvider.getTags(container.image);
+            // Get all available tags for semver update checks
+            const tags = container.image.tag.semver
+                ? await registryProvider.getTags(container.image)
+                : [];
 
             // Get candidate tags (based on tag name)
             const tagsCandidates = getTagCandidates(


### PR DESCRIPTION
WUD currently enumerates every registry tag for all watched images, including non-semver tags such as `latest`. `getTagCandidates()` discards every non-semver candidate afterward, so repositories with long tag histories can generate multiple avoidable paginated GHCR requests before the current-tag digest check.

This change only fetches tags for semver update checks. Non-semver images keep the existing current-tag digest path, while semver images continue to enumerate candidates. The scope is intentionally limited to removing the request amplification demonstrated in the issue.

## Change summary

- Skip `getTags()` for non-semver images.
- Preserve digest resolution for current mutable tags.
- Add regression coverage proving `latest` skips enumeration while semver checks still enumerate tags.

## Testing

- `npm --prefix app test -- --runInBand --coverage=false watchers/providers/docker/Docker.test.ts` — 56 passed.
- `npm --prefix app test -- --runInBand --silent` — 603 passed.
- `npm --prefix app run lint` — 0 errors.
- `npm --prefix app run build` — passed.

Addresses #1136
