### PR TITLE
🐛 [AUTH] Hide basic strategy from login when no local users exist

### DIFF
--- a/app/api/auth.test.ts
+++ b/app/api/auth.test.ts
@@ -1,11 +1,18 @@
 import express from 'express';
 import request from 'supertest';
 import * as auth from './auth';
+import * as registry from '../registry';
+import { countLocalUsers } from '../store/user';
 
 jest.mock('./SqliteSessionStore', () => {
     const session = require('express-session');
     return jest.fn().mockImplementation(() => new session.MemoryStore());
 });
+
+jest.mock('../store/user', () => ({
+    getUserById: jest.fn(),
+    countLocalUsers: jest.fn(),
+}));
 
 jest.mock('../store', () => ({
     store: {
@@ -47,6 +54,20 @@ describe('API Auth', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        (registry.getState as jest.Mock).mockReturnValue({
+            authentication: {
+                mockAuth: {
+                    getId: () => 'mockAuth',
+                    getStrategy: () => ({ name: 'mockStrategy' }),
+                    getStrategyDescription: () => ({
+                        type: 'mock',
+                        name: 'Mock Auth',
+                        logoutUrl: 'http://logout',
+                    }),
+                },
+            },
+        });
+        (countLocalUsers as jest.Mock).mockResolvedValue(1);
         app = express();
         app.use(express.json());
 
@@ -82,6 +103,67 @@ describe('API Auth', () => {
         expect(res.body).toEqual([
             { type: 'mock', name: 'Mock Auth', logoutUrl: 'http://logout' },
         ]);
+    });
+
+    test('GET /auth/strategies should exclude basic strategy when countLocalUsers is 0', async () => {
+        (countLocalUsers as jest.Mock).mockResolvedValue(0);
+        (registry.getState as jest.Mock).mockReturnValue({
+            authentication: {
+                basicAuth: {
+                    getId: () => 'basicAuth',
+                    getStrategy: () => ({ name: 'basic' }),
+                    getStrategyDescription: () => ({
+                        type: 'basic',
+                        name: 'Local Credentials',
+                    }),
+                },
+                oidcAuth: {
+                    getId: () => 'oidcAuth',
+                    getStrategy: () => ({ name: 'oidc' }),
+                    getStrategyDescription: () => ({
+                        type: 'oidc',
+                        name: 'Keycloak',
+                    }),
+                },
+            },
+        });
+
+        const res = await request(app).get('/auth/strategies');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual([{ type: 'oidc', name: 'Keycloak' }]);
+        expect(countLocalUsers).toHaveBeenCalled();
+    });
+
+    test('GET /auth/strategies should include basic strategy when countLocalUsers > 0', async () => {
+        (countLocalUsers as jest.Mock).mockResolvedValue(2);
+        (registry.getState as jest.Mock).mockReturnValue({
+            authentication: {
+                basicAuth: {
+                    getId: () => 'basicAuth',
+                    getStrategy: () => ({ name: 'basic' }),
+                    getStrategyDescription: () => ({
+                        type: 'basic',
+                        name: 'Local Credentials',
+                    }),
+                },
+                oidcAuth: {
+                    getId: () => 'oidcAuth',
+                    getStrategy: () => ({ name: 'oidc' }),
+                    getStrategyDescription: () => ({
+                        type: 'oidc',
+                        name: 'Keycloak',
+                    }),
+                },
+            },
+        });
+
+        const res = await request(app).get('/auth/strategies');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual([
+            { type: 'oidc', name: 'Keycloak' },
+            { type: 'basic', name: 'Local Credentials' },
+        ]);
+        expect(countLocalUsers).toHaveBeenCalled();
     });
 
     test('POST /auth/login should return user', async () => {

--- a/app/api/auth.ts
+++ b/app/api/auth.ts
@@ -11,7 +11,7 @@ import SqliteSessionStore from './SqliteSessionStore';
 import Authentication, {
     StrategyDescription,
 } from '../authentications/providers/Authentication';
-import { getUserById } from '../store/user';
+import { getUserById, countLocalUsers } from '../store/user';
 import { verifyToken } from '../store/token';
 
 const router = express.Router();
@@ -81,7 +81,7 @@ function useStrategy(authentication: Authentication, app) {
     }
 }
 
-function getUniqueStrategies() {
+async function getUniqueStrategies() {
     const strategies = Object.values(registry.getState().authentication).map(
         (authentication) => authentication.getStrategyDescription(),
     );
@@ -96,18 +96,31 @@ function getUniqueStrategies() {
             uniqueStrategies.push(strategy);
         }
     });
+
+    // If basic strategy is present, only expose it if there is at least one local user in the database
+    const hasBasic = uniqueStrategies.find((s) => s.type === 'basic');
+    if (hasBasic) {
+        const localUserCount = await countLocalUsers();
+        if (localUserCount === 0) {
+            return uniqueStrategies
+                .filter((s) => s.type !== 'basic')
+                .sort((s1, s2) => s1.name.localeCompare(s2.name));
+        }
+    }
+
     return uniqueStrategies.sort((s1, s2) => s1.name.localeCompare(s2.name));
 }
 
 /**
  * Return the registered strategies from the registry.
  */
-function getStrategies(req, res) {
-    res.json(getUniqueStrategies());
+async function getStrategies(req, res) {
+    res.json(await getUniqueStrategies());
 }
 
-function getLogoutRedirectUrl() {
-    const strategyWithRedirectUrl = getUniqueStrategies().find(
+async function getLogoutRedirectUrl() {
+    const strategies = await getUniqueStrategies();
+    const strategyWithRedirectUrl = strategies.find(
         (strategy) => strategy.logoutUrl,
     );
     if (strategyWithRedirectUrl) {
@@ -137,10 +150,10 @@ function login(req, res) {
 /**
  * Logout current user.
  */
-function logout(req, res) {
+async function logout(req, res) {
     req.logout(() => {});
     res.status(200).json({
-        logoutUrl: getLogoutRedirectUrl(),
+        logoutUrl: await getLogoutRedirectUrl(),
     });
 }
 

--- a/app/store/user.test.ts
+++ b/app/store/user.test.ts
@@ -8,6 +8,7 @@ import {
     deleteUser,
     countUsers,
     countAdminUsers,
+    countLocalUsers,
     hashPassword,
     verifyPassword,
 } from './user';
@@ -105,6 +106,29 @@ describe('User Store', () => {
         const admins = await countAdminUsers();
         expect(total).toBeGreaterThanOrEqual(2);
         expect(admins).toBeGreaterThanOrEqual(2);
+    });
+
+    test('should count local users correctly', async () => {
+        const initialLocal = await countLocalUsers();
+        const oidcUser = await createUser({
+            username: 'oidc-user',
+            provider: 'oidc',
+            role: 'ro',
+        });
+        // countLocalUsers should not increase when adding an OIDC user
+        expect(await countLocalUsers()).toBe(initialLocal);
+
+        const localUser = await createUser({
+            username: 'another-local-user',
+            provider: 'local',
+            password: 'password',
+            role: 'ro',
+        });
+        expect(await countLocalUsers()).toBe(initialLocal + 1);
+
+        await deleteUser(localUser.id);
+        await deleteUser(oidcUser.id);
+        expect(await countLocalUsers()).toBe(initialLocal);
     });
 
     test('should delete a user', async () => {

--- a/app/store/user.ts
+++ b/app/store/user.ts
@@ -231,3 +231,16 @@ export async function countAdminUsers(): Promise<number> {
         .get();
     return count ? Number(count.count) : 0;
 }
+
+/**
+ * Count number of local users.
+ */
+export async function countLocalUsers(): Promise<number> {
+    const db = getDb();
+    const count = db
+        .select({ count: sql<number>`count(*)` })
+        .from(users)
+        .where(eq(users.provider, 'local'))
+        .get();
+    return count ? Number(count.count) : 0;
+}

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -8,4 +8,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 > Changes below are merged on `main` and will be included in the upcoming release.
 
 ---
-
+- 🐛 [AUTH] Hide basic strategy from login when no local users exist in database


### PR DESCRIPTION
## Description
When running WUD in pure OIDC environments where no local database users (`provider = 'local'`) exist, exposing the basic credentials login form is unnecessary and confusing.

This PR dynamically filters out the `basic` authentication strategy from `GET /api/auth/strategies` whenever `countLocalUsers() === 0`. When at least one local user is present in the database, the strategy is exposed as normal.

## Changes
- `app/store/user.ts`: Add `countLocalUsers()` to count users with `provider = 'local'`.
- `app/api/auth.ts`: Make `getUniqueStrategies()` async and exclude `basic` when `countLocalUsers() === 0`.
- `app/store/user.test.ts`: Add unit test for `countLocalUsers()`.
- `app/api/auth.test.ts`: Add unit tests for `GET /auth/strategies` with 0 and > 0 local users.
- `website/docs/changelog/next.md`: Add changelog entry.