### PR TITLE
fix(oidc): pass skipSubjectCheck for bearer token userinfo validation

### DIFF
--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -177,3 +177,35 @@ test('getUserFromAccessToken should return unknown for missing email', async () 
     const user = await oidc.getUserFromAccessToken('token');
     expect(user).toEqual({ username: 'unknown' });
 });
+
+test('getUserFromAccessToken should skip the subject check when called without a claim (bearer token path)', async () => {
+    oidc.configuration = { ...configurationValid, ttl: -1 };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'bearer@example.com',
+    });
+
+    await oidc.getUserFromAccessToken('token');
+
+    expect(client.fetchUserInfo).toHaveBeenCalledWith(
+        mockConfig,
+        'token',
+        client.skipSubjectCheck,
+    );
+});
+
+test('getUserFromAccessToken should check the subject when called with a claim (authorization code path)', async () => {
+    oidc.configuration = { ...configurationValid, ttl: -1 };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'code@example.com',
+    });
+
+    await oidc.getUserFromAccessToken('token', { sub: 'abc' } as any);
+
+    expect(client.fetchUserInfo).toHaveBeenCalledWith(
+        mockConfig,
+        'token',
+        'abc',
+    );
+});

--- a/app/authentications/providers/oidc/Oidc.ts
+++ b/app/authentications/providers/oidc/Oidc.ts
@@ -271,7 +271,7 @@ class Oidc extends Authentication {
         const userInfo = await client.fetchUserInfo(
             config,
             accessToken,
-            claim?.sub,
+            claim?.sub ?? client.skipSubjectCheck,
         );
 
         // check the usernameclaim, if it doesn't exist, try to use the email and log a warning


### PR DESCRIPTION
Fixes #1145
Relates to #624

## Problem

OIDC bearer-token API authentication (`Authorization: Bearer <token>`) always fails with 401, logging:
```
Error when validating the user access token ("expectedSubject" must be a string)
```
even for a token the IdP itself accepts. See #1145 for full repro.

## Cause

`getUserFromAccessToken()` calls `client.fetchUserInfo(config, accessToken, claim?.sub)`. On the bearer-token path there's no `claim` (no authorization-code exchange happened for this request), so `expectedSubject` is `undefined` — which `oauth4webapi` rejects outright rather than treating as "skip the check". The authorization-code/browser-login path is unaffected since it always supplies a real `sub` from the ID token.

## Fix

Pass the library's own sentinel for "nothing to check the subject against":

```diff
-    claim?.sub,
+    claim?.sub ?? client.skipSubjectCheck,
```

This keeps the subject cross-check on the authorization-code path (where a trusted `sub` is available) and explicitly skips it only on the bearer path (where there's nothing to compare against — the token's validity is already established by the userinfo call succeeding at all).

## Testing

- Added unit tests asserting `fetchUserInfo` is called with `client.skipSubjectCheck` when no claim is passed, and with the real `sub` when one is (previously untested — the existing suite fully mocks `openid-client`, so it couldn't catch the missing argument).
- `npm test` — all tests pass.
- Verified live against a real Authentik 2026.8.0 instance: same access token, same WUD build, only this one-line change — before: `401` / `"expectedSubject" must be a string`; after: `200`.

## Optional follow-up (out of scope here)

WUD validates bearer tokens via a live call to the IdP's `/userinfo` endpoint rather than local JWT/JWKS verification. That's spec-valid but has real limitations worth a separate discussion: no audience (`aud`) check, a per-request runtime dependency on the IdP, and poor fit for client-credentials/service-account tokens (confirmed while testing this fix — Authentik returns `403 insufficient_scope` for `/userinfo` with a client-credentials token, since it's not tied to an end-user). This PR only fixes the crash in the existing mechanism.
