### PR TITLE
📝 [DOCS] Update documentation URLs in registry error logs to point to getwud.app

### DIFF
--- a/app/registry/index.test.ts
+++ b/app/registry/index.test.ts
@@ -445,3 +445,35 @@ test('deregisterWatchers should throw when errors occurred', async () => {
         'Error when deregistering component .',
     );
 });
+
+test('getDocumentationLink should return correct URLs for each component kind', () => {
+    const getDocumentationLink = registry.testable_getDocumentationLink;
+    expect(getDocumentationLink('trigger')).toBe(
+        'https://getwud.app/docs/configuration/triggers',
+    );
+    expect(getDocumentationLink('watcher')).toBe(
+        'https://getwud.app/docs/configuration/watchers',
+    );
+    expect(getDocumentationLink('registry')).toBe(
+        'https://getwud.app/docs/configuration/registries',
+    );
+    expect(getDocumentationLink('authentication')).toBe(
+        'https://getwud.app/docs/configuration/authentications',
+    );
+    expect(getDocumentationLink('unknown')).toBe(
+        'https://getwud.app/docs/configuration',
+    );
+});
+
+test('getHelpfulErrorMessage should include getwud.app doc link when provider not found', () => {
+    const getHelpfulErrorMessage = registry.testable_getHelpfulErrorMessage;
+    const message = getHelpfulErrorMessage(
+        'authentication',
+        'oidc_admin',
+        "Cannot find module './oidc_admin'",
+        ['oidc'],
+    );
+    expect(message).toContain(
+        'For more information, visit: https://getwud.app/docs/configuration/authentications',
+    );
+});

--- a/app/registry/index.ts
+++ b/app/registry/index.ts
@@ -69,19 +69,12 @@ function getAvailableProviders(basePath: string) {
  */
 function getDocumentationLink(kind: ComponentKind) {
     const docLinks: Record<ComponentKind, string> = {
-        trigger:
-            'https://github.com/getwud/wud/tree/main/docs/configuration/triggers',
-        watcher:
-            'https://github.com/getwud/wud/tree/main/docs/configuration/watchers',
-        registry:
-            'https://github.com/getwud/wud/tree/main/docs/configuration/registries',
-        authentication:
-            'https://github.com/getwud/wud/tree/main/docs/configuration/authentications',
+        trigger: 'https://getwud.app/docs/configuration/triggers',
+        watcher: 'https://getwud.app/docs/configuration/watchers',
+        registry: 'https://getwud.app/docs/configuration/registries',
+        authentication: 'https://getwud.app/docs/configuration/authentications',
     };
-    return (
-        docLinks[kind] ||
-        'https://github.com/getwud/wud/tree/main/docs/configuration'
-    );
+    return docLinks[kind] || 'https://getwud.app/docs/configuration';
 }
 
 /**
@@ -451,5 +444,7 @@ export {
     deregisterWatchers as testable_deregisterWatchers,
     deregisterAuthentications as testable_deregisterAuthentications,
     deregisterAll as testable_deregisterAll,
+    getDocumentationLink as testable_getDocumentationLink,
+    getHelpfulErrorMessage as testable_getHelpfulErrorMessage,
     log as testable_log,
 };

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -12,4 +12,5 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🚀 [COMMUNITY] Add GitHub Sponsors integration across repository and documentation
 - 🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges
 - 📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference (fixes #1226)
+- 📝 [DOCS] Update documentation URLs in registry error logs to point to getwud.app (fixes #1233)
 - 🐛 [UI] Fix application version display in UI, mock data, and store


### PR DESCRIPTION
## Description

Following the migration of the documentation site to Docusaurus at [getwud.app](https://getwud.app), component provider error logs in `app/registry/index.ts` were still referencing `https://github.com/getwud/wud/tree/main/docs/configuration/...` which returned 404.

This PR updates `getDocumentationLink` to return `https://getwud.app/docs/configuration/${kind}s` (and `https://getwud.app/docs/configuration` as fallback).

Fixes #1233.

## Changes
- `app/registry/index.ts`: Update doc links mapping to `getwud.app`.
- `app/registry/index.test.ts`: Add unit tests for `getDocumentationLink` and `getHelpfulErrorMessage`.
- `website/docs/changelog/next.md`: Record entry in unreleased changelog.

## Checklist
- [x] Backend unit tests pass
- [x] Code is linted without errors
- [x] Documentation website builds cleanly (`npm run build` in `website/`)
- [x] Changelog entry added in `website/docs/changelog/next.md`