### PR TITLE
fix(registry): limit requests and retry rate limits

### DIFF
--- a/app/registries/Registry.test.ts
+++ b/app/registries/Registry.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+import axios from 'axios';
 import log from '../log';
 
 jest.mock('axios');
@@ -339,7 +340,6 @@ test('getImageManifestDigest should throw when no digest found', async () => {
 });
 
 test('callRegistry should call authenticate', async () => {
-    const { default: axios } = await import('axios');
     axios.mockResolvedValue({ data: {} });
     const registryMocked = new Registry();
     registryMocked.log = log;
@@ -350,6 +350,264 @@ test('callRegistry should call authenticate', async () => {
         method: 'get',
     });
     expect(spyAuthenticate).toHaveBeenCalledTimes(1);
+});
+
+describe('registry request throttling', () => {
+    const request = (registryMocked: Registry, url = 'url') =>
+        registryMocked.callRegistry({
+            image: {},
+            url,
+            method: 'get',
+        });
+    const rateLimitError = (retryAfter?: string) => ({
+        response: {
+            status: 429,
+            headers: { get: () => retryAfter },
+        },
+    });
+    const runTimeoutsImmediately = () =>
+        jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+            callback();
+            return 0;
+        });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('should default concurrency to two and validate overrides', () => {
+        const registryMocked = new Registry();
+
+        expect(registryMocked.validateConfiguration({})).toEqual({
+            concurrency: 2,
+        });
+        expect(
+            registryMocked.validateConfiguration({ concurrency: '2' }),
+        ).toEqual({ concurrency: 2 });
+        expect(() =>
+            registryMocked.validateConfiguration({ concurrency: 0 }),
+        ).toThrow();
+        expect(() =>
+            registryMocked.validateConfiguration({ concurrency: 1.5 }),
+        ).toThrow();
+    });
+
+    test('should limit concurrent requests', async () => {
+        const registryMocked = new Registry();
+        await registryMocked.register('registry', 'test', 'test', {
+            concurrency: 2,
+        });
+        let active = 0;
+        let maximumActive = 0;
+        let releaseRequests;
+        const requestsBlocked = new Promise((resolve) => {
+            releaseRequests = resolve;
+        });
+        axios.mockImplementation(async () => {
+            active += 1;
+            maximumActive = Math.max(maximumActive, active);
+            await requestsBlocked;
+            active -= 1;
+            return { data: {} };
+        });
+
+        const requests = [
+            request(registryMocked),
+            request(registryMocked),
+            request(registryMocked),
+        ];
+        await new Promise(setImmediate);
+
+        expect(axios).toHaveBeenCalledTimes(2);
+        releaseRequests();
+        await Promise.all(requests);
+        expect(axios).toHaveBeenCalledTimes(3);
+        expect(maximumActive).toBe(2);
+    });
+
+    test('should start queued requests in FIFO order', async () => {
+        const registryMocked = new Registry();
+        await registryMocked.register('registry', 'test', 'test', {
+            concurrency: 1,
+        });
+        const started = [];
+        const releases = {};
+        axios.mockImplementation(
+            (options) =>
+                new Promise((resolve) => {
+                    started.push(options.url);
+                    releases[options.url] = () => resolve({ data: {} });
+                }),
+        );
+
+        const requests = [
+            request(registryMocked, 'first'),
+            request(registryMocked, 'second'),
+            request(registryMocked, 'third'),
+        ];
+        await new Promise(setImmediate);
+        expect(started).toEqual(['first']);
+
+        releases.first();
+        await new Promise(setImmediate);
+        expect(started).toEqual(['first', 'second']);
+
+        releases.second();
+        await new Promise(setImmediate);
+        expect(started).toEqual(['first', 'second', 'third']);
+
+        releases.third();
+        await Promise.all(requests);
+    });
+
+    test('should isolate concurrency limits by registry instance', async () => {
+        const firstRegistry = new Registry();
+        const secondRegistry = new Registry();
+        await firstRegistry.register('registry', 'test', 'first', {
+            concurrency: 1,
+        });
+        await secondRegistry.register('registry', 'test', 'second', {
+            concurrency: 1,
+        });
+        let maximumActive = 0;
+        let active = 0;
+        let releaseRequests;
+        const requestsBlocked = new Promise((resolve) => {
+            releaseRequests = resolve;
+        });
+        axios.mockImplementation(async () => {
+            active += 1;
+            maximumActive = Math.max(maximumActive, active);
+            await requestsBlocked;
+            active -= 1;
+            return { data: {} };
+        });
+
+        const requests = [
+            request(firstRegistry, 'first-1'),
+            request(firstRegistry, 'first-2'),
+            request(secondRegistry, 'second-1'),
+            request(secondRegistry, 'second-2'),
+        ];
+        await new Promise(setImmediate);
+
+        expect(axios.mock.calls.map(([options]) => options.url)).toEqual([
+            'first-1',
+            'second-1',
+        ]);
+        expect(maximumActive).toBe(2);
+
+        releaseRequests();
+        await Promise.all(requests);
+        expect(axios).toHaveBeenCalledTimes(4);
+    });
+
+    test('should honor Retry-After seconds and reuse authentication', async () => {
+        const registryMocked = new Registry();
+        const error = rateLimitError('2');
+        axios.mockRejectedValueOnce(error).mockResolvedValueOnce({
+            data: { ok: true },
+        });
+        const timeout = runTimeoutsImmediately();
+        const authenticate = jest.spyOn(registryMocked, 'authenticate');
+
+        await expect(request(registryMocked)).resolves.toEqual({ ok: true });
+
+        expect(timeout).toHaveBeenCalledWith(expect.any(Function), 2000);
+        expect(axios).toHaveBeenCalledTimes(2);
+        expect(authenticate).toHaveBeenCalledTimes(1);
+    });
+
+    test('should honor an HTTP-date Retry-After header', async () => {
+        const registryMocked = new Registry();
+        const now = Date.parse('2026-08-20T12:00:00Z');
+        jest.spyOn(Date, 'now').mockReturnValue(now);
+        axios
+            .mockRejectedValueOnce(
+                rateLimitError(new Date(now + 5000).toUTCString()),
+            )
+            .mockResolvedValueOnce({ data: {} });
+        const timeout = runTimeoutsImmediately();
+
+        await request(registryMocked);
+
+        expect(timeout).toHaveBeenCalledWith(expect.any(Function), 5000);
+    });
+
+    test('should use exponential backoff with jitter without Retry-After', async () => {
+        const registryMocked = new Registry();
+        axios
+            .mockRejectedValueOnce(rateLimitError())
+            .mockRejectedValueOnce(rateLimitError())
+            .mockResolvedValueOnce({ data: {} });
+        jest.spyOn(Math, 'random').mockReturnValue(0.5);
+        const timeout = runTimeoutsImmediately();
+
+        await request(registryMocked);
+
+        expect(timeout.mock.calls.map((call) => call[1])).toEqual([1500, 3000]);
+        expect(axios).toHaveBeenCalledTimes(3);
+    });
+
+    test('should stop after two retries and preserve the original error', async () => {
+        const registryMocked = new Registry();
+        const error = rateLimitError();
+        axios.mockRejectedValue(error);
+        runTimeoutsImmediately();
+
+        await expect(request(registryMocked)).rejects.toBe(error);
+
+        expect(axios).toHaveBeenCalledTimes(3);
+    });
+
+    test('should not retry non-429 errors or a Retry-After over one minute', async () => {
+        const registryMocked = new Registry();
+        const timeout = jest.spyOn(global, 'setTimeout');
+        const serverError = { response: { status: 500, headers: {} } };
+        axios.mockRejectedValueOnce(serverError);
+
+        await expect(request(registryMocked)).rejects.toBe(serverError);
+        expect(axios).toHaveBeenCalledTimes(1);
+
+        const longRateLimit = rateLimitError('61');
+        axios.mockRejectedValueOnce(longRateLimit);
+        await expect(request(registryMocked)).rejects.toBe(longRateLimit);
+        expect(axios).toHaveBeenCalledTimes(2);
+        expect(timeout).not.toHaveBeenCalled();
+    });
+
+    test('should release the permit while a throttled request waits', async () => {
+        const registryMocked = new Registry();
+        await registryMocked.register('registry', 'test', 'test', {
+            concurrency: 1,
+        });
+        let releaseRetry;
+        jest.spyOn(global, 'setTimeout').mockImplementation((callback) => {
+            releaseRetry = callback;
+            return 0;
+        });
+        axios.mockImplementation((options) => {
+            if (options.url === 'throttled' && axios.mock.calls.length === 1) {
+                return Promise.reject(rateLimitError());
+            }
+            return Promise.resolve({ data: { url: options.url } });
+        });
+
+        const throttled = request(registryMocked, 'throttled');
+        const successful = request(registryMocked, 'successful');
+        await expect(successful).resolves.toEqual({ url: 'successful' });
+        expect(axios.mock.calls.map(([options]) => options.url)).toEqual([
+            'throttled',
+            'successful',
+        ]);
+
+        releaseRetry();
+        await expect(throttled).resolves.toEqual({ url: 'throttled' });
+    });
 });
 
 describe('shouldWatchDigest', () => {

--- a/app/registries/Registry.ts
+++ b/app/registries/Registry.ts
@@ -1,8 +1,13 @@
 import axios, { AxiosRequestConfig, Method, AxiosResponse } from 'axios';
 import log from '../log';
-import Component from '../registry/Component';
+import Component, { ComponentConfiguration } from '../registry/Component';
 import { getSummaryTags } from '../prometheus/registry';
 import { ContainerImage } from '../model/container';
+
+const DEFAULT_CONCURRENCY = 2;
+const MAX_RATE_LIMIT_RETRIES = 2;
+const RATE_LIMIT_BACKOFF_BASE_MS = 2000;
+const MAX_RETRY_AFTER_MS = 60000;
 
 export interface RegistryManifest {
     digest?: string;
@@ -40,6 +45,59 @@ export interface RegistryManifestResponse {
  * Docker Registry Abstract class.
  */
 export class Registry extends Component {
+    private activeRequests = 0;
+    private readonly pendingRequests: (() => void)[] = [];
+
+    validateConfiguration(
+        configuration: ComponentConfiguration,
+    ): ComponentConfiguration {
+        const isObjectConfiguration =
+            configuration !== null &&
+            typeof configuration === 'object' &&
+            !Array.isArray(configuration);
+        const { concurrency, ...providerConfiguration } = isObjectConfiguration
+            ? configuration
+            : { concurrency: undefined };
+
+        const concurrencyValidated = this.joi
+            .number()
+            .integer()
+            .min(1)
+            .default(DEFAULT_CONCURRENCY)
+            .validate(concurrency);
+        if (concurrencyValidated.error) {
+            throw concurrencyValidated.error;
+        }
+
+        const providerSchema = this.getConfigurationSchema();
+        let providerConfigurationValidated = providerSchema.validate(
+            isObjectConfiguration ? providerConfiguration : configuration,
+        );
+        if (
+            providerConfigurationValidated.error &&
+            isObjectConfiguration &&
+            Object.hasOwn(configuration, 'concurrency') &&
+            Object.keys(providerConfiguration).length === 0
+        ) {
+            const anonymousConfigurationValidated = providerSchema.validate('');
+            if (!anonymousConfigurationValidated.error) {
+                providerConfigurationValidated =
+                    anonymousConfigurationValidated;
+            }
+        }
+        if (providerConfigurationValidated.error) {
+            throw providerConfigurationValidated.error;
+        }
+
+        return {
+            ...(providerConfigurationValidated.value !== null &&
+            typeof providerConfigurationValidated.value === 'object'
+                ? providerConfigurationValidated.value
+                : {}),
+            concurrency: concurrencyValidated.value,
+        };
+    }
+
     /**
      * Encode Bse64(login:password)
      */
@@ -311,8 +369,6 @@ export class Registry extends Component {
         headers?: any;
         resolveWithFullResponse?: boolean;
     }): Promise<T | AxiosResponse<T>> {
-        const start = new Date().getTime();
-
         // Request options
         const axiosOptions: AxiosRequestConfig = {
             url,
@@ -320,23 +376,104 @@ export class Registry extends Component {
             headers,
             responseType: 'json',
         };
+        let axiosOptionsWithAuth: AxiosRequestConfig | undefined;
 
-        const axiosOptionsWithAuth = await this.authenticate(
-            image,
-            axiosOptions,
-        );
+        for (let retry = 0; ; retry += 1) {
+            try {
+                const response = await this.withRequestPermit(async () => {
+                    const start = new Date().getTime();
+                    try {
+                        axiosOptionsWithAuth =
+                            axiosOptionsWithAuth ||
+                            (await this.authenticate(image, axiosOptions));
+                        return (await axios(
+                            axiosOptionsWithAuth,
+                        )) as AxiosResponse<T>;
+                    } finally {
+                        this.observePrometheusSummaryTags(start);
+                    }
+                });
+                return resolveWithFullResponse ? response : response.data;
+            } catch (error: any) {
+                if (
+                    error?.response?.status !== 429 ||
+                    retry >= MAX_RATE_LIMIT_RETRIES
+                ) {
+                    throw error;
+                }
+
+                const retryAfter = this.getRetryAfterMs(error);
+                if (
+                    retryAfter !== undefined &&
+                    retryAfter > MAX_RETRY_AFTER_MS
+                ) {
+                    this.log.warn(
+                        `Registry rate limited; Retry-After exceeds ${MAX_RETRY_AFTER_MS}ms, deferring until the next check`,
+                    );
+                    throw error;
+                }
+
+                const delay = retryAfter ?? this.getRateLimitBackoffMs(retry);
+                this.log.warn(
+                    `Registry rate limited; retry ${retry + 1}/${MAX_RATE_LIMIT_RETRIES} in ${delay}ms`,
+                );
+                await new Promise((resolve) => setTimeout(resolve, delay));
+            }
+        }
+    }
+
+    private async withRequestPermit<T>(request: () => Promise<T>): Promise<T> {
+        if (
+            this.activeRequests >=
+            (this.configuration.concurrency ?? DEFAULT_CONCURRENCY)
+        ) {
+            await new Promise<void>((resolve) =>
+                this.pendingRequests.push(resolve),
+            );
+        } else {
+            this.activeRequests += 1;
+        }
 
         try {
-            const response = (await axios(
-                axiosOptionsWithAuth,
-            )) as AxiosResponse<T>;
-            this.observePrometheusSummaryTags(start);
-            return resolveWithFullResponse ? response : response.data;
-        } catch (error) {
-            const end = new Date().getTime();
-            this.observePrometheusSummaryTags(start);
-            throw error;
+            return await request();
+        } finally {
+            const next = this.pendingRequests.shift();
+            if (next) {
+                next();
+            } else {
+                this.activeRequests -= 1;
+            }
         }
+    }
+
+    private getRetryAfterMs(error: any): number | undefined {
+        const headers = error?.response?.headers;
+        const retryAfter =
+            typeof headers?.get === 'function'
+                ? headers.get('retry-after')
+                : headers?.['retry-after'];
+
+        if (retryAfter === undefined || retryAfter === null) {
+            return undefined;
+        }
+
+        const retryAfterString = String(retryAfter).trim();
+        if (/^\d+$/.test(retryAfterString)) {
+            return Number(retryAfterString) * 1000;
+        }
+
+        const retryAt = Date.parse(retryAfterString);
+        if (Number.isNaN(retryAt) || retryAt <= Date.now()) {
+            return undefined;
+        }
+        return retryAt - Date.now();
+    }
+
+    private getRateLimitBackoffMs(retry: number) {
+        const exponentialDelay = RATE_LIMIT_BACKOFF_BASE_MS * 2 ** retry;
+        return Math.round(
+            exponentialDelay / 2 + (Math.random() * exponentialDelay) / 2,
+        );
     }
 
     observePrometheusSummaryTags(start: number) {

--- a/app/registries/providers/custom/Custom.test.ts
+++ b/app/registries/providers/custom/Custom.test.ts
@@ -19,7 +19,14 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         url: 'http://localhost:5000',
         login: 'login',
         password: 'password',
+        concurrency: 2,
     });
+});
+
+test('validatedConfiguration should require a URL with concurrency', async () => {
+    expect(() => {
+        custom.validateConfiguration({ concurrency: 2 });
+    }).toThrow('"url" is required');
 });
 
 test('validatedConfiguration should throw error when auth is not base64', async () => {

--- a/app/registries/providers/custom/Custom.ts
+++ b/app/registries/providers/custom/Custom.ts
@@ -7,32 +7,29 @@ import { ContainerImage } from '../../../model/container';
  */
 class Custom extends DockerRegistryV2 {
     getConfigurationSchema(): AnySchema<any> {
-        return this.joi.alternatives([
-            this.joi.string().allow(''),
-            this.joi.object().keys({
-                url: this.joi.string().uri().required(),
-                login: this.joi.alternatives().conditional('password', {
-                    not: undefined,
-                    then: this.joi.string().required(),
-                    otherwise: this.joi.any().forbidden(),
-                }),
-                password: this.joi.alternatives().conditional('login', {
-                    not: undefined,
-                    then: this.joi.string().required(),
-                    otherwise: this.joi.any().forbidden(),
-                }),
-                auth: this.joi.alternatives().conditional('login', {
-                    not: undefined,
-                    then: this.joi.any().forbidden(),
-                    otherwise: this.joi
-                        .alternatives()
-                        .try(
-                            this.joi.string().base64(),
-                            this.joi.string().valid(''),
-                        ),
-                }),
+        return this.joi.object().keys({
+            url: this.joi.string().uri().required(),
+            login: this.joi.alternatives().conditional('password', {
+                not: undefined,
+                then: this.joi.string().required(),
+                otherwise: this.joi.any().forbidden(),
             }),
-        ]);
+            password: this.joi.alternatives().conditional('login', {
+                not: undefined,
+                then: this.joi.string().required(),
+                otherwise: this.joi.any().forbidden(),
+            }),
+            auth: this.joi.alternatives().conditional('login', {
+                not: undefined,
+                then: this.joi.any().forbidden(),
+                otherwise: this.joi
+                    .alternatives()
+                    .try(
+                        this.joi.string().base64(),
+                        this.joi.string().valid(''),
+                    ),
+            }),
+        });
     }
 
     /**

--- a/app/registries/providers/ecr/Ecr.test.ts
+++ b/app/registries/providers/ecr/Ecr.test.ts
@@ -46,6 +46,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         secretaccesskey: 'secretaccesskey',
         region: 'region',
         public: false,
+        concurrency: 2,
     });
 });
 

--- a/app/registries/providers/ghcr/Ghcr.test.ts
+++ b/app/registries/providers/ghcr/Ghcr.test.ts
@@ -39,6 +39,35 @@ describe('GitHub Container Registry specific tests', () => {
         expect(result.headers.Authorization).toBe(`Bearer ${expectedBearer}`);
     });
 
+    test('should apply registry concurrency configuration', async () => {
+        const authenticated = new Ghcr();
+        await authenticated.register('registry', 'ghcr', 'authenticated', {
+            username: 'testuser',
+            token: 'testtoken',
+            concurrency: '2',
+        });
+        expect(authenticated.configuration.concurrency).toBe(2);
+
+        const anonymous = new Ghcr();
+        await anonymous.register('registry', 'ghcr', 'public', {
+            concurrency: '3',
+        });
+        expect(anonymous.configuration).toEqual({ concurrency: 3 });
+    });
+
+    test.each([0, -1, 1.5, 'many'])(
+        'should reject invalid concurrency %s',
+        (concurrency) => {
+            expect(() =>
+                ghcr.validateConfiguration({
+                    username: 'testuser',
+                    token: 'testtoken',
+                    concurrency,
+                }),
+            ).toThrow();
+        },
+    );
+
     test('should return undefined auth pull when missing username', async () => {
         ghcr.configuration = { token: 'test-token' };
         const auth = await ghcr.getAuthPull();

--- a/app/registries/providers/gitea/Gitea.test.ts
+++ b/app/registries/providers/gitea/Gitea.test.ts
@@ -22,6 +22,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         url: 'https://gitea.acme.com',
         login: 'login',
         password: 'password',
+        concurrency: 2,
     });
 });
 

--- a/app/registries/providers/gitlab/Gitlab.test.ts
+++ b/app/registries/providers/gitlab/Gitlab.test.ts
@@ -23,6 +23,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         authurl: 'https://gitlab.com',
         username: '',
         token: 'abcdef',
+        concurrency: 2,
     });
     expect(
         gitlab.validateConfiguration({
@@ -35,6 +36,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         authurl: 'https://custom.com',
         username: '',
         token: 'abcdef',
+        concurrency: 2,
     });
     expect(
         gitlab.validateConfiguration({
@@ -46,6 +48,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
         authurl: 'https://gitlab.com',
         username: 'custom-user',
         token: 'abcdef',
+        concurrency: 2,
     });
 });
 
@@ -55,6 +58,7 @@ test('validatedConfiguration should allow anonymous configuration for public pro
         authurl: 'https://gitlab.com',
         username: '',
         token: '',
+        concurrency: 2,
     });
 });
 

--- a/app/registries/providers/quay/Quay.test.ts
+++ b/app/registries/providers/quay/Quay.test.ts
@@ -20,8 +20,10 @@ quay.configuration = {
 quay.log = log;
 
 test('validatedConfiguration should initialize when anonymous configuration is valid', async () => {
-    expect(quay.validateConfiguration('')).toStrictEqual({});
-    expect(quay.validateConfiguration(undefined)).toStrictEqual({});
+    expect(quay.validateConfiguration('')).toStrictEqual({ concurrency: 2 });
+    expect(quay.validateConfiguration(undefined)).toStrictEqual({
+        concurrency: 2,
+    });
 });
 
 test('validatedConfiguration should initialize when auth configuration is valid', async () => {
@@ -35,6 +37,7 @@ test('validatedConfiguration should initialize when auth configuration is valid'
         namespace: 'namespace',
         account: 'account',
         token: 'token',
+        concurrency: 2,
     });
 });
 
@@ -125,6 +128,13 @@ test('authenticate should populate header with base64 bearer', async () => {
             Authorization: 'Bearer token',
         },
     });
+});
+
+test('authenticate should propagate rate limits', async () => {
+    const error = { response: { status: 429 } };
+    axios.mockRejectedValueOnce(error);
+
+    await expect(quay.authenticate({}, { headers: {} })).rejects.toBe(error);
 });
 
 test('authenticate should not populate header with base64 bearer when anonymous', async () => {

--- a/app/registries/providers/quay/Quay.ts
+++ b/app/registries/providers/quay/Quay.ts
@@ -43,7 +43,10 @@ class Quay extends DockerRegistryV2 {
             try {
                 const response = await axios<{ token: string }>(request);
                 token = response.data.token;
-            } catch (e) {
+            } catch (e: any) {
+                if (e?.response?.status === 429) {
+                    throw e;
+                }
                 this.log.warn(
                     `Error when trying to get an access token (${e.message})`,
                 );

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -35,6 +35,7 @@ description: Unreleased changes and upcoming features in What's Up Docker (WUD).
 - 🐛 Fix login redirect issues when WUD is exposed under a subpath
 - 🐛 `HTTP` Mask HTTP auth password and bearer token values
 - 🐛 Preserve update results across registry errors
+- 🐛 `REGISTRIES` Bound concurrent registry requests and retry transient HTTP 429 responses
 - 🐛 `DOCKER-COMPOSE` Prefer trigger-level configuration over automatic labels
 - 🐛 `UI` Fix dynamic chunk loading failure (`ChunkLoadError`) when navigating between nested configuration routes
 - ⚠️ `UI` Deprecate Homarr icon prefix (`hl:`, `hl-`) in favor of `selfhst:` (automatically mapped with a deprecation warning)

--- a/website/docs/configuration/registries/README.md
+++ b/website/docs/configuration/registries/README.md
@@ -4,6 +4,7 @@ description: Overview of container registry integrations and authentication in W
 ---
 
 import { RegistryGrid, RegistryCard } from '@site/src/components/RegistryCard';
+import { ConfigList, ConfigOption } from '@site/src/components/ConfigOption';
 
 # Registries
 
@@ -12,6 +13,27 @@ WUD inspects remote container registries to discover image tags, digest hashes, 
 :::tip[How WUD Resolves Registries]
 When WUD monitors a container (e.g. `redis:7-alpine` or `ghcr.io/owner/app:1.2.0`), it parses the image name to detect the target registry domain automatically.
 :::
+
+---
+
+## Request Throttling
+
+WUD limits requests independently for each configured registry instance. Requests above the limit wait in FIFO order, so one registry cannot consume the capacity of another.
+
+<ConfigList>
+  <ConfigOption
+    name="WUD_REGISTRY_{REGISTRY_TYPE}_{REGISTRY_NAME}_CONCURRENCY"
+    required={false}
+    type="integer"
+    defaultValue="2"
+    supported="Any integer greater than or equal to 1">
+    Maximum number of active requests for this registry instance. An invalid value prevents the registry from registering.
+  </ConfigOption>
+</ConfigList>
+
+When a registry returns HTTP 429, WUD retries twice. It honors `Retry-After` values up to 60 seconds; otherwise it waits for a jittered 1–2 seconds before the first retry and 2–4 seconds before the second. Request slots are released during these delays. Longer retry windows are deferred to the next normal scan, and non-429 failures are not retried.
+
+Retry timing is fixed and is not separately configurable.
 
 ---
 

--- a/website/docs/configuration/registries/ghcr/README.md
+++ b/website/docs/configuration/registries/ghcr/README.md
@@ -39,6 +39,15 @@ Public packages work out of the box with zero configuration. Configure this modu
     supported="Valid GitHub Personal Access Token (`ghp_...` or classic)">
     GitHub Personal Access Token (PAT)
   </ConfigOption>
+
+  <ConfigOption
+    name="WUD_REGISTRY_GHCR_{registry_name}_CONCURRENCY"
+    required={false}
+    type="integer"
+    defaultValue="2"
+    supported="Any integer greater than or equal to 1">
+    Maximum number of active requests for this GHCR configuration.
+  </ConfigOption>
 </ConfigList>
 
 ---
@@ -57,6 +66,7 @@ services:
     environment:
       - WUD_REGISTRY_GHCR_LOCAL_USERNAME=johndoe
       - WUD_REGISTRY_GHCR_LOCAL_TOKEN=ghp_1234567890abcdefghijklmnopqrstuvwxyz
+      - WUD_REGISTRY_GHCR_LOCAL_CONCURRENCY=2
 ```
 
 </TabItem>
@@ -66,11 +76,24 @@ services:
 docker run \
   -e WUD_REGISTRY_GHCR_LOCAL_USERNAME="johndoe" \
   -e WUD_REGISTRY_GHCR_LOCAL_TOKEN="ghp_1234567890abcdefghijklmnopqrstuvwxyz" \
+  -e WUD_REGISTRY_GHCR_LOCAL_CONCURRENCY=2 \
   getwud/wud
 ```
 
 </TabItem>
 </Tabs>
+
+### Limit Anonymous GHCR Requests
+
+An anonymous registry configuration can set only the concurrency limit:
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    environment:
+      - WUD_REGISTRY_GHCR_PUBLIC_CONCURRENCY=1
+```
 
 ---
 


### PR DESCRIPTION
WUD starts container checks concurrently, so semver images assigned to the same registry can issue a concentrated burst of tag-list and manifest requests. A transient HTTP 429 currently fails immediately, leaving those images unchecked until a later scan.

Production diagnosis for #1136 observed 51 watches start within 18 ms, followed by 10 GHCR tag-list requests within roughly 3 ms; nine returned HTTP 429 within the next second. The same burst pattern repeated on the configured scan schedule. #1143 removed unnecessary tag enumeration for non-semver images, but semver checks still need bounded registry traffic and retry handling.

## Change summary

- Limit each configured registry instance to two active requests by default, with FIFO queuing and an optional `WUD_REGISTRY_{REGISTRY_TYPE}_{REGISTRY_NAME}_CONCURRENCY` override.
- Retry only HTTP 429 responses, with two bounded retries that honor `Retry-After` values up to 60 seconds and otherwise use jittered exponential backoff.
- Release request permits before retry delays, preserve non-429 behavior, and keep limits isolated between registry instances.
- Preserve authenticated and anonymous provider validation, including Custom registry URL requirements and Quay authentication-endpoint rate limits.
- Document the new registry setting and retry behavior in the registry and GHCR configuration guides and changelog.

## Testing

- `npm --prefix app test -- --runInBand --coverage=false registries` — 25 suites / 287 tests passed.
- `npm --prefix app test -- --runInBand --silent --coverage=false --forceExit` — 99 suites / 1,003 tests passed.
- `npm --prefix app run build` — passed.
- `npm --prefix app run lint` — 0 errors (161 existing warnings).
- `npm --prefix website run build` — passed.
- Prettier check for affected backend files and the changelog — passed; migrated registry docs retain the existing Docusaurus formatting.
- `git diff --check` — passed.

Closes #1136
