### PR TITLE
Fix storage by reusing existing storage for loki

### DIFF
--- a/app/api/LokiSessionStore.test.ts
+++ b/app/api/LokiSessionStore.test.ts
@@ -1,0 +1,154 @@
+import Loki from 'lokijs';
+import session from 'express-session';
+import LokiSessionStore from './LokiSessionStore';
+
+describe('LokiSessionStore', () => {
+    test('should reuse the existing sessions collection on the provided db', () => {
+        const db = new Loki('test.db');
+        const existingCollection = db.addCollection('Sessions', {
+            indices: ['sid'],
+        });
+
+        const store = new LokiSessionStore(db);
+
+        expect(store).toBeDefined();
+        expect(db.getCollection('Sessions')).toBe(existingCollection);
+    });
+
+    test('should persist and retrieve sessions from the shared db instance', (done) => {
+        const db = new Loki('test.db');
+        const store = new LokiSessionStore(db);
+        const sessionData = {
+            cookie: {} as session.Cookie,
+            oidc: {
+                codeVerifier: 'code-verifier',
+                state: 'state',
+            },
+            passport: {
+                user: '{"username":"tester"}',
+            },
+        } as unknown as session.SessionData;
+
+        store.set('sid-1', sessionData, (setError) => {
+            expect(setError).toBeNull();
+
+            const sessionsCollection = db.getCollection('Sessions');
+            expect(sessionsCollection.findOne({ sid: 'sid-1' })).toBeDefined();
+
+            store.get('sid-1', (getError, storedSession) => {
+                expect(getError).toBeNull();
+                expect(storedSession).toEqual(sessionData);
+                done();
+            });
+        });
+    });
+
+    test('should reject and remove expired sessions based on cookie expiry', (done) => {
+        const db = new Loki('test.db');
+        const store = new LokiSessionStore(db);
+        const sessionData = {
+            cookie: {
+                expires: new Date(Date.now() - 60_000),
+            } as session.Cookie,
+            oidc: {
+                codeVerifier: 'code-verifier',
+                state: 'state',
+            },
+            passport: {
+                user: '{"username":"tester"}',
+            },
+        } as unknown as session.SessionData;
+
+        store.set('expired-cookie', sessionData, () => {
+            store.get('expired-cookie', (_getError, storedSession) => {
+                expect(storedSession).toBeNull();
+                expect(
+                    db.getCollection('Sessions').findOne({
+                        sid: 'expired-cookie',
+                    }),
+                ).toBeNull();
+                done();
+            });
+        });
+    });
+
+    test('should reject and remove expired sessions based on ttl fallback', (done) => {
+        const db = new Loki('test.db');
+        const store = new LokiSessionStore(db, 1);
+        const sessionData = {
+            cookie: {} as session.Cookie,
+            oidc: {
+                codeVerifier: 'code-verifier',
+                state: 'state',
+            },
+            passport: {
+                user: '{"username":"tester"}',
+            },
+        } as unknown as session.SessionData;
+
+        store.set('expired-ttl', sessionData, () => {
+            const storedSession = db
+                .getCollection('Sessions')
+                .findOne({ sid: 'expired-ttl' });
+            storedSession.updatedAt = new Date(Date.now() - 5_000);
+            db.getCollection('Sessions').update(storedSession);
+
+            store.get('expired-ttl', (_getError, refreshedSession) => {
+                expect(refreshedSession).toBeNull();
+                expect(
+                    db
+                        .getCollection('Sessions')
+                        .findOne({ sid: 'expired-ttl' }),
+                ).toBeNull();
+                done();
+            });
+        });
+    });
+
+    test('should persist refreshed cookie data on touch', (done) => {
+        const db = new Loki('test.db');
+        const store = new LokiSessionStore(db);
+        const originalSessionData = {
+            cookie: {
+                expires: new Date(Date.now() + 30_000),
+            } as session.Cookie,
+        } as unknown as session.SessionData;
+        const refreshedSessionData = {
+            cookie: {
+                expires: new Date(Date.now() + 60_000),
+            } as session.Cookie,
+        } as unknown as session.SessionData;
+
+        store.set('sid-touch', originalSessionData, () => {
+            store.touch('sid-touch', refreshedSessionData, () => {
+                store.get('sid-touch', (_getError, storedSession) => {
+                    expect(storedSession).toEqual(refreshedSessionData);
+                    done();
+                });
+            });
+        });
+    });
+
+    test('should evaluate ttl fallback when updatedAt is reloaded as a string', (done) => {
+        const db = new Loki('test.db');
+        const store = new LokiSessionStore(db, 1);
+        const sessionData = {
+            cookie: {} as session.Cookie,
+        } as unknown as session.SessionData;
+
+        store.set('sid-string-date', sessionData, () => {
+            const storedSession = db
+                .getCollection('Sessions')
+                .findOne({ sid: 'sid-string-date' });
+            storedSession.updatedAt = new Date(
+                Date.now() - 5_000,
+            ).toISOString();
+            db.getCollection('Sessions').update(storedSession);
+
+            store.get('sid-string-date', (_getError, refreshedSession) => {
+                expect(refreshedSession).toBeNull();
+                done();
+            });
+        });
+    });
+});

