### PR TITLE
🚀 [TRIGGER] Support real container selection and labels in Trigger Test dialog

### DIFF
--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -183,4 +183,44 @@ describe('Container Store (SQLite)', () => {
 
         container.deleteContainer('stack-container-id');
     });
+
+    test('getContainer and getContainers should restore updateAvailable and updateKind from history', () => {
+        const updateContainerSample = {
+            ...sampleContainer,
+            id: 'container-update-kind',
+            name: 'update-kind-test',
+            updateAvailable: true,
+            updateKind: {
+                kind: 'tag',
+                localValue: '1.0.0',
+                remoteValue: '2.0.0',
+                semverDiff: 'major',
+            },
+            result: {
+                tag: '2.0.0',
+            },
+        };
+
+        container.insertContainer(updateContainerSample);
+
+        const fetched = container.getContainer('container-update-kind');
+        expect(fetched).toBeDefined();
+        expect(fetched?.updateAvailable).toBe(true);
+        expect(fetched?.updateKind).toEqual({
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+            semverDiff: 'major',
+        });
+
+        const list = container.getContainers({ name: 'update-kind-test' });
+        expect(list.length).toBe(1);
+        expect(list[0].updateAvailable).toBe(true);
+        expect(list[0].updateKind).toEqual({
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+            semverDiff: 'major',
+        });
+    });
 });

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -80,6 +80,20 @@ function buildContainerFromRows(
                 message: historyRow.errorMessage,
             };
         }
+        if (
+            historyRow.updateAvailable !== undefined &&
+            historyRow.updateAvailable !== null
+        ) {
+            raw.updateAvailable = Boolean(historyRow.updateAvailable);
+        }
+        if (historyRow.updateKind) {
+            raw.updateKind = {
+                kind: historyRow.updateKind,
+                localValue: historyRow.localValue ?? undefined,
+                remoteValue: historyRow.remoteValue ?? undefined,
+                semverDiff: historyRow.semverDiff ?? undefined,
+            };
+        }
     }
 
     return validateContainer(raw);

--- a/ui/src/components/TriggerTestDialog.vue
+++ b/ui/src/components/TriggerTestDialog.vue
@@ -20,9 +20,21 @@
           <strong class="text-high-emphasis">{{ trigger?.type }} / {{ trigger?.name }}</strong>.
         </div>
 
+        <v-autocomplete
+          label="Source Container"
+          v-model="selectedContainerId"
+          :items="containerOptions"
+          variant="outlined"
+          density="compact"
+          hide-details
+          clearable
+          class="mb-3"
+        />
+
         <v-text-field
           label="Container ID"
           v-model="container.id"
+          :disabled="!!selectedContainerId"
           variant="outlined"
           density="compact"
           hide-details
@@ -32,6 +44,7 @@
         <v-text-field
           label="Container Name"
           v-model="container.name"
+          :disabled="!!selectedContainerId"
           variant="outlined"
           density="compact"
           hide-details
@@ -41,6 +54,7 @@
         <v-text-field
           label="Container Watcher"
           v-model="container.watcher"
+          :disabled="!!selectedContainerId"
           variant="outlined"
           density="compact"
           hide-details
@@ -117,6 +131,7 @@
 </template>
 
 <script lang="ts">
+import { getAllContainers } from "@/services/container";
 import { runTrigger } from "@/services/trigger";
 import { defineComponent } from "vue";
 
