### PR TITLE
📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference

### DIFF
--- a/app/configuration/index.test.ts
+++ b/app/configuration/index.test.ts
@@ -157,3 +157,16 @@ test('getPrometheusConfiguration should be disabled when overridden', () => {
         enabled: false,
     });
 });
+
+test('getAuthenticationConfigurations should return auth providers and exclude admin key', () => {
+    configuration.wudEnvVars.WUD_AUTH_ADMIN_USER = 'admin';
+    configuration.wudEnvVars.WUD_AUTH_ADMIN_PASSWORD = 'password';
+    configuration.wudEnvVars.WUD_AUTH_OIDC_DISCOVERY =
+        'https://oidc.example.com';
+    const authConfigs = configuration.getAuthenticationConfigurations();
+    expect(authConfigs).toHaveProperty('oidc');
+    expect(authConfigs).not.toHaveProperty('admin');
+    delete configuration.wudEnvVars.WUD_AUTH_ADMIN_USER;
+    delete configuration.wudEnvVars.WUD_AUTH_ADMIN_PASSWORD;
+    delete configuration.wudEnvVars.WUD_AUTH_OIDC_DISCOVERY;
+});

--- a/app/configuration/index.ts
+++ b/app/configuration/index.ts
@@ -93,7 +93,12 @@ export function getRegistryConfigurations() {
  * @returns {*}
  */
 export function getAuthenticationConfigurations() {
-    return get('wud.auth', wudEnvVars);
+    const authConfigs = get('wud.auth', wudEnvVars) as any;
+    if (authConfigs && typeof authConfigs === 'object') {
+        const { admin, ...providers } = authConfigs;
+        return providers;
+    }
+    return authConfigs;
 }
 
 /**

--- a/app/store/auth_bootstrap.test.ts
+++ b/app/store/auth_bootstrap.test.ts
@@ -53,6 +53,23 @@ describe('Auth Bootstrap', () => {
         await expect(bootstrapAuth()).resolves.not.toThrow();
     });
 
+    test('should allow startup if named OIDC instance is configured with admin group', async () => {
+        (
+            configuration.getAuthenticationConfigurations as jest.Mock
+        ).mockReturnValue({
+            oidc: {
+                authentik: {
+                    discovery: 'https://oidc.example.com',
+                    admingroup: 'wud-admins',
+                },
+            },
+        });
+        (configuration.get as jest.Mock).mockReturnValue(undefined);
+
+        // Should not throw error
+        await expect(bootstrapAuth()).resolves.not.toThrow();
+    });
+
     test('should throw fail-fast error when DB is empty and no admin config exists', async () => {
         (
             configuration.getAuthenticationConfigurations as jest.Mock
@@ -60,7 +77,7 @@ describe('Auth Bootstrap', () => {
         (configuration.get as jest.Mock).mockReturnValue(undefined);
 
         await expect(bootstrapAuth()).rejects.toThrow(
-            /Authentication is mandatory: No administrator user found/,
+            'Authentication is mandatory: No administrator user found. Please set WUD_AUTH_ADMIN_USER and WUD_AUTH_ADMIN_PASSWORD, or configure WUD_AUTH_OIDC_{name}_ADMINGROUP.',
         );
     });
 });

--- a/app/store/auth_bootstrap.ts
+++ b/app/store/auth_bootstrap.ts
@@ -116,17 +116,12 @@ export async function bootstrapAuth(): Promise<void> {
 
     // 4. Check if OIDC is configured with an admin group
     const oidcConfig = authConfigs.oidc;
-    const envVars = wudEnvVars as Record<string, any>;
     if (oidcConfig && typeof oidcConfig === 'object') {
         const hasOidcWithAdmin =
-            (oidcConfig.discovery &&
-                (oidcConfig.admingroup || envVars.WUD_AUTH_OIDC_ADMIN_GROUP)) ||
+            (oidcConfig.discovery && oidcConfig.admingroup) ||
             Object.values(oidcConfig).some(
                 (c: any) =>
-                    c &&
-                    typeof c === 'object' &&
-                    c.discovery &&
-                    (c.admingroup || envVars.WUD_AUTH_OIDC_ADMIN_GROUP),
+                    c && typeof c === 'object' && c.discovery && c.admingroup,
             );
         if (hasOidcWithAdmin) {
             log.info(
@@ -138,9 +133,9 @@ export async function bootstrapAuth(): Promise<void> {
 
     // 5. Fail-fast
     log.error(
-        'Authentication is mandatory. No administrator user exists in the database, and no administrator is configured via environment variables (WUD_AUTH_ADMIN_USER / WUD_AUTH_ADMIN_PASSWORD) or OIDC admin group (WUD_AUTH_OIDC_ADMIN_GROUP). Please configure an administrator to start WUD.',
+        'Authentication is mandatory. No administrator user exists in the database, and no administrator is configured via environment variables (WUD_AUTH_ADMIN_USER / WUD_AUTH_ADMIN_PASSWORD) or OIDC admin group (WUD_AUTH_OIDC_{name}_ADMINGROUP). Please configure an administrator to start WUD.',
     );
     throw new Error(
-        'Authentication is mandatory: No administrator user found. Please set WUD_AUTH_ADMIN_USER and WUD_AUTH_ADMIN_PASSWORD, or configure WUD_AUTH_OIDC_ADMIN_GROUP.',
+        'Authentication is mandatory: No administrator user found. Please set WUD_AUTH_ADMIN_USER and WUD_AUTH_ADMIN_PASSWORD, or configure WUD_AUTH_OIDC_{name}_ADMINGROUP.',
     );
 }

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -11,3 +11,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🐛 [AUTH] Hide basic strategy from login when no local users exist in database
 - 🚀 [COMMUNITY] Add GitHub Sponsors integration across repository and documentation
 - 🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges
+- 📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference (fixes #1226)

--- a/website/docs/configuration/authentications/README.md
+++ b/website/docs/configuration/authentications/README.md
@@ -28,7 +28,7 @@ Alternatively, WUD maintains backward compatibility with legacy basic authentica
 
 ### Omitting the Local Administrator with OIDC SSO
 
-If you configure an OpenID Connect provider with an administrator group (`WUD_AUTH_OIDC_{name}_ADMINGROUP` or `WUD_AUTH_OIDC_ADMIN_GROUP`), **you do not need any local administrator account** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
+If you configure an OpenID Connect provider with an administrator group (`WUD_AUTH_OIDC_{name}_ADMINGROUP`), **you do not need any local administrator account** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
 
 WUD's startup verification recognizes the OIDC admin group configuration and starts cleanly without requiring local admin credentials. Upon their first login, any user belonging to the configured admin group is automatically provisioned and assigned the `admin` role in WUD. This enables a 100% SSO-driven, zero-local-credentials deployment!
 

--- a/website/docs/configuration/authentications/oidc/README.md
+++ b/website/docs/configuration/authentications/oidc/README.md
@@ -112,7 +112,7 @@ When a user logs in through OIDC, WUD automatically creates an account in the in
 :::
 
 :::tip[Zero Local Credentials: Omit Local Administrator with OIDC]
-If you define `WUD_AUTH_OIDC_{name}_ADMINGROUP` (or the global `WUD_AUTH_OIDC_ADMIN_GROUP`), **you do not need to configure any local administrator** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
+If you define `WUD_AUTH_OIDC_{name}_ADMINGROUP`, **you do not need to configure any local administrator** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
 
 WUD's startup verification recognizes that your Identity Provider provides administrative users, allowing the container to start cleanly without local credentials. When a user in the admin group logs in via OIDC for the first time, WUD automatically provisions their account and grants them full `admin` permissions. This enables a 100% SSO-driven, zero-local-credentials deployment!
 :::

--- a/website/versioned_docs/version-9.0.0/configuration/authentications/README.md
+++ b/website/versioned_docs/version-9.0.0/configuration/authentications/README.md
@@ -28,7 +28,7 @@ Alternatively, WUD maintains backward compatibility with legacy basic authentica
 
 ### Omitting the Local Administrator with OIDC SSO
 
-If you configure an OpenID Connect provider with an administrator group (`WUD_AUTH_OIDC_{name}_ADMINGROUP` or `WUD_AUTH_OIDC_ADMIN_GROUP`), **you do not need any local administrator account** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
+If you configure an OpenID Connect provider with an administrator group (`WUD_AUTH_OIDC_{name}_ADMINGROUP`), **you do not need any local administrator account** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
 
 WUD's startup verification recognizes the OIDC admin group configuration and starts cleanly without requiring local admin credentials. Upon their first login, any user belonging to the configured admin group is automatically provisioned and assigned the `admin` role in WUD. This enables a 100% SSO-driven, zero-local-credentials deployment!
 

--- a/website/versioned_docs/version-9.0.0/configuration/authentications/oidc/README.md
+++ b/website/versioned_docs/version-9.0.0/configuration/authentications/oidc/README.md
@@ -112,7 +112,7 @@ When a user logs in through OIDC, WUD automatically creates an account in the in
 :::
 
 :::tip[Zero Local Credentials: Omit Local Administrator with OIDC]
-If you define `WUD_AUTH_OIDC_{name}_ADMINGROUP` (or the global `WUD_AUTH_OIDC_ADMIN_GROUP`), **you do not need to configure any local administrator** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
+If you define `WUD_AUTH_OIDC_{name}_ADMINGROUP`, **you do not need to configure any local administrator** (`WUD_AUTH_ADMIN_USER` / `WUD_AUTH_ADMIN_PASSWORD`).
 
 WUD's startup verification recognizes that your Identity Provider provides administrative users, allowing the container to start cleanly without local credentials. When a user in the admin group logs in via OIDC for the first time, WUD automatically provisions their account and grants them full `admin` permissions. This enables a 100% SSO-driven, zero-local-credentials deployment!
 :::


### PR DESCRIPTION
## Description
Resolves #1226 by clarifying OIDC admin group configuration and removing invalid global environment variable references:
- In `app/store/auth_bootstrap.ts`, removed references to `WUD_AUTH_OIDC_ADMIN_GROUP` and updated error messages to use the legitimate modular instance format `WUD_AUTH_OIDC_{name}_ADMINGROUP`.
- In `app/configuration/index.ts`, excluded the `admin` key in `getAuthenticationConfigurations()` so that WUD does not attempt to register `admin` as an authentication provider.
- In documentation (`docs/` and `versioned_docs/version-9.0.0/`), removed references to `WUD_AUTH_OIDC_ADMIN_GROUP` to align with the standard modular syntax `WUD_AUTH_OIDC_{name}_ADMINGROUP`.
- Updated changelog.