--- a/app/api/LokiSessionStore.ts
+++ b/app/api/LokiSessionStore.ts
@@ -1,0 +1,125 @@
+import session from 'express-session';
+import type { Collection } from 'lokijs';
+import type Loki from 'lokijs';
+
+interface StoredSession {
+    sid: string;
+    content: session.SessionData;
+    updatedAt: Date | string;
+}
+
+class LokiSessionStore extends session.Store {
+    private collection: Collection<StoredSession>;
+
+    private readonly ttlMs: number | null;
+
+    constructor(db: Loki, ttlSeconds = 604800) {
+        super();
+        this.ttlMs = ttlSeconds > 0 ? ttlSeconds * 1000 : null;
+        const existingCollection = db.getCollection<StoredSession>('Sessions');
+        this.collection =
+            existingCollection ||
+            db.addCollection<StoredSession>('Sessions', {
+                indices: ['sid'],
+            });
+    }
+
+    private isExpired(storedSession: StoredSession) {
+        const cookieExpires = storedSession.content?.cookie?.expires;
+        if (cookieExpires) {
+            return new Date(cookieExpires).getTime() <= Date.now();
+        }
+        if (this.ttlMs == null) {
+            return false;
+        }
+        return (
+            new Date(storedSession.updatedAt).getTime() + this.ttlMs <=
+            Date.now()
+        );
+    }
+
+    private deleteIfExpired(storedSession: StoredSession | null) {
+        if (storedSession && this.isExpired(storedSession)) {
+            this.collection.remove(storedSession);
+            return true;
+        }
+        return false;
+    }
+
+    private cleanupExpiredSessions() {
+        this.collection
+            .find()
+            .filter((storedSession) => this.isExpired(storedSession))
+            .forEach((storedSession) => this.collection.remove(storedSession));
+    }
+
+    get(
+        sid: string,
+        callback: (
+            err?: unknown,
+            sessionData?: session.SessionData | null,
+        ) => void,
+    ) {
+        const storedSession = this.collection.findOne({ sid });
+        if (this.deleteIfExpired(storedSession)) {
+            callback(null, null);
+            return;
+        }
+        callback(null, storedSession?.content || null);
+    }
+
+    set(
+        sid: string,
+        sessionData: session.SessionData,
+        callback?: (err?: unknown) => void,
+    ) {
+        this.cleanupExpiredSessions();
+        const storedSession = this.collection.findOne({ sid });
+        if (storedSession) {
+            storedSession.content = sessionData;
+            storedSession.updatedAt = new Date();
+            this.collection.update(storedSession);
+        } else {
+            this.collection.insert({
+                sid,
+                content: sessionData,
+                updatedAt: new Date(),
+            });
+        }
+        callback?.(null);
+    }
+
+    destroy(sid: string, callback?: (err?: unknown) => void) {
+        this.collection.findAndRemove({ sid });
+        callback?.(null);
+    }
+
+    clear(callback?: (err?: unknown) => void) {
+        this.collection.clear();
+        callback?.(null);
+    }
+
+    length(callback: (err: unknown, length?: number) => void) {
+        callback(null, this.collection.count());
+    }
+
+    touch(
+        sid: string,
+        sessionData: session.SessionData,
+        callback?: () => void,
+    ) {
+        const storedSession = this.collection.findOne({ sid });
+        if (this.deleteIfExpired(storedSession)) {
+            callback?.();
+            return;
+        }
+        if (storedSession) {
+            storedSession.content = sessionData;
+            storedSession.updatedAt = new Date();
+            this.collection.update(storedSession);
+        }
+        callback?.();
+    }
+}
+
+export default LokiSessionStore;

