### PR TITLE
support bearer token for custom registries

### DIFF
--- a/app/registries/providers/custom/Custom.test.ts
+++ b/app/registries/providers/custom/Custom.test.ts
@@ -29,6 +29,19 @@ test('validatedConfiguration should require a URL with concurrency', async () =>
     }).toThrow('"url" is required');
 });
 
+test('validatedConfiguration should initialize with a bearer token', async () => {
+    expect(
+        custom.validateConfiguration({
+            url: 'http://localhost:5000',
+            token: 'personal-access-token',
+        }),
+    ).toStrictEqual({
+        url: 'http://localhost:5000',
+        token: 'personal-access-token',
+        concurrency: 2,
+    });
+});
+
 test('validatedConfiguration should throw error when auth is not base64', async () => {
     expect(() => {
         custom.validateConfiguration({
@@ -43,6 +56,17 @@ test('maskConfiguration should mask configuration secrets', async () => {
         auth: undefined,
         login: 'login',
         password: 'p******d',
+        url: 'http://localhost:5000',
+    });
+});
+
+test('maskConfiguration should mask bearer tokens', async () => {
+    custom.configuration = {
+        url: 'http://localhost:5000',
+        token: 'personal-access-token',
+    };
+    expect(custom.maskConfiguration()).toEqual({
+        token: 'p*******************n',
         url: 'http://localhost:5000',
     });
 });
@@ -72,9 +96,26 @@ test('normalizeImage should return the proper registry v2 endpoint', async () =>
 });
 
 test('authenticate should add basic auth', async () => {
+    custom.configuration = {
+        login: 'login',
+        password: 'password',
+        url: 'http://localhost:5000',
+    };
     expect(custom.authenticate(undefined, { headers: {} })).resolves.toEqual({
         headers: {
             Authorization: 'Basic bG9naW46cGFzc3dvcmQ=',
+        },
+    });
+});
+
+test('authenticate should add bearer auth for a token', async () => {
+    custom.configuration = {
+        token: 'personal-access-token',
+        url: 'http://localhost:5000',
+    };
+    expect(custom.authenticate(undefined, { headers: {} })).resolves.toEqual({
+        headers: {
+            Authorization: 'Bearer personal-access-token',
         },
     });
 });
@@ -84,9 +125,9 @@ test('getAuthCredentials should return base64 creds when set in configuration', 
     expect(custom.getAuthCredentials()).toEqual('dXNlcm5hbWU6cGFzc3dvcmQ=');
 });
 
-test('getAuthCredentials should return base64 creds when login/token set in configuration', async () => {
+test('getAuthCredentials should return base64 creds when login/password set in configuration', async () => {
     custom.configuration.login = 'username';
-    custom.configuration.token = 'password';
+    custom.configuration.password = 'password';
     expect(custom.getAuthCredentials()).toEqual('dXNlcm5hbWU6cGFzc3dvcmQ=');
 });
 

--- a/app/registries/providers/custom/Custom.ts
+++ b/app/registries/providers/custom/Custom.ts
@@ -1,4 +1,5 @@
 import { AnySchema } from 'joi';
+import { AxiosRequestConfig } from 'axios';
 import DockerRegistryV2 from '../../DockerRegistryV2';
 import { ContainerImage } from '../../../model/container';
 
@@ -19,6 +20,15 @@ class Custom extends DockerRegistryV2 {
                 then: this.joi.string().required(),
                 otherwise: this.joi.any().forbidden(),
             }),
+            token: this.joi.alternatives().conditional('login', {
+                not: undefined,
+                then: this.joi.any().forbidden(),
+                otherwise: this.joi.alternatives().conditional('auth', {
+                    not: undefined,
+                    then: this.joi.any().forbidden(),
+                    otherwise: this.joi.string(),
+                }),
+            }),
             auth: this.joi.alternatives().conditional('login', {
                 not: undefined,
                 then: this.joi.any().forbidden(),
@@ -32,6 +42,17 @@ class Custom extends DockerRegistryV2 {
         });
     }
 
+    maskConfiguration() {
+        return this.maskSensitiveFields(['password', 'token', 'auth']);
+    }
+
+    /**
+     * Return true if image has no registry url.
+     */
+    match(imageUrl: string) {
+        return this.configuration.url.indexOf(imageUrl) !== -1;
+    }
+
     /**
      * Normalize images according to Custom characteristics.
      */
@@ -39,6 +60,22 @@ class Custom extends DockerRegistryV2 {
         const imageNormalized = image;
         imageNormalized.registry.url = `${this.configuration.url}/v2`;
         return imageNormalized;
+    }
+
+    async authenticate(
+        image: ContainerImage,
+        requestOptions: AxiosRequestConfig,
+    ) {
+        if (this.configuration.token) {
+            return this.authenticateBearer(
+                requestOptions,
+                this.configuration.token,
+            );
+        }
+        return this.authenticateBasic(
+            requestOptions,
+            this.getAuthCredentials(),
+        );
     }
 }
 

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -16,6 +16,7 @@ description: Unreleased changes and upcoming features in What's Up Docker (WUD).
 - 🚀 [UI] Add demo mode with mock services for static deployment
 - 🚀 [REGISTRY] Enable anonymous access by default for Gitlab public registry
 - 🚀 [REGISTRY] Enable anonymous access by default for LSCR and TrueForge public registries
+- 🚀 [REGISTRY] Support direct bearer-token authentication for custom registries
 
 - 🐛 [WATCHER] Fix docker watcher crashing on startup when `watchdigestdefault` is configured by restoring the property and passing it to registries (fixes #1150)
 - 🐛 [REGISTRY] Fix Gitlab registry provider ignoring configuration defaults (fixes Gitlab registry integration)

--- a/website/docs/configuration/registries/custom/README.md
+++ b/website/docs/configuration/registries/custom/README.md
@@ -50,6 +50,13 @@ import TabItem from '@theme/TabItem';
     supported="Base64-encoded username:password (mutually exclusive with LOGIN/PASSWORD)">
     Direct Base64-encoded `username:password` string
   </ConfigOption>
+
+  <ConfigOption name="WUD_REGISTRY_CUSTOM_{registry_name}_TOKEN"
+    type="string"
+    required={false}
+    supported="Bearer token (mutually exclusive with LOGIN/PASSWORD and AUTH)">
+    Access token sent as `Authorization: Bearer &lt;token&gt;`
+  </ConfigOption>
 </ConfigList>
 
 ---
@@ -80,6 +87,20 @@ docker run \
 
 </TabItem>
 </Tabs>
+
+### Bearer Token Authentication
+
+Use `TOKEN` when the registry accepts a bearer token directly. Do not combine it
+with `LOGIN`, `PASSWORD`, or `AUTH`.
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    environment:
+      - WUD_REGISTRY_CUSTOM_LOCAL_URL=https://registry.example.com
+      - WUD_REGISTRY_CUSTOM_LOCAL_TOKEN=personal-access-token
+```
 
 ### Authenticated Private Registry
 


### PR DESCRIPTION
## Summary

Adds direct bearer-token authentication support for custom Docker registries.

## Changes

- Adds the `TOKEN` configuration option for custom registries.
- Sends tokens using `Authorization: Bearer <token>`.
- Enforces mutual exclusivity with `LOGIN`/`PASSWORD` and `AUTH`.
- Masks bearer tokens in configuration output.
- Preserves existing Basic authentication behavior.
- Adds unit tests and documentation.
- Updates the unreleased changelog.

## Configuration example

```yaml
environment:
  - WUD_REGISTRY_CUSTOM_LOCAL_URL=https://registry.example.com
  - WUD_REGISTRY_CUSTOM_LOCAL_TOKEN=personal-access-token
```

Fixes
- #1132
