### PR TITLE
feat(mqtt): set update entity title to the container display name

### DIFF
--- a/app/triggers/providers/mqtt/Hass.test.ts
+++ b/app/triggers/providers/mqtt/Hass.test.ts
@@ -151,6 +151,23 @@ test('addContainerSensor must publish sensor discovery message expected by HA', 
     );
 });
 
+test('addContainerSensor must publish the container display name as title', async () => {
+    await hass.addContainerSensor({
+        name: 'container-name',
+        displayName: 'my-container',
+        watcher: 'watcher-name',
+        displayIcon: 'mdi:docker',
+    });
+    const discoveryPayload = JSON.parse(
+        mqttClientMock.publish.mock.calls[0][1],
+    );
+
+    // `name` drives the entity name; `title` is what the HA Updates page shows
+    // as supporting text, since the headline is the (shared) device name.
+    expect(discoveryPayload.name).toEqual('my-container');
+    expect(discoveryPayload.title).toEqual('my-container');
+});
+
 test.each(containerData)(
     'removeContainerSensor must publish sensor discovery message expected by HA',
     async ({ containerName, data }) => {

--- a/app/triggers/providers/mqtt/Hass.ts
+++ b/app/triggers/providers/mqtt/Hass.ts
@@ -172,6 +172,13 @@ class Hass {
                 name: container.displayName,
                 icon: sanitizeIcon(container.displayIcon),
                 options: {
+                    // Home Assistant's "Updates" page prints the DEVICE name as
+                    // the headline and falls back to the entity name only when
+                    // the entity has no device. Every wud container shares one
+                    // device, so without a title every row reads "wud" followed
+                    // by a bare version. `title` puts the container name into
+                    // the supporting text, making the rows distinguishable.
+                    title: container.displayName,
                     force_update: true,
                     value_template: HASS_ENTITY_VALUE_TEMPLATE,
                     latest_version_topic: containerStateSensor.topic,


### PR DESCRIPTION
## Problem

Home Assistant's **Settings → Updates** page prints the **device** name as each
row's headline, falling back to the entity name only when an entity has no
device (`frontend/src/panels/config/dashboard/ha-config-updates.ts` uses
`computeDeviceNameDisplay`). The supporting line underneath is
`<area> ⸱ <title> <latest_version>`.

Every container watched by wud is attached to one shared device (`getHaDevice()`
returns a constant `{identifiers: [hass.deviceid], name: hass.devicename}`), and
wud sets no `title`. The result is that a user with four pending container
updates sees four identical rows:

```
wud
Homelab · sha256:4fe919de
wud
Homelab · 2026.9.0
wud
Homelab · 3.1.2
wud
Homelab · 8.4.0
```

There is no way to tell which container each row refers to. The per-entity
naming is already correct — discovery publishes `name: container.displayName`
— the Updates page simply never reads it.

## Change

Add the MQTT update platform's optional `title` to the container discovery
options, set to `container.displayName`. The rows become:

```
wud
Homelab · rota-bridge sha256:4fe919de
wud
Homelab · homeassistant 2026.9.0
wud
Homelab · paperless 3.1.2
wud
Homelab · wud 8.4.0
```

`title` is already part of the MQTT update discovery schema, so nothing is
needed on the Home Assistant side — see
[`homeassistant/components/mqtt/update.py`](https://github.com/home-assistant/core/blob/dev/homeassistant/components/mqtt/update.py):
`CONF_TITLE = "title"`, accepted as `vol.Optional(CONF_TITLE): cv.string` in
`PLATFORM_SCHEMA_MODERN` (which `DISCOVERY_SCHEMA` extends) and applied via
`self._attr_title = self._config.get(CONF_TITLE)`.

`container.displayName` is used rather than `container.name`, for consistency
with the `name` field published alongside it — so a `wud.display.name` label
carries through to the Updates page too. When `displayName` is undefined the key
is dropped by `JSON.stringify`, exactly as the neighbouring `release_url`
already behaves, so existing discovery payloads are byte-identical.

## Scope

This deliberately does **not** try to fix the duplicated `wud` headline. That
needs a device per container, which is a bigger behavioural change and probably
wants an opt-in flag — see #615 (change device name) and #486 (remove the `wud`
prefix). This is the one-line improvement that makes the existing page usable in
the meantime.

## Verification

- `cd app && npx jest triggers/providers/mqtt` — 18 passed.
- Full backend suite: 1004 passed. One unrelated suite,
  `triggers/providers/command/Command.test.ts`, fails identically on a clean
  checkout of `main` on this machine (Windows), so it is pre-existing and not
  caused by this change.
- `npx eslint` and `npx prettier --check` clean on both changed files. (The
  repo's `npm run lint` script cannot run as-is on Windows — its `'**/*.ts'`
  glob is single-quoted — so ESLint was invoked directly on the changed files.)
- Not run: `ui` unit tests, `e2e`, and `ui-e2e`. This change touches only
  `app/triggers/providers/mqtt/`, and those suites need a live Docker
  environment.

A new test covers the added behaviour; the existing exact-payload assertion in
`Hass.test.ts` is unchanged and still passes, since that fixture supplies no
`displayName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
