### PR TITLE
🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges

### DIFF
--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
     title: WUD REST API
-    version: 1.0.0
+    version: 9.0.0
     description: |
         Welcome to the *WUD* REST API documentation.
 

--- a/ui/src/public-path.ts
+++ b/ui/src/public-path.ts
@@ -1,6 +1,8 @@
 // Set runtime public path for webpack dynamic chunk loading
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-const basePath = ((window as any).__WUD_BASE_PATH__ || '/').replace(/\/?$/, '/');
-// eslint-disable-next-line camelcase
-__webpack_public_path__ = basePath;
+if ((window as any).__WUD_BASE_PATH__) {
+  const basePath = (window as any).__WUD_BASE_PATH__.replace(/\/?$/, '/');
+  // eslint-disable-next-line camelcase
+  __webpack_public_path__ = basePath;
+}
 

--- a/ui/tests/public-path.spec.ts
+++ b/ui/tests/public-path.spec.ts
@@ -6,10 +6,11 @@ describe('public-path.ts', () => {
     jest.resetModules();
   });
 
-  it('sets __webpack_public_path__ to / when __WUD_BASE_PATH__ is not set', () => {
+  it('does not set __webpack_public_path__ when __WUD_BASE_PATH__ is not set', () => {
     delete (window as any).__WUD_BASE_PATH__;
+    delete (global as any).__webpack_public_path__;
     require('@/public-path');
-    expect((global as any).__webpack_public_path__).toBe('/');
+    expect((global as any).__webpack_public_path__).toBeUndefined();
   });
 
   it('sets __webpack_public_path__ to base path with trailing slash', () => {

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -10,3 +10,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 ---
 - 🐛 [AUTH] Hide basic strategy from login when no local users exist in database
 - 🚀 [COMMUNITY] Add GitHub Sponsors integration across repository and documentation
+- 🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -224,7 +224,7 @@ const config = {
               },
               {
                 label: 'API Reference',
-                to: '/docs/api',
+                to: '/docs/api/reference/wud-rest-api',
               },
             ],
           },

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -119,6 +119,11 @@
   background-color: var(--ifm-navbar-link-hover-color);
 }
 
+/* Hide redundant OpenAPI version badge inside markdown content since Docusaurus already displays the doc version badge */
+.theme-doc-markdown .theme-doc-version-badge {
+  display: none;
+}
+
 /* Subtle micro-animations for interactive elements */
 .navbar__item,
 .button,

--- a/website/src/pages/docs/api/index.tsx
+++ b/website/src/pages/docs/api/index.tsx
@@ -1,0 +1,6 @@
+import React from 'react';
+import { Redirect } from '@docusaurus/router';
+
+export default function ApiRedirect(): React.JSX.Element {
+  return <Redirect to="/docs/api/reference/wud-rest-api" />;
+}

--- a/website/versioned_docs/version-9.0.0/api/reference/wud-rest-api.info.mdx
+++ b/website/versioned_docs/version-9.0.0/api/reference/wud-rest-api.info.mdx
@@ -14,11 +14,6 @@ import SchemaTabs from "@theme/SchemaTabs";
 import TabItem from "@theme/TabItem";
 import Export from "@theme/ApiExplorer/Export";
 
-<span
-  className={"theme-doc-version-badge badge badge--secondary"}
-  children={"Version: 1.0.0"}
->
-</span>
 
 <Export
   url={"/wud/openapi.yaml"}


### PR DESCRIPTION
### Summary of Changes

1. **Live Demo blank screen fix**:
   - Fixed `public-path.ts` which was setting Webpack's `__webpack_public_path__` to `'/'` whenever `window.__WUD_BASE_PATH__` was undefined.
   - In demo mode (`website/static/demo-app`), chunk requests were resolving to root `/js/...` instead of relative `./js/...`, causing 404 errors on dynamic route imports and preventing views from rendering.
   - Added unit test in `ui/tests/public-path.spec.ts` and rebuilt the demo bundle.

2. **Footer API Reference 404 fix**:
   - Updated the footer link in `website/docusaurus.config.js` from `/docs/api` to `/docs/api/reference/wud-rest-api`.
   - Added a client-side redirect in `website/src/pages/docs/api/index.tsx` to ensure any direct navigation to `/docs/api` redirects gracefully.

3. **Duplicate version badges on API page**:
   - Updated `info.version` to `9.0.0` in `app/api/openapi.yaml`.
   - Removed duplicate inline version badges in generated and versioned API MDX docs.
   - Added CSS rule `.theme-doc-markdown .theme-doc-version-badge { display: none; }` in `website/src/css/custom.css` so only Docusaurus' official document version badge is displayed.

### Verification
- [x] UI unit tests passed: `npm run test:unit` (41 suites, 246 passed)
- [x] UI linter passed: `npm run lint` (0 errors)
- [x] Demo UI build verified: `npm run build:demo`
- [x] Backend unit tests passed: `npm test` (106 suites, 1100 passed)
- [x] Backend linter passed: `npm run lint` (0 errors)
- [x] Documentation static build passed cleanly without broken links: `npm run build`