### PR TITLE
🚀 [TRIGGER] Add support for tags and icon in NTFY trigger (fixes #1216)

### DIFF
--- a/app/triggers/providers/ntfy/Ntfy.test.ts
+++ b/app/triggers/providers/ntfy/Ntfy.test.ts
@@ -11,6 +11,8 @@ const configurationValid = {
     url: 'http://xxx.com',
     topic: 'xxx',
     priority: 2,
+    tags: [],
+    icon: '',
     mode: 'simple',
     threshold: 'all',
     once: true,
@@ -32,6 +34,46 @@ test('validateConfiguration should return validated configuration when valid', a
     const validatedConfiguration =
         ntfy.validateConfiguration(configurationValid);
     expect(validatedConfiguration).toStrictEqual(configurationValid);
+});
+
+test('validateConfiguration should accept tags as array', async () => {
+    const validatedConfiguration = ntfy.validateConfiguration({
+        ...configurationValid,
+        tags: ['tag1', 'tag2'],
+    });
+    expect(validatedConfiguration.tags).toEqual(['tag1', 'tag2']);
+});
+
+test('validateConfiguration should accept tags as comma-separated string', async () => {
+    const validatedConfiguration = ntfy.validateConfiguration({
+        ...configurationValid,
+        tags: 'tag1, tag2, tag3',
+    });
+    expect(validatedConfiguration.tags).toEqual(['tag1', 'tag2', 'tag3']);
+});
+
+test('validateConfiguration should accept valid icon url', async () => {
+    const validatedConfiguration = ntfy.validateConfiguration({
+        ...configurationValid,
+        icon: 'https://example.com/icon.png',
+    });
+    expect(validatedConfiguration.icon).toEqual('https://example.com/icon.png');
+});
+
+test('validateConfiguration should throw error when icon is invalid', async () => {
+    expect(() => {
+        ntfy.validateConfiguration({
+            ...configurationValid,
+            icon: 'not-a-valid-url',
+        });
+    }).toThrowError(ValidationError);
+
+    expect(() => {
+        ntfy.validateConfiguration({
+            ...configurationValid,
+            icon: 'ftp://example.com/icon.png',
+        });
+    }).toThrowError(ValidationError);
 });
 
 test('validateConfiguration should throw error when invalid', async () => {
@@ -148,6 +190,106 @@ test('trigger should use bearer auth when configured like that', async () => {
         headers: {
             'Content-Type': 'application/json',
             Authorization: 'Bearer token',
+        },
+        method: 'POST',
+        url: 'http://xxx.com',
+    });
+});
+
+test('trigger should include tags and icon in payload when configured', async () => {
+    ntfy.configuration = {
+        ...configurationValid,
+        tags: ['tag1', 'tag2'],
+        icon: 'https://example.com/icon.png',
+    };
+    const container = {
+        name: 'container1',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+    };
+    axios.mockResolvedValue({ data: {} });
+    await ntfy.trigger(container);
+    expect(axios).toHaveBeenCalledWith({
+        data: {
+            message:
+                'Container container1 running with tag 1.0.0 can be updated to tag 2.0.0',
+            priority: 2,
+            title: 'New tag found for container container1',
+            topic: 'xxx',
+            tags: ['tag1', 'tag2'],
+            icon: 'https://example.com/icon.png',
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        url: 'http://xxx.com',
+    });
+});
+
+test('triggerBatch should call http client without tags and icon when not configured', async () => {
+    ntfy.configuration = configurationValid;
+    const containers = [
+        {
+            name: 'container1',
+            updateKind: {
+                kind: 'tag',
+                localValue: '1.0.0',
+                remoteValue: '2.0.0',
+            },
+        },
+    ];
+    axios.mockResolvedValue({ data: {} });
+    await ntfy.triggerBatch(containers);
+    expect(axios).toHaveBeenCalledWith({
+        data: {
+            message:
+                '- Container container1 running with tag 1.0.0 can be updated to tag 2.0.0\n',
+            priority: 2,
+            title: '1 updates available',
+            topic: 'xxx',
+        },
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        method: 'POST',
+        url: 'http://xxx.com',
+    });
+});
+
+test('triggerBatch should call http client with tags and icon when configured', async () => {
+    ntfy.configuration = {
+        ...configurationValid,
+        tags: ['tag1', 'tag2'],
+        icon: 'https://example.com/icon.png',
+    };
+    const containers = [
+        {
+            name: 'container1',
+            updateKind: {
+                kind: 'tag',
+                localValue: '1.0.0',
+                remoteValue: '2.0.0',
+            },
+        },
+    ];
+    axios.mockResolvedValue({ data: {} });
+    await ntfy.triggerBatch(containers);
+    expect(axios).toHaveBeenCalledWith({
+        data: {
+            message:
+                '- Container container1 running with tag 1.0.0 can be updated to tag 2.0.0\n',
+            priority: 2,
+            title: '1 updates available',
+            topic: 'xxx',
+            tags: ['tag1', 'tag2'],
+            icon: 'https://example.com/icon.png',
+        },
+        headers: {
+            'Content-Type': 'application/json',
         },
         method: 'POST',
         url: 'http://xxx.com',

--- a/app/triggers/providers/ntfy/Ntfy.ts
+++ b/app/triggers/providers/ntfy/Ntfy.ts
@@ -20,6 +20,24 @@ class Ntfy extends Trigger {
                 .default('https://ntfy.sh'),
             topic: this.joi.string(),
             priority: this.joi.number().integer().min(0).max(5),
+            tags: this.joi
+                .alternatives([
+                    this.joi.array().items(this.joi.string()),
+                    this.joi
+                        .string()
+                        .empty('')
+                        .custom((value) =>
+                            value.split(',').map((t) => t.trim()),
+                        ),
+                ])
+                .default([]),
+            icon: this.joi
+                .string()
+                .uri({
+                    scheme: ['http', 'https'],
+                })
+                .allow('')
+                .default(''),
             auth: this.joi.object({
                 user: this.joi.string(),
                 password: this.joi.string(),
@@ -51,12 +69,19 @@ class Ntfy extends Trigger {
      * @returns {Promise<void>}
      */
     async trigger(container) {
-        return this.sendHttpRequest({
+        const body = {
             topic: this.configuration.topic,
             title: this.renderSimpleTitle(container),
             message: this.renderSimpleBody(container),
             priority: this.configuration.priority,
-        });
+        };
+        if (this.configuration.tags && this.configuration.tags.length > 0) {
+            body.tags = this.configuration.tags;
+        }
+        if (this.configuration.icon) {
+            body.icon = this.configuration.icon;
+        }
+        return this.sendHttpRequest(body);
     }
 
     /**
@@ -65,12 +90,19 @@ class Ntfy extends Trigger {
      * @returns {Promise<*>}
      */
     async triggerBatch(containers) {
-        return this.sendHttpRequest({
+        const body = {
             topic: this.configuration.topic,
             title: this.renderBatchTitle(containers),
             message: this.renderBatchBody(containers),
             priority: this.configuration.priority,
-        });
+        };
+        if (this.configuration.tags && this.configuration.tags.length > 0) {
+            body.tags = this.configuration.tags;
+        }
+        if (this.configuration.icon) {
+            body.icon = this.configuration.icon;
+        }
+        return this.sendHttpRequest(body);
     }
 
     /**

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -29,6 +29,7 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🚀 [REGISTRY] Support direct bearer-token authentication for custom registries
 - 🚀 [REGISTRY] Add support for Docker Hardened Images (dhi.io) (fixes #875)
 - 🚀 [UI] Display Docker Compose stack / project name with filtering chip and drawer details (fixes #1205)
+- 🚀 [TRIGGER] Add support for tags and icon in NTFY trigger (fixes #1216)
 - 🔧 [DOCS] Refresh OpenID Connect (OIDC) and container registry documentation with modern Vue 3 UI screenshots and fix relative asset paths
 
 - ⚠️ [AUTH] Anonymous authentication removed: WUD now enforces mandatory authentication. At least one administrator account must be provisioned (via `WUD_AUTH_ADMIN_USER`/`WUD_AUTH_ADMIN_PASSWORD`, legacy `WUD_AUTH_BASIC_*`, or an OIDC provider with an admin group). WUD will fail-fast on startup if no administrator is available.

--- a/website/docs/configuration/triggers/ntfy/README.md
+++ b/website/docs/configuration/triggers/ntfy/README.md
@@ -45,6 +45,22 @@ import TabItem from '@theme/TabItem';
     ntfy notification priority
   </ConfigOption>
 
+  <ConfigOption
+    name="WUD_TRIGGER_NTFY_{trigger_name}_TAGS"
+    required={false}
+    type="string"
+    supported="Comma-separated tags or emojis">
+    List of tags and/or emojis (e.g. `whale,package` or `warning`) [see docs](https://docs.ntfy.sh/publish/#tags-emojis)
+  </ConfigOption>
+
+  <ConfigOption
+    name="WUD_TRIGGER_NTFY_{trigger_name}_ICON"
+    required={false}
+    type="url"
+    supported="Valid HTTP/HTTPS URL">
+    Custom icon URL to display with the notification [see docs](https://docs.ntfy.sh/publish/#icons)
+  </ConfigOption>
+
   <ConfigOption name="WUD_TRIGGER_NTFY_{trigger_name}_AUTH_TOKEN"
     required={false}
     type="string"


### PR DESCRIPTION
## Description
This PR adds support for `tags` and `icon` properties in the NTFY trigger, addressing #1216.

### Changes
- **Backend (`Ntfy.ts`)**:
  - Added Joi schema validation for `tags` (array or comma-separated string, defaults to `[]`) and `icon` (HTTP/HTTPS URL, defaults to `''`).
  - Added `tags` and `icon` to the HTTP JSON payload in both `trigger` and `triggerBatch`.
- **Tests (`Ntfy.test.ts`)**:
  - Added unit tests for schema validation (array, CSV string, valid URL, invalid URL rejection).
  - Added unit tests verifying `tags` and `icon` are passed in HTTP request payloads.
- **Documentation**:
  - Updated `website/docs/configuration/triggers/ntfy/README.md` with new parameters and environment variables.
  - Updated `website/docs/changelog/next.md`.

Fixes #1216.
