### PR TITLE
fix(docker): read the container id from Actor.ID, not the legacy flat id

### DIFF
--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -447,7 +447,11 @@ export class Docker extends Watcher {
             return;
         }
         const action = dockerEvent.Action;
-        const containerId = dockerEvent.id;
+        // The container id lives in `Actor.ID`. The flat `id` field is a
+        // legacy alias that recent daemons (Docker 29.x) no longer send,
+        // which left containerId undefined and silently disabled the
+        // status refresh below.
+        const containerId = dockerEvent.Actor?.ID ?? dockerEvent.id;
 
         // If the container was created or destroyed => perform a watch
         if (action === 'destroy' || action === 'create') {


### PR DESCRIPTION
Docker 29.x no longer sends the flat `id` / `status` fields on the events stream; the container id is only in `Actor.ID`. `containerId` was therefore always undefined, so onDockerEvent asked the daemon for `/containers/undefined/json` on every start/die and never refreshed a container's status. The exception is caught, so nothing was reported.

Verified on Docker 29.8.0: with the fix, "Status changed from running to exited" and back is logged again; without it, that line never appears.

The `?? dockerEvent.id` fallback keeps older daemons working.

Fix for https://github.com/getwud/wud/issues/1208