### PR TITLE
fix(docker): exclude tags that transform to the current version

### DIFF
--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -989,6 +989,44 @@ describe('Docker Watcher', () => {
 
             expect(result).toEqual({ tag: '1.3' });
         });
+
+        test('should not propose a tag that transforms to the same version as the current one', async () => {
+            const container = {
+                includeTags: '^4.5.\\d+-ls\\d+$',
+                transformTags: '^(\\d+\\.\\d+\\.\\d+)-ls\\d+$ => $1',
+                image: {
+                    registry: { name: 'hub' },
+                    tag: { value: '4.5.5-ls239', semver: true },
+                    digest: { watch: false },
+                },
+            };
+            const mockRegistry = {
+                getTags: jest.fn().mockResolvedValue([
+                    '4.5.5-ls244', // rebuild of 4.5.5 - same version after transform
+                    '4.5.5-ls239', // current tag
+                ]),
+                shouldWatchDigest: jest.fn(() => false),
+            };
+            registry.getState.mockReturnValue({
+                registry: { hub: mockRegistry },
+            });
+
+            // Emulate the real transformer (strip the -lsNNN rebuild suffix)
+            mockTag.transform.mockImplementation((formula, tag) =>
+                tag.replace(/-ls\d+$/, ''),
+            );
+            // Emulate semver gte (equal versions are treated as valid here);
+            // the transform-equal rebuild must still be excluded by the gate.
+            mockTag.isGreater.mockImplementation((t1, t2) => t1 >= t2);
+
+            const mockLogChild = { error: jest.fn(), warn: jest.fn() };
+
+            const result = await docker.findNewVersion(container, mockLogChild);
+
+            // 4.5.5-ls244 normalizes to the same 4.5.5 as the current image,
+            // so it must NOT be proposed as the next tag.
+            expect(result).toEqual({ tag: '4.5.5-ls239' });
+        });
     });
 
     describe('Container Details', () => {

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -159,16 +159,20 @@ function getTagCandidates(
             });
         }
 
-        // Keep only greater semver
-        filteredTags = filteredTags.filter((tag) =>
-            isGreaterSemver(
-                transformTag(container.transformTags, tag),
-                transformTag(
-                    container.transformTags,
-                    container.image.tag.value,
-                ),
-            ),
-        );
+        // Keep only greater semver (strict). A tag that transforms to the
+        // same version as the current one (for example a rebuild suffix stripped
+        // by the transform formula) is not an upgrade and must be excluded.
+        filteredTags = filteredTags.filter((tag) => {
+            const tagTransformed = transformTag(container.transformTags, tag);
+            const currentTransformed = transformTag(
+                container.transformTags,
+                container.image.tag.value,
+            );
+            return (
+                tagTransformed !== currentTransformed &&
+                isGreaterSemver(tagTransformed, currentTransformed)
+            );
+        });
 
         // Apply semver sort desc
         filteredTags.sort((t1, t2) => {


### PR DESCRIPTION
### Summary

when the registry only offers tags that the transformTags formula normalizes to the same version as the current one, both tags normalize to the same version but the candidate gate in getTagCandidates still accepts the rebuild

example: linuxserver sabnzbd image, current tag is 4.5.5-ls239 and the registry has 4.5.5-ls244, with a transform formula that strips the -lsNNN suffix

```yaml
labels:
  - 'wud.tag.include=^\d+\.\d+\.\d+-ls\d+$$'
  - 'wud.tag.transform=^(\d+\.\d+\.\d+)-ls\d+$$ => $$1'
```

the keep only greater semver gate uses isGreater which is semver gte, so an equal after transform tag passes it, and the semver sort compares transformed tags with the same gte, so transformed equal tags count as greater there too and the selected candidate ends up depending on the order the registry returns the tags, the same registry content can give result.tag = 4.5.5-ls239 or result.tag = 4.5.5-ls244

the stored candidate then contradicts the model itself, since updateAvailable in model/container.ts already decides updates by transformed tag inequality (localTag !== remoteTag), so WUD keeps a phantom next tag in its state while reporting no update

### Behavior / compatibility

- the gate now keeps a candidate only when its transformed value is different from the current transformed value AND greater semver, so getTagCandidates agrees with the updateAvailable rule and the result no longer flips with registry tag order
- strictly greater transforms and no transform flows are unchanged
- updateAvailable itself is untouched

### Test plan

added should not propose a tag that transforms to the same version as the current one in app/watchers/providers/docker/Docker.test.ts, it emulates the -ls suffix stripping transform and a gte comparison, then asserts the rebuild is not proposed

it fails without the source change (received 4.5.5-ls244 instead of 4.5.5-ls239) and passes with it

```
npx jest watchers/providers/docker/Docker.test.ts   # 58 passed
npx eslint watchers/providers/docker/Docker.ts watchers/providers/docker/Docker.test.ts   # 0 errors
```

relates to #938

### Checklist
- [x] odd behavior verified before the fix (pre-change probe with real modules, outcome depended on registry tag order)
- [x] unit test added that fails without the fix and passes with it
- [x] lint clean on changed files
- [x] no dependency / lockfile change