@@ -136,10 +151,17 @@ export default defineComponent({
   data() {
     return {
       isTriggering: false,
+      containers: [] as any[],
+      selectedContainerId: null as string | null,
       container: {
         id: "123456789",
         name: "container_test",
         watcher: "watcher_test",
+        stack: "test-stack",
+        labels: {
+          "com.docker.compose.project.working_dir": "/opt/docker/container_test",
+          "com.docker.compose.service": "container_test",
+        },
         updateKind: {
           kind: "tag",
           semverDiff: "major",
@@ -152,7 +174,55 @@ export default defineComponent({
       },
     };
   },
+  computed: {
+    containerOptions(): any[] {
+      const mockOption = {
+        title: "Mock Container (Sample data)",
+        value: null,
+      };
+      const realOptions = (this.containers || []).map((c: any) => ({
+        title: `${c.name} (${c.watcher})`,
+        value: c.id,
+      }));
+      return [mockOption, ...realOptions];
+    },
+  },
+  watch: {
+    async modelValue(val: boolean) {
+      if (val) {
+        await this.loadContainers();
+      }
+    },
+    selectedContainerId(newId: string | null) {
+      if (newId) {
+        const selected = (this.containers || []).find((c: any) => c.id === newId);
+        if (selected) {
+          this.container.id = selected.id;
+          this.container.name = selected.name;
+          this.container.watcher = selected.watcher;
+          if (selected.image?.tag?.value) {
+            this.container.updateKind.localValue = selected.image.tag.value;
+          }
+        }
+      } else {
+        this.container.id = "123456789";
+        this.container.name = "container_test";
+        this.container.watcher = "watcher_test";
+        this.container.updateKind.localValue = "1.2.3";
+      }
+    },
+  },
+  async mounted() {
+    await this.loadContainers();
+  },
   methods: {
+    async loadContainers() {
+      try {
+        this.containers = (await getAllContainers()) || [];
+      } catch {
+        this.containers = [];
+      }
+    },
     close() {
       this.$emit("update:modelValue", false);
     },
@@ -160,10 +230,31 @@ export default defineComponent({
       if (!this.trigger) return;
       this.isTriggering = true;
       try {
+        let payload: any;
+        if (this.selectedContainerId) {
+          const selectedContainer = (this.containers || []).find(
+            (c: any) => c.id === this.selectedContainerId,
+          );
+          payload = selectedContainer
+            ? JSON.parse(JSON.stringify(selectedContainer))
+            : JSON.parse(JSON.stringify(this.container));
+          payload.updateAvailable = true;
+          payload.updateKind = { ...this.container.updateKind };
+          if (!payload.result) payload.result = {};
+          if (this.container.updateKind.kind === "tag") {
+            payload.result.tag = this.container.updateKind.remoteValue;
+          } else if (this.container.updateKind.kind === "digest") {
+            payload.result.digest = this.container.updateKind.remoteValue;
+          }
+          payload.result.link = this.container.updateKind.result.link;
+        } else {
+          payload = this.container;
+        }
+
         await runTrigger({
           triggerType: this.trigger.type,
           triggerName: this.trigger.name,
-          container: this.container,
+          container: payload,
         });
         (this as any).$eventBus?.emit("notify", "Trigger executed with success");
         this.close();

--- a/ui/tests/components/TriggerTestDialog.spec.ts
+++ b/ui/tests/components/TriggerTestDialog.spec.ts
@@ -1,9 +1,14 @@
 import { mount } from '@vue/test-utils';
 import TriggerTestDialog from '@/components/TriggerTestDialog.vue';
 import * as triggerService from '@/services/trigger';
+import * as containerService from '@/services/container';
 
 jest.mock('@/services/trigger', () => ({
   runTrigger: jest.fn(),
+}));
+
+jest.mock('@/services/container', () => ({
+  getAllContainers: jest.fn(),
 }));
 
 describe('TriggerTestDialog.vue', () => {
@@ -12,6 +17,38 @@ describe('TriggerTestDialog.vue', () => {
     type: 'slack',
     name: 'myslack',
   };
+
+  const mockRealContainers = [
+    {
+      id: 'real-container-1',
+      name: 'nginx-prod',
+      watcher: 'local',
+      stack: 'web',
+      labels: {
+        'com.docker.compose.service': 'nginx',
+      },
+      image: {
+        tag: {
+          value: '1.25.0',
+        },
+      },
+    },
+    {
+      id: 'real-container-2',
+      name: 'redis-cache',
+      watcher: 'remote',
+      image: {
+        tag: {
+          value: '7.0.0',
+        },
+      },
+    },
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (containerService.getAllContainers as jest.Mock).mockResolvedValue(mockRealContainers);
+  });
 
   it('renders correctly when opened', () => {
     const wrapper = mount(TriggerTestDialog, {
@@ -23,6 +60,20 @@ describe('TriggerTestDialog.vue', () => {
 
     expect(wrapper.text()).toContain('Test Trigger');
     expect(wrapper.text()).toContain('slack / myslack');
+    expect(wrapper.html()).toContain('Source Container');
+  });
+
+  it('loads containers on mount', async () => {
+    const wrapper = mount(TriggerTestDialog, {
+      props: {
+        modelValue: true,
+        trigger: mockTrigger,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+    expect(containerService.getAllContainers).toHaveBeenCalled();
+    expect((wrapper.vm as any).containers).toEqual(mockRealContainers);
   });
 
   it('emits update:modelValue on close', () => {
@@ -38,7 +89,7 @@ describe('TriggerTestDialog.vue', () => {
     expect(wrapper.emitted('update:modelValue')![0]).toEqual([false]);
   });
 
-  it('calls runTrigger service when executing trigger', async () => {
+  it('calls runTrigger with enriched mock container when no real container is selected', async () => {
     (triggerService.runTrigger as jest.Mock).mockResolvedValueOnce({ ok: true });
 
     const wrapper = mount(TriggerTestDialog, {
@@ -55,7 +106,122 @@ describe('TriggerTestDialog.vue', () => {
       container: expect.objectContaining({
         id: '123456789',
         name: 'container_test',
+        watcher: 'watcher_test',
+        stack: 'test-stack',
+        labels: {
+          'com.docker.compose.project.working_dir': '/opt/docker/container_test',
+          'com.docker.compose.service': 'container_test',
+        },
       }),
     });
+  });
+
+  it('pre-fills fields and sends cloned container payload with simulation state when real container is selected', async () => {
+    (triggerService.runTrigger as jest.Mock).mockResolvedValueOnce({ ok: true });
+
+    const wrapper = mount(TriggerTestDialog, {
+      props: {
+        modelValue: true,
+        trigger: mockTrigger,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    // Select real container
+    (wrapper.vm as any).selectedContainerId = 'real-container-1';
+    await wrapper.vm.$nextTick();
+
+    // Verify fields are pre-filled
+    expect((wrapper.vm as any).container.id).toBe('real-container-1');
+    expect((wrapper.vm as any).container.name).toBe('nginx-prod');
+    expect((wrapper.vm as any).container.watcher).toBe('local');
+    expect((wrapper.vm as any).container.updateKind.localValue).toBe('1.25.0');
+
+    // Execute trigger
+    await (wrapper.vm as any).executeTrigger();
+
+    expect(triggerService.runTrigger).toHaveBeenCalledWith({
+      triggerType: 'slack',
+      triggerName: 'myslack',
+      container: expect.objectContaining({
+        id: 'real-container-1',
+        name: 'nginx-prod',
+        watcher: 'local',
+        stack: 'web',
+        labels: {
+          'com.docker.compose.service': 'nginx',
+        },
+        updateAvailable: true,
+        updateKind: expect.objectContaining({
+          kind: 'tag',
+          localValue: '1.25.0',
+          remoteValue: '4.5.6',
+        }),
+        result: expect.objectContaining({
+          tag: '4.5.6',
+          link: 'https://my-container/release-notes/',
+        }),
+      }),
+    });
+  });
+
+  it('supports digest update simulation when real container is selected', async () => {
+    (triggerService.runTrigger as jest.Mock).mockResolvedValueOnce({ ok: true });
+
+    const wrapper = mount(TriggerTestDialog, {
+      props: {
+        modelValue: true,
+        trigger: mockTrigger,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    (wrapper.vm as any).selectedContainerId = 'real-container-1';
+    await wrapper.vm.$nextTick();
+
+    (wrapper.vm as any).container.updateKind.kind = 'digest';
+    (wrapper.vm as any).container.updateKind.remoteValue = 'sha256:abcdef123456';
+
+    await (wrapper.vm as any).executeTrigger();
+
+    expect(triggerService.runTrigger).toHaveBeenCalledWith({
+      triggerType: 'slack',
+      triggerName: 'myslack',
+      container: expect.objectContaining({
+        id: 'real-container-1',
+        name: 'nginx-prod',
+        updateAvailable: true,
+        updateKind: expect.objectContaining({
+          kind: 'digest',
+          remoteValue: 'sha256:abcdef123456',
+        }),
+        result: expect.objectContaining({
+          digest: 'sha256:abcdef123456',
+        }),
+      }),
+    });
+  });
+
+  it('resets container fields to default mock when clearing container selection', async () => {
+    const wrapper = mount(TriggerTestDialog, {
+      props: {
+        modelValue: true,
+        trigger: mockTrigger,
+      },
+    });
+
+    await wrapper.vm.$nextTick();
+
+    (wrapper.vm as any).selectedContainerId = 'real-container-1';
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as any).container.name).toBe('nginx-prod');
+
+    (wrapper.vm as any).selectedContainerId = null;
+    await wrapper.vm.$nextTick();
+    expect((wrapper.vm as any).container.name).toBe('container_test');
+    expect((wrapper.vm as any).container.id).toBe('123456789');
+    expect((wrapper.vm as any).container.watcher).toBe('watcher_test');
   });
 });

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -30,6 +30,7 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🚀 [REGISTRY] Add support for Docker Hardened Images (dhi.io) (fixes #875)
 - 🚀 [UI] Display Docker Compose stack / project name with filtering chip and drawer details (fixes #1205)
 - 🚀 [TRIGGER] Add support for tags and icon in NTFY trigger (fixes #1216)
+- 🚀 [TRIGGER] Support real container selection and labels in Trigger Test dialog (fixes #1216)
 - 🚀 [TRIGGER] Overhaul Home Assistant MQTT integration with update entity, install actions, per-watcher devices, and storm prevention (fixes #1148, #649, #381, #216)
 - 🔧 [DOCS] Refresh OpenID Connect (OIDC) and container registry documentation with modern Vue 3 UI screenshots and fix relative asset paths
 


### PR DESCRIPTION
Closes #1216

### Summary of Changes

1. **Frontend (`TriggerTestDialog.vue`)**:
   - Added a **Source Container** (`v-autocomplete`) allowing users to pick an actual existing container from WUD as the test base, with a fallback option for the default mock container.
   - When an actual container is selected, its real properties (`labels`, `stack`, `image`, etc.) are cloned and injected with the simulated update state (`updateAvailable: true`, simulated `updateKind`, `result.tag`/`result.digest`, `result.link`).
   - The default mock container now includes sample compose labels (`com.docker.compose.project.working_dir`, `com.docker.compose.service`) and `stack: 'test-stack'` so template tests work out of the box even without a real container selected.
   - Container identifier fields are auto-populated and set to readonly when an actual container is chosen.
   - Added comprehensive unit tests in `TriggerTestDialog.spec.ts`.

2. **Backend (`app/store/container.ts`)**:
   - Rehydrated `updateAvailable` and `updateKind` from `historyRow` in `buildContainerFromRows` so that `getContainer` and `getContainers` completely restore the update status.
   - Added unit test coverage in `app/store/container.test.ts`.

3. **Changelog**:
   - Updated `website/docs/changelog/next.md`.