### PR TITLE
🐛 [STORE] Fix container query filtering on updateAvailable (fixes #1197)

### DIFF
--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -223,4 +223,77 @@ describe('Container Store (SQLite)', () => {
             semverDiff: 'major',
         });
     });
+
+    test('getContainers should filter by updateAvailable and combined query parameters', () => {
+        const containerWithUpdate = {
+            ...sampleContainer,
+            id: 'c-with-update',
+            name: 'c-with-update',
+            watcher: 'docker-local',
+            updateAvailable: true,
+            result: {
+                tag: '1.1.0',
+            },
+        };
+        const containerNoUpdate = {
+            ...sampleContainer,
+            id: 'c-no-update',
+            name: 'c-no-update',
+            watcher: 'docker-local',
+            updateAvailable: false,
+            result: {
+                tag: '1.0.0',
+            },
+        };
+        const containerOtherWatcherWithUpdate = {
+            ...sampleContainer,
+            id: 'c-other-watcher-with-update',
+            name: 'c-other-watcher-with-update',
+            watcher: 'docker-remote',
+            updateAvailable: true,
+            result: {
+                tag: '2.0.0',
+            },
+        };
+
+        container.insertContainer(containerWithUpdate);
+        container.insertContainer(containerNoUpdate);
+        container.insertContainer(containerOtherWatcherWithUpdate);
+
+        // Filter only updateAvailable: true
+        const withUpdateOnly = container.getContainers({
+            updateAvailable: true,
+        });
+        expect(withUpdateOnly.map((c) => c.id).sort()).toEqual([
+            'c-other-watcher-with-update',
+            'c-with-update',
+        ]);
+
+        // Filter only updateAvailable: false
+        const noUpdateOnly = container.getContainers({
+            updateAvailable: false,
+        });
+        expect(noUpdateOnly.map((c) => c.id)).toEqual(['c-no-update']);
+
+        // Combined filter watcher + updateAvailable: true
+        const combined = container.getContainers({
+            watcher: 'docker-local',
+            updateAvailable: true,
+        });
+        expect(combined.map((c) => c.id)).toEqual(['c-with-update']);
+
+        // Combined filter watcher + updateAvailable: false
+        const combinedNoUpdate = container.getContainers({
+            watcher: 'docker-local',
+            updateAvailable: false,
+        });
+        expect(combinedNoUpdate.map((c) => c.id)).toEqual(['c-no-update']);
+
+        // Non-matching filter
+        const nonMatching = container.getContainers({
+            watcher: 'docker-remote',
+            updateAvailable: false,
+        });
+        expect(nonMatching).toEqual([]);
+    });
 });

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -363,18 +363,9 @@ export function getContainers(query: Record<string, any> = {}): Container[] {
         return [];
     }
 
-    let containerRows = db.select().from(schema.containers).all();
+    const containerRows = db.select().from(schema.containers).all();
 
-    // In-memory filter for any query attributes
-    if (query && Object.keys(query).length > 0) {
-        containerRows = containerRows.filter((row) => {
-            return Object.entries(query).every(
-                ([k, v]) => (row as any)[k] === v,
-            );
-        });
-    }
-
-    const containerList = containerRows.map((containerRow) => {
+    let containerList = containerRows.map((containerRow) => {
         const imageRow = db
             .select()
             .from(schema.containerImages)
@@ -393,6 +384,15 @@ export function getContainers(query: Record<string, any> = {}): Container[] {
 
         return buildContainerFromRows(containerRow, imageRow, historyRow);
     });
+
+    // In-memory filter for any query attributes
+    if (query && Object.keys(query).length > 0) {
+        containerList = containerList.filter((container) => {
+            return Object.entries(query).every(
+                ([k, v]) => (container as any)[k] === v,
+            );
+        });
+    }
 
     return containerList.sort(
         byValues([

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -13,4 +13,5 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges
 - 📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference (fixes #1226)
 - 📝 [DOCS] Update documentation URLs in registry error logs to point to getwud.app (fixes #1233)
+- 🐛 [STORE] Fix container query filtering on updateAvailable and hydrated properties (fixes #1197)
 - 🐛 [UI] Fix application version display in UI, mock data, and store


### PR DESCRIPTION
### Description
Fix container query filtering in `containerStore.getContainers(query)` by applying the query filter on fully hydrated container objects rather than raw SQLite rows.

### Context
Fixes #1197. Resolves the issue where `updateAvailable` queries returned empty arrays, causing Home Assistant MQTT sensor counters (`update_count` and `update_status`) to remain at 0/false.

### Changes
- `app/store/container.ts`: Move in-memory query filter after container hydration.
- `app/store/container.test.ts`: Add tests for `updateAvailable` and combined query filtering.
- `website/docs/changelog/next.md`: Add changelog entry.

### Checklist
- [x] Backend unit tests pass (`store/container.test.ts`, `triggers/providers/mqtt/Hass.test.ts`)
- [x] Code is linted without errors (`npm run lint`)
- [x] Documentation website builds cleanly (`npm run build` in `website/`)
- [x] Changelog entry added in `website/docs/changelog/next.md`