### PR TITLE
fix(tag): substitute empty string for unmatched optional capture group

### DIFF
--- a/app/tag/index.test.ts
+++ b/app/tag/index.test.ts
@@ -288,6 +288,15 @@ describe('transform', () => {
                 '1.2.3',
             );
         });
+
+        test('should substitute an empty string for an unmatched optional capture group', async () => {
+            // The formula references group 4, an optional group that does not
+            // participate when the tag has no suffix. It must not leak the
+            // literal "undefined" into the transformed tag.
+            expect(
+                semver.transform('^(\\d+)-(\\d+)(-(a|b))?$ => $2.$1-$4', '3-4'),
+            ).toBe('4.3-');
+        });
     });
 });
 

--- a/app/tag/index.ts
+++ b/app/tag/index.ts
@@ -82,7 +82,13 @@ export function transform(transformFormula, originalTag) {
             );
             transformedTag = transformedTag.replace(
                 new RegExp(placeholder.replace('$', '\\$'), 'g'),
-                originalTagMatches[placeholderIndex],
+                // An optional capture group may not participate in the match
+                // (for example an optional group in the formula). Substitute
+                // an empty string for it, rather than letting replace() coerce
+                // undefined into the literal "undefined" and corrupt the tag.
+                originalTagMatches[placeholderIndex] !== undefined
+                    ? originalTagMatches[placeholderIndex]
+                    : '',
             );
         });
         return transformedTag;


### PR DESCRIPTION
### Summary

when a `transformTags` formula references a capture group that does not participate in the match (for example an optional group), the transformed tag ends up containing the literal text `undefined`

```ts
// formula: ^(\d+)-(\d+)(-(a|b))?$ => $2.$1-$4
transformTags('3-4') // -> "4.3-undefined"  (expected "4.3-")
```

`String.prototype.replace()` coerces the `undefined` group value into the string `"undefined"`, so that corrupted tag then feeds the semver comparison and the `result_tag` shown in the UI, meaning an optional group breaks both the update ordering and the displayed result

this substitutes an empty string for a non-participating group, which is what regex semantics expect for an optional group, regular transforms (all groups participating) are unchanged

### Test plan

added `should substitute an empty string for an unmatched optional capture group` in `app/tag/index.test.ts`, it fails without the source change (received `"4.3-undefined"` instead of `"4.3-"`) and passes with it

`npx eslint tag/index.ts tag/index.test.ts` → 0 errors
`npx jest tag/index.test.ts` → 48 passed

### Checklist
- [x] bug verified (odd output reproduced before the fix)
- [x] unit test added that fails without the fix and passes with it
- [x] lint clean on changed files
- [x] no dependency / lockfile change
