### PR TITLE
🚀 [COMMUNITY] Add GitHub Sponsors integration across repository, documentation and web UI

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# These are supported funding model platforms
+
+github: [fmartinou]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![CI Status](https://img.shields.io/github/actions/workflow/status/getwud/wud/ci.yml?branch=main&style=flat-square&logo=githubactions&logoColor=white)](https://github.com/getwud/wud/actions/workflows/ci.yml)
 [![License](https://img.shields.io/github/license/getwud/wud?style=flat-square&color=41B883)](https://github.com/getwud/wud/blob/main/LICENSE)
 [![Documentation](https://img.shields.io/badge/docs-getwud.github.io%2Fwud-2563EB?style=flat-square&logo=docusaurus&logoColor=white)](https://getwud.app/)
+[![GitHub Sponsors](https://img.shields.io/badge/Sponsor-GitHub-ea4aaa?style=flat-square&logo=githubsponsors&logoColor=white)](https://github.com/sponsors/fmartinou)
 [![Buy Me A Coffee](https://img.shields.io/badge/Donate-Buy%20Me%20A%20Coffee-orange?style=flat-square&logo=buy-me-a-coffee)](https://www.buymeacoffee.com/61rUNMm)
 [![Donate PayPal](https://img.shields.io/badge/Donate-PayPal-00457C?style=flat-square&logo=paypal&logoColor=white)](https://www.paypal.com/donate/?business=ZSDMEC3ZE8DQ8&no_recurring=0&currency_code=EUR)
 
@@ -173,12 +174,15 @@ For complete setup guides, advanced configurations, tutorials, and API reference
 
 ---
 
-## 🤝 Community & Support
+## 💖 Supporting WUD
 
-- 🛠️ **Want to contribute?** Read our [Developer & Contributing Guide](CONTRIBUTING.md).
-- 🐛 **Found a bug or need a feature?** Submit an [Issue](https://github.com/getwud/wud/issues).
-- ⭐ **Like WUD?** Give us a star on [GitHub](https://github.com/getwud/wud)!
-- ☕ **Support the maintainer:** [Buy me a coffee](https://www.buymeacoffee.com/61rUNMm) or [Donate via PayPal](https://www.paypal.com/donate/?business=ZSDMEC3ZE8DQ8&no_recurring=0&currency_code=EUR).
+WUD is free and open-source software built and maintained with passion. If WUD saves you time or helps keep your homelab and production containers running up-to-date, please consider supporting its ongoing development:
+
+- 💖 **[Sponsor @fmartinou on GitHub Sponsors](https://github.com/sponsors/fmartinou)**
+- ☕ **[Buy me a coffee](https://www.buymeacoffee.com/61rUNMm)**
+- 💳 **[Donate via PayPal](https://www.paypal.com/donate/?business=ZSDMEC3ZE8DQ8&no_recurring=0&currency_code=EUR)**
+
+Your support helps cover domain name renewals (`getwud.app`), AI developer tooling subscriptions, and rewards the time spent maintaining registry integrations and building new features. Thank you!
 
 ---
 

--- a/ui/src/components/NavigationDrawer.vue
+++ b/ui/src/components/NavigationDrawer.vue
@@ -125,6 +125,34 @@
           <v-list-item-title class="text-body-2 font-weight-medium">Documentation</v-list-item-title>
         </v-list-item>
 
+        <!-- Sponsor Link -->
+        <div v-if="mini" class="d-flex justify-center mb-1">
+          <v-btn
+            icon="mdi-heart"
+            variant="text"
+            density="comfortable"
+            size="small"
+            color="pink"
+            href="https://github.com/sponsors/fmartinou"
+            target="_blank"
+            class="rounded-lg"
+          >
+            <v-icon size="20" color="pink">mdi-heart</v-icon>
+            <v-tooltip activator="parent" location="right">Sponsor WUD</v-tooltip>
+          </v-btn>
+        </div>
+        <v-list-item
+          v-else
+          href="https://github.com/sponsors/fmartinou"
+          target="_blank"
+          rounded="lg"
+          class="nav-item mb-1 text-pink"
+          prepend-icon="mdi-heart"
+          append-icon="mdi-open-in-new"
+        >
+          <v-list-item-title class="text-body-2 font-weight-medium">Sponsor WUD</v-list-item-title>
+        </v-list-item>
+
         <!-- User / Settings Menu -->
         <v-menu location="top end" offset="8" :close-on-content-click="false">
           <template v-slot:activator="{ props }">

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -9,3 +9,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 
 ---
 - 🐛 [AUTH] Hide basic strategy from login when no local users exist in database
+- 🚀 [COMMUNITY] Add GitHub Sponsors integration across repository and documentation

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -201,6 +201,11 @@ const config = {
             position: 'right',
           },
           {
+            href: 'https://github.com/sponsors/fmartinou',
+            position: 'right',
+            label: '💖 Sponsor',
+          },
+          {
             href: 'https://github.com/getwud/wud',
             position: 'right',
             className: 'header-github-link',


### PR DESCRIPTION
## Description
Integrates GitHub Sponsors (`@fmartinou`) cleanly across the WUD ecosystem:

- **Repository**:
  - Adds `.github/FUNDING.yml` pointing to `github: [fmartinou]` to activate the native GitHub Sponsor button.
  - Adds a GitHub Sponsors badge at the top of `README.md`.
  - Adds a humble, dedicated `## 💖 Supporting WUD` section in `README.md`.
- **Documentation Website (`getwud.app`)**:
  - Adds a discreet `💖 Sponsor` link in the top navigation bar of Docusaurus.
- **Web UI (`ui/`)**:
  - Adds an elegant, non-intrusive `Sponsor WUD` link with a heart icon in the navigation drawer footer.

## Validation
- UI unit tests: 41/41 suites passed (246 tests).
- UI linter: clean, 0 errors.
- Documentation website build: clean build passed.
- Changelog updated in `website/docs/changelog/next.md`.