--- a/app/api/auth.test.ts
+++ b/app/api/auth.test.ts
@@ -1,15 +1,22 @@
 import express from 'express';
 import request from 'supertest';
 import * as auth from './auth';
-import * as store from '../store';
 import * as registry from '../registry';
 
-jest.mock('../store', () => ({
-    getConfiguration: jest.fn(() => ({
-        path: '/tmp',
-        file: 'test.db',
-    })),
-}));
+jest.mock('../store', () => {
+    const Loki = require('lokijs');
+    const db = new Loki('test.db');
+
+    return {
+        store: {
+            getDb: jest.fn(() => db),
+            getConfiguration: jest.fn(() => ({
+                path: '/tmp',
+                file: 'test.db',
+            })),
+        },
+    };
+});
 
 jest.mock('../registry', () => ({
     getState: jest.fn(() => ({

--- a/app/api/auth.test.ts
+++ b/app/api/auth.test.ts
@@ -1,7 +1,6 @@
 import express from 'express';
 import request from 'supertest';
 import * as auth from './auth';
-import * as registry from '../registry';
 
 jest.mock('../store', () => {
     const Loki = require('lokijs');
@@ -103,7 +102,7 @@ describe('API Auth', () => {
         const tempApp = express();
         tempApp.use(express.json());
         auth.init(tempApp);
-        tempApp.use((err: any, req: any, res: any, next: any) => {
+        tempApp.use((err: any, req: any, res: any) => {
             console.error(err);
             res.status(500).json({ error: err.message });
         });

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -1,27 +1,27 @@
-// @ts-nocheck
 import express from 'express';
 import session from 'express-session';
-import ConnectLoki from 'connect-loki';
-const LokiStore = ConnectLoki(session);
 import passport from 'passport';
 import { v5 as uuidV5 } from 'uuid';
 import getmac from 'getmac';
-import * as store from '../store';
+import { store } from '../store';
 import * as registry from '../registry';
 import log from '../log';
 import { getVersion } from '../configuration';
+import LokiSessionStore from './LokiSessionStore';
+import Authentication, {
+    StrategyDescription,
+} from '../authentications/providers/Authentication';
 
 const router = express.Router();
 
 // The configured strategy ids.
-const STRATEGY_IDS = [];
+const STRATEGY_IDS: string[] = [];
 
 // Constant WUD namespace for uuid v5 bound sessions.
 const WUD_NAMESPACE = 'dee41e92-5fc4-460e-beec-528c9ea7d760';
 
 /**
  * Get all strategies id.
- * @returns {[]}
  */
 export function getAllIds() {
     return STRATEGY_IDS;
@@ -29,10 +29,6 @@ export function getAllIds() {
 
 /**
  * Express middleware to protect routes.
- * @param req
- * @param res
- * @param next
- * @returns {*}
  */
 export function requireAuthentication(req, res, next): any {
     if (req.isAuthenticated()) {
@@ -47,16 +43,13 @@ export function requireAuthentication(req, res, next): any {
 
 /**
  * Get cookie max age.
- * @param days
- * @returns {number}
  */
-function getCookieMaxAge(days) {
+function getCookieMaxAge(days: number) {
     return 3600 * 1000 * 24 * days;
 }
 
 /**
  * Get session secret key (bound to wud version).
- * @returns {string}
  */
 function getSessionSecretKey() {
     const stringToHash = `wud.${getVersion()}.${getmac()}`;
@@ -65,10 +58,8 @@ function getSessionSecretKey() {
 
 /**
  * Register a strategy to passport.
- * @param authentication
- * @param app
  */
-function useStrategy(authentication, app) {
+function useStrategy(authentication: Authentication, app) {
     try {
         const strategy = authentication.getStrategy(app);
         passport.use(authentication.getId(), strategy);
@@ -84,7 +75,7 @@ function getUniqueStrategies() {
     const strategies = Object.values(registry.getState().authentication).map(
         (authentication) => authentication.getStrategyDescription(),
     );
-    const uniqueStrategies = [];
+    const uniqueStrategies: StrategyDescription[] = [];
     strategies.forEach((strategy) => {
         if (
             !uniqueStrategies.find(
@@ -100,8 +91,6 @@ function getUniqueStrategies() {
 
 /**
  * Return the registered strategies from the registry.
- * @param req
- * @param res
  */
 function getStrategies(req, res) {
     res.json(getUniqueStrategies());
@@ -119,8 +108,6 @@ function getLogoutRedirectUrl() {
 
 /**
  * Get current user.
- * @param req
- * @param res
  */
 function getUser(req, res) {
     const user = req.user || { username: 'anonymous' };
@@ -129,8 +116,6 @@ function getUser(req, res) {
 
 /**
  * Login user (and return it).
- * @param req
- * @param res
  */
 function login(req, res) {
     return getUser(req, res);
@@ -138,8 +123,6 @@ function login(req, res) {
 
 /**
  * Logout current user.
- * @param req
- * @param res
  */
 function logout(req, res) {
     req.logout(() => {});
@@ -148,18 +131,16 @@ function logout(req, res) {
     });
 }
 
+let lokiStore: LokiSessionStore | undefined;
 /**
  * Init auth (passport.js).
- * @returns {*}
  */
 export function init(app) {
+    lokiStore = new LokiSessionStore(store.getDb());
     // Init express session
     app.use(
         session({
-            store: new LokiStore({
-                path: `${store.getConfiguration().path}/${store.getConfiguration().file}`,
-                ttl: 604800, // 7 days
-            }),
+            store: lokiStore,
             secret: getSessionSecretKey(),
             resave: false,
             saveUninitialized: false,
@@ -183,7 +164,7 @@ export function init(app) {
         done(null, JSON.stringify(user));
     });
 
-    passport.deserializeUser((user, done) => {
+    passport.deserializeUser((user: string, done) => {
         done(null, JSON.parse(user));
     });
 

--- a/app/api/store.test.ts
+++ b/app/api/store.test.ts
@@ -4,9 +4,11 @@ import * as storeApi from './store';
 import * as store from '../store';
 
 jest.mock('../store', () => ({
-    getConfiguration: jest.fn(() => ({
-        someConfig: 'value',
-    })),
+    store: {
+        getConfiguration: jest.fn(() => ({
+            someConfig: 'value',
+        })),
+    },
 }));
 
 describe('API Store', () => {

--- a/app/api/store.ts
+++ b/app/api/store.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import express from 'express';
 import nocache from 'nocache';
-import * as store from '../store';
+import { store } from '../store';
 
 const router = express.Router();
 

--- a/app/authentications/providers/Authentication.ts
+++ b/app/authentications/providers/Authentication.ts
@@ -24,9 +24,15 @@ class Authentication extends Component {
         throw new Error('getStrategy must be implemented');
     }
 
-    getStrategyDescription() {
+    getStrategyDescription(): StrategyDescription {
         throw new Error('getStrategyDescription must be implemented');
     }
 }
 
 export default Authentication;
+
+export interface StrategyDescription {
+    type: string;
+    name: string;
+    logoutUrl?: string;
+}

--- a/app/index.test.ts
+++ b/app/index.test.ts
@@ -9,7 +9,9 @@ jest.mock('./log', () => ({
 }));
 
 jest.mock('./store', () => ({
-    init: jest.fn().mockResolvedValue(),
+    store: {
+        init: jest.fn().mockResolvedValue(),
+    },
 }));
 
 jest.mock('./registry', () => ({
@@ -50,7 +52,7 @@ describe('Main Application', () => {
         expect(log.info).toHaveBeenCalledWith(
             'WUD is starting (version = 1.0.0)',
         );
-        expect(store.init).toHaveBeenCalled();
+        expect(store.store.init).toHaveBeenCalled();
         expect(prometheus.init).toHaveBeenCalled();
         expect(registry.init).toHaveBeenCalled();
         expect(api.init).toHaveBeenCalled();

--- a/app/index.ts
+++ b/app/index.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 import { getVersion } from './configuration';
 import log from './log';
-import * as store from './store';
+import { store } from './store';
 import * as registry from './registry';
 import * as api from './api';
 import * as prometheus from './prometheus';

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -15,7 +15,6 @@
                 "body-parser": "^1.20.6",
                 "bunyan": "1.8.15",
                 "capitalize": "2.0.4",
-                "connect-loki": "1.2.0",
                 "cors": "2.8.5",
                 "dockerode": "^5.0.1",
                 "express": "^4.22.2",
@@ -4084,15 +4083,6 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.0.2",
                 "typedarray": "^0.0.6"
-            }
-        },
-        "node_modules/connect-loki": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/connect-loki/-/connect-loki-1.2.0.tgz",
-            "integrity": "sha512-SFQ3iM0km8Wt8xrbX2kOVi7HPrpCXN6Kx/pV7DX+GIK4ZwVwwQP7UIRhSQ+gv4lHEQ+Du3TTn1IcsgPwVikmwQ==",
-            "license": "MIT",
-            "dependencies": {
-                "lokijs": "^1.5.11"
             }
         },
         "node_modules/content-disposition": {

--- a/app/package.json
+++ b/app/package.json
@@ -22,7 +22,6 @@
         "body-parser": "^1.20.6",
         "bunyan": "1.8.15",
         "capitalize": "2.0.4",
-        "connect-loki": "1.2.0",
         "cors": "2.8.5",
         "dockerode": "^5.0.1",
         "express": "^4.22.2",

--- a/app/store/index.test.ts
+++ b/app/store/index.test.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import fs from 'fs';
-import * as store from './index';
+import { store } from './index';
 
 // Mock dependencies
 jest.mock('lokijs', () => {
@@ -85,7 +85,8 @@ describe('Store Module', () => {
             }));
         });
 
-        const storeWithError = await import('./index');
+        const { store: storeWithError } = await import('./index');
+
         await expect(storeWithError.init()).rejects.toThrow(
             'Database load failed',
         );

--- a/app/store/index.ts
+++ b/app/store/index.ts
@@ -1,75 +1,110 @@
-// @ts-nocheck
 import joi from 'joi';
 import Loki from 'lokijs';
 import fs from 'fs';
 import logger from '../log';
-const log = logger.child({ component: 'store' });
+import bunyan from 'bunyan';
 import { getStoreConfiguration } from '../configuration';
 
 import * as app from './app';
 import * as container from './container';
 
-// Store Configuration Schema
-const configurationSchema = joi.object().keys({
-    path: joi.string().default('/store'),
-    file: joi.string().default('wud.json'),
-});
+class Store {
+    private db: Loki;
 
-// Validate Configuration
-const configurationToValidate = configurationSchema.validate(
-    getStoreConfiguration() || {},
-);
-if (configurationToValidate.error) {
-    throw configurationToValidate.error;
-}
-const configuration = configurationToValidate.value;
+    private readonly configuration: {
+        path: string;
+        file: string;
+    };
 
-// Loki DB
-const db = new Loki(`${configuration.path}/${configuration.file}`, {
-    autosave: true,
-});
+    private log: bunyan;
+    constructor() {
+        this.log = logger.child({ component: 'store' });
 
-function createCollections() {
-    app.createCollections(db);
-    container.createCollections(db);
-}
+        // Store Configuration Schema
+        const configurationSchema = joi
+            .object<{
+                path: string;
+                file: string;
+            }>()
+            .keys({
+                path: joi.string().default('/store'),
+                file: joi.string().default('wud.json'),
+            });
 
-/**
- * Load DB.
- * @param err
- * @param resolve
- * @param reject
- * @returns {Promise<void>}
- */
-async function loadDb(err, resolve, reject) {
-    if (err) {
-        reject(err);
-    } else {
-        // Create collections
-        createCollections();
-        resolve();
+        // Validate Configuration
+        const configurationToValidate = configurationSchema.validate(
+            getStoreConfiguration() || {},
+        );
+        if (configurationToValidate.error) {
+            throw configurationToValidate.error;
+        }
+        this.configuration = configurationToValidate.value;
+
+        // Loki DB
+        this.db = new Loki(
+            `${this.configuration.path}/${this.configuration.file}`,
+            {
+                autosave: true,
+                serializationMethod: 'pretty',
+            },
+        );
+    }
+
+    createCollections() {
+        app.createCollections(this.db);
+        container.createCollections(this.db);
+    }
+    /**
+     * Load DB.
+     */
+    async loadDb(
+        err: any,
+        resolve: (value: void) => void,
+        reject: (reason?: any) => void,
+    ) {
+        if (err) {
+            reject(err);
+        } else {
+            // Create collections
+            this.createCollections();
+            resolve();
+        }
+    }
+
+    /**
+     * Init DB.
+     */
+    public async init() {
+        this.log.info(
+            `Load store from (${this.configuration.path}/${this.configuration.file})`,
+        );
+        if (!fs.existsSync(this.configuration.path)) {
+            this.log.info(`Create folder ${this.configuration.path}`);
+            fs.mkdirSync(this.configuration.path);
+        }
+
+        return new Promise<void>((resolve, reject) => {
+            this.db.loadDatabase({}, (err) =>
+                this.loadDb(err, resolve, reject),
+            );
+        });
+    }
+
+    /**
+     * Get configuration.
+     */
+    public getConfiguration() {
+        return this.configuration;
+    }
+
+    public getDb() {
+        return this.db;
+    }
+
+    public dispose() {
+        this.log.info('Disposing db store');
+        this.db.close();
     }
 }
 
-/**
- * Init DB.
- * @returns {Promise<unknown>}
- */
-export async function init() {
-    log.info(`Load store from (${configuration.path}/${configuration.file})`);
-    if (!fs.existsSync(configuration.path)) {
-        log.info(`Create folder ${configuration.path}`);
-        fs.mkdirSync(configuration.path);
-    }
-    return new Promise((resolve, reject) => {
-        db.loadDatabase({}, (err) => loadDb(err, resolve, reject));
-    });
-}
-
-/**
- * Get configuration.
- * @returns {*}
- */
-export function getConfiguration() {
-    return configuration;
-}
+export const store = new Store();


### PR DESCRIPTION
## Summary

Replace `connect-loki` with a native Loki-backed Express session store that reuses WUD’s existing Loki database.

## Changes

- Encapsulate the Loki database and store configuration in a shared `Store` instance.
- Add `LokiSessionStore` implementing the required `express-session` store methods
- Reuse the existing `Sessions` collection when the database is already initialized.
- Persist sessions in WUD’s configured Loki database.
- Remove the `connect-loki` dependency.
- Handle expired sessions using:
  - The session cookie’s expiry date when available.
  - A seven-day TTL fallback otherwise.

## Why

The previous `connect-loki` integration opened its own Loki database connection. This could result in the session store using a different database instance from the rest of WUD, preventing reliable session persistence and database reuse.
Depending on what saved at what time, sessions or the main database could have been overridden by the other save.

The new implementation shares WUD’s initialized Loki database and `Sessions` collection.

Fixes 
- #1154

