### PR TITLE
🧪 [TESTS] Add end-to-end MQTT and Home Assistant discovery test suite

### DIFF
--- a/e2e/config/index.js
+++ b/e2e/config/index.js
@@ -4,4 +4,5 @@ module.exports = {
     port: process.env.WUD_PORT || 3000,
     username: process.env.WUD_USERNAME || 'john',
     password: process.env.WUD_PASSWORD || 'doe',
+    mqttUrl: process.env.MQTT_URL || `mqtt://${process.env.MQTT_HOST || '127.0.0.1'}:${process.env.MQTT_PORT || 1883}`,
 };

--- a/e2e/features/api-trigger.feature
+++ b/e2e/features/api-trigger.feature
@@ -4,7 +4,7 @@ Feature: WUD Trigger API Exposure
     When I GET /api/triggers
     Then response code should be 200
     And response body should be valid json
-    And response body path $ should be of type array with length 1
+    And response body path $ should be of type array with length 2
     And response body path $[0].id should be mock.example
     And response body path $[0].type should be mock
     And response body path $[0].name should be example
@@ -14,6 +14,9 @@ Feature: WUD Trigger API Exposure
     And response body path $[0].configuration.simpletitle should be New \$\{container.updateKind.kind\} found for container \$\{container.name\}
     And response body path $[0].configuration.batchtitle should be \$\{containers.length\} updates available
     And response body path $[0].configuration.mock should be mock
+    And response body path $[1].id should be mqtt.e2e
+    And response body path $[1].type should be mqtt
+    And response body path $[1].name should be e2e
 
   Scenario: WUD must allow to get specific Triggers state
     When I GET /api/triggers/mock/example
@@ -28,3 +31,15 @@ Feature: WUD Trigger API Exposure
     And response body path $.configuration.simpletitle should be New \$\{container.updateKind.kind\} found for container \$\{container.name\}
     And response body path $.configuration.batchtitle should be \$\{containers.length\} updates available
     And response body path $.configuration.mock should be mock
+
+  Scenario: WUD must allow to get MQTT trigger state
+    When I GET /api/triggers/mqtt/e2e
+    Then response code should be 200
+    And response body should be valid json
+    And response body path $.id should be mqtt.e2e
+    And response body path $.type should be mqtt
+    And response body path $.name should be e2e
+    And response body path $.configuration.url should be mqtt://mosquitto:1883
+    And response body path $.configuration.topic should be wud/container
+    And response body path $.configuration.hass.enabled should be true
+    And response body path $.configuration.hass.discovery should be true

--- a/e2e/features/mqtt.feature
+++ b/e2e/features/mqtt.feature
@@ -1,0 +1,88 @@
+Feature: MQTT Trigger and Home Assistant Auto-Discovery
+
+  Background:
+    Given I connect to the MQTT broker
+
+  Scenario: WUD publishes connection status to MQTT
+    Then an MQTT message should be published on topic "wud/container/status"
+    And the MQTT message on topic "wud/container/status" should equal "online"
+    And an MQTT message should be published on topic "homeassistant/binary_sensor/wud_container_status/config"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_status/config" should be valid json
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_status/config" path "unique_id" should be "wud_container_status"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_status/config" path "device_class" should be "connectivity"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_status/config" path "state_topic" should be "wud/container/status"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_status/config" path "device.identifiers[0]" should be "wud"
+
+  Scenario: WUD publishes global container count sensors to MQTT
+    Then an MQTT message should be published on topic "wud/container/total_count"
+    And the MQTT message on topic "wud/container/total_count" should equal "9"
+    And an MQTT message should be published on topic "wud/container/update_count"
+    And the MQTT message on topic "wud/container/update_count" should match "^\d+$"
+    And an MQTT message should be published on topic "wud/container/update_status"
+    And the MQTT message on topic "wud/container/update_status" should equal "true"
+
+  Scenario: WUD publishes global count sensors discovery to Home Assistant
+    Then an MQTT message should be published on topic "homeassistant/sensor/wud_container_total_count/config"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_total_count/config" path "unique_id" should be "wud_container_total_count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_total_count/config" path "name" should be "Total container count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_total_count/config" path "state_topic" should be "wud/container/total_count"
+    And an MQTT message should be published on topic "homeassistant/sensor/wud_container_update_count/config"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_update_count/config" path "unique_id" should be "wud_container_update_count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_update_count/config" path "name" should be "Total container update count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_update_count/config" path "state_topic" should be "wud/container/update_count"
+    And an MQTT message should be published on topic "homeassistant/binary_sensor/wud_container_update_status/config"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_update_status/config" path "unique_id" should be "wud_container_update_status"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_update_status/config" path "name" should be "Total container update status"
+
+  Scenario: WUD publishes per-watcher sensors to MQTT
+    Then an MQTT message should be published on topic "wud/container/local/total_count"
+    And the MQTT message on topic "wud/container/local/total_count" should equal "9"
+    And an MQTT message should be published on topic "wud/container/local/update_count"
+    And the MQTT message on topic "wud/container/local/update_count" should match "^\d+$"
+    And an MQTT message should be published on topic "wud/container/local/update_status"
+    And the MQTT message on topic "wud/container/local/update_status" should equal "true"
+    And an MQTT message should be published on topic "wud/container/local/running"
+    And the MQTT message on topic "wud/container/local/running" should equal "false"
+
+  Scenario: WUD publishes per-watcher sensors discovery to Home Assistant
+    Then an MQTT message should be published on topic "homeassistant/sensor/wud_container_local_total_count/config"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_local_total_count/config" path "unique_id" should be "wud_container_local_total_count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_local_total_count/config" path "device.identifiers[0]" should be "wud_local"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_local_total_count/config" path "device.name" should be "wud (local)"
+    And an MQTT message should be published on topic "homeassistant/sensor/wud_container_local_update_count/config"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_local_update_count/config" path "unique_id" should be "wud_container_local_update_count"
+    And the MQTT message on topic "homeassistant/sensor/wud_container_local_update_count/config" path "device.identifiers[0]" should be "wud_local"
+    And an MQTT message should be published on topic "homeassistant/binary_sensor/wud_container_local_update_status/config"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_local_update_status/config" path "unique_id" should be "wud_container_local_update_status"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_local_update_status/config" path "device.identifiers[0]" should be "wud_local"
+    And an MQTT message should be published on topic "homeassistant/binary_sensor/wud_container_local_running/config"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_local_running/config" path "unique_id" should be "wud_container_local_running"
+    And the MQTT message on topic "homeassistant/binary_sensor/wud_container_local_running/config" path "device.identifiers[0]" should be "wud_local"
+
+  Scenario Outline: WUD publishes container update entity discovery to Home Assistant
+    Then an MQTT message should be published on topic "homeassistant/update/<entityId>/config"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" should be valid json
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "unique_id" should be "<entityId>"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "state_topic" should be "<stateTopic>"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "latest_version_topic" should be "<stateTopic>"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "command_topic" should be "<commandTopic>"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "payload_install" should be "INSTALL"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "icon" should be "<icon>"
+    And the MQTT message on topic "homeassistant/update/<entityId>/config" path "device.identifiers[0]" should be "wud_local"
+    Examples:
+      | entityId                                     | stateTopic                                  | commandTopic                                        | icon                 |
+      | wud_container_local_hub_alpine_latest        | wud/container/local/hub_alpine_latest       | wud/container/local/hub_alpine_latest/install       | mdi:linux            |
+      | wud_container_local_hub_nginx_latest         | wud/container/local/hub_nginx_latest        | wud/container/local/hub_nginx_latest/install        | mdi:server-network   |
+      | wud_container_local_hub_homeassistant_202161| wud/container/local/hub_homeassistant_202161| wud/container/local/hub_homeassistant_202161/install| mdi:home-assistant   |
+      | wud_container_local_quay_prometheus         | wud/container/local/quay_prometheus        | wud/container/local/quay_prometheus/install         | mdi:chart-areaspline |
+
+  Scenario Outline: WUD publishes container state payloads to MQTT
+    Then an MQTT message should be published on topic "<topic>"
+    And the MQTT message on topic "<topic>" should be valid json
+    And the MQTT message on topic "<topic>" path "name" should be "<containerName>"
+    And the MQTT message on topic "<topic>" path "watcher" should be "local"
+    And the MQTT message on topic "<topic>" path "update_available" should be <update_available>
+    Examples:
+      | topic                                 | containerName            | update_available |
+      | wud/container/local/hub_alpine_latest | hub_alpine_latest        | false            |
+      | wud/container/local/hub_nginx_latest  | hub_nginx_latest         | true             |

--- a/e2e/features/step_definitions/mqtt.js
+++ b/e2e/features/step_definitions/mqtt.js
@@ -1,0 +1,179 @@
+const mqtt = require('mqtt');
+const assert = require('assert');
+const {
+    Given,
+    Then,
+    AfterAll,
+    setDefaultTimeout,
+} = require('@cucumber/cucumber');
+const configuration = require('../../config');
+
+setDefaultTimeout(20 * 1000);
+
+let client = null;
+const receivedMessages = new Map();
+const waitingListeners = [];
+
+function getValueByPath(obj, path) {
+    const keys = path.replace(/\[(\d+)\]/g, '.$1').split('.');
+    return keys.reduce((curr, key) => {
+        if (curr === undefined || curr === null) {
+            return undefined;
+        }
+        return curr[key];
+    }, obj);
+}
+
+function getMqttClient() {
+    return new Promise((resolve, reject) => {
+        if (client && client.connected) {
+            resolve(client);
+            return;
+        }
+
+        const brokerUrl = configuration.mqttUrl;
+        client = mqtt.connect(brokerUrl, {
+            clientId: `wud_e2e_${Math.random().toString(16).substring(2, 8)}`,
+            clean: true,
+            connectTimeout: 5000,
+        });
+
+        client.on('connect', () => {
+            client.subscribe('#', { qos: 0 }, (err) => {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                setTimeout(() => resolve(client), 500);
+            });
+        });
+
+        client.on('message', (topic, message) => {
+            const payload = message.toString();
+            receivedMessages.set(topic, payload);
+
+            for (let i = waitingListeners.length - 1; i >= 0; i -= 1) {
+                const listener = waitingListeners[i];
+                if (listener.topic === topic) {
+                    listener.resolve(payload);
+                    waitingListeners.splice(i, 1);
+                }
+            }
+        });
+
+        client.on('error', (err) => {
+            reject(err);
+        });
+    });
+}
+
+function waitForMessage(topic, timeoutMs = 3000) {
+    if (receivedMessages.has(topic)) {
+        return Promise.resolve(receivedMessages.get(topic));
+    }
+
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => {
+            const index = waitingListeners.findIndex(
+                (l) => l.topic === topic && l.resolve === resolve,
+            );
+            if (index !== -1) {
+                waitingListeners.splice(index, 1);
+            }
+            reject(new Error(`Timeout waiting for MQTT message on topic: ${topic}`));
+        }, timeoutMs);
+
+        waitingListeners.push({
+            topic,
+            resolve: (val) => {
+                clearTimeout(timer);
+                resolve(val);
+            },
+        });
+    });
+}
+
+Given(/^I connect to the MQTT broker$/, async () => {
+    await getMqttClient();
+});
+
+Then(/^an MQTT message should be published on topic "([^"]*)"$/, async (topic) => {
+    const payload = await waitForMessage(topic);
+    assert(payload !== undefined, `Expected message on topic ${topic}`);
+});
+
+Then(/^no MQTT message should be published on topic "([^"]*)"$/, (topic) => {
+    assert(
+        !receivedMessages.has(topic),
+        `Expected no message on topic ${topic}, but received: ${receivedMessages.get(topic)}`,
+    );
+});
+
+Then(/^the MQTT message on topic "([^"]*)" should equal "([^"]*)"$/, async (topic, expected) => {
+    const payload = await waitForMessage(topic);
+    assert.strictEqual(payload, expected, `Topic ${topic} expected "${expected}" but got "${payload}"`);
+});
+
+Then(/^the MQTT message on topic "([^"]*)" should match "([^"]*)"$/, async (topic, regexStr) => {
+    const payload = await waitForMessage(topic);
+    const regex = new RegExp(regexStr);
+    assert(regex.test(payload), `Topic ${topic} payload "${payload}" does not match regex "${regexStr}"`);
+});
+
+Then(/^the MQTT message on topic "([^"]*)" should be valid json$/, async (topic) => {
+    const payload = await waitForMessage(topic);
+    try {
+        JSON.parse(payload);
+    } catch (e) {
+        assert.fail(`Topic ${topic} payload is not valid JSON: ${payload}`);
+    }
+});
+
+Then(/^the MQTT message on topic "([^"]*)" path "([^"]*)" should be "([^"]*)"$/, async (topic, path, expected) => {
+    const payload = await waitForMessage(topic);
+    const json = JSON.parse(payload);
+    const actual = getValueByPath(json, path);
+    assert.strictEqual(
+        String(actual),
+        expected,
+        `Topic ${topic} at path "${path}" expected "${expected}" but got "${actual}"`,
+    );
+});
+
+Then(/^the MQTT message on topic "([^"]*)" path "([^"]*)" should be (true|false|\d+(?:\.\d+)?)$/, async (topic, path, expected) => {
+    const payload = await waitForMessage(topic);
+    const json = JSON.parse(payload);
+    const actual = getValueByPath(json, path);
+    let expectedTyped;
+    if (expected === 'true') {
+        expectedTyped = true;
+    } else if (expected === 'false') {
+        expectedTyped = false;
+    } else {
+        expectedTyped = Number(expected);
+    }
+    assert.strictEqual(
+        actual,
+        expectedTyped,
+        `Topic ${topic} at path "${path}" expected ${expectedTyped} but got ${actual}`,
+    );
+});
+
+Then(/^the MQTT message on topic "([^"]*)" path "([^"]*)" should contain "([^"]*)"$/, async (topic, path, expected) => {
+    const payload = await waitForMessage(topic);
+    const json = JSON.parse(payload);
+    const actual = getValueByPath(json, path);
+    assert(
+        String(actual).includes(expected),
+        `Topic ${topic} at path "${path}" value "${actual}" does not contain "${expected}"`,
+    );
+});
+
+AfterAll(async () => {
+    if (client) {
+        await new Promise((resolve) => {
+            client.end(false, resolve);
+        });
+        client = null;
+    }
+});

--- a/e2e/package-lock.json
+++ b/e2e/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@cucumber/cucumber": "11.1.1",
-        "apickli": "3.0.3"
+        "apickli": "3.0.3",
+        "mqtt": "5.14.1"
       },
       "devDependencies": {
         "@dotenvx/dotenvx": "^1.51.4",
@@ -38,6 +39,15 @@
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
       "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -606,17 +616,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "22.20.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.2.tgz",
+      "integrity": "sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.4.tgz",
       "integrity": "sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==",
       "license": "MIT"
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.24",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.24.tgz",
+      "integrity": "sha512-NRvUNC/JFGPJvqdAfEve8oginbM6V08u5NzLWpG8MwA2kTPOLnqk+wpwuPT+mp3aUsxyuT6m2gnrPuHYCruzEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/uuid": {
       "version": "9.0.8",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
       "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@ungap/structured-clone": {
       "version": "1.3.3",
@@ -632,6 +669,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
       }
     },
     "node_modules/acorn": {
@@ -986,6 +1035,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -993,6 +1062,49 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/bl": {
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-6.1.6.tgz",
+      "integrity": "sha512-jLsPgN/YSvPUg9UX0Kd73CXpm2Psg9FxMeCSXnk3WBO3CMT10JMwijubhGfHCnFu6TPn1ei3b975dxv7K2pWVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.0",
+        "buffer": "^6.0.3",
+        "inherits": "^2.0.4",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/bl/node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/bl/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/body-parser": {
@@ -1049,6 +1161,42 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/broker-factory": {
+      "version": "3.1.15",
+      "resolved": "https://registry.npmjs.org/broker-factory/-/broker-factory-3.1.15.tgz",
+      "integrity": "sha512-ko+aWvgNuP49meGrdjUu7rC+Y+Wai3cCPxP3xWwHsHfehFjOh5ZQM2yC4gEB2UddeZ/YXhm0K1eG/L6fxym2Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -1248,6 +1396,12 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/commist": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-3.2.0.tgz",
+      "integrity": "sha512-4PIMoPniho+LqXmpS5d3NuGYncG6XWlkBSVGiWycL22dd42OYdUGil2CWuzklaJoNxyxUSpO4MKIBU94viWNAw==",
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -2292,6 +2446,24 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -2355,6 +2527,19 @@
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
       "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
       "license": "MIT"
+    },
+    "node_modules/fast-unique-numbers": {
+      "version": "9.0.27",
+      "resolved": "https://registry.npmjs.org/fast-unique-numbers/-/fast-unique-numbers-9.0.27.tgz",
+      "integrity": "sha512-nDA9ADeINN8SA2u2wCtU+siWFTTDqQR37XvgPIDDmboWQeExz7X0mImxuaN+kJddliIqy2FpVRmnvRZ+j8i1/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=18.2.0"
+      }
     },
     "node_modules/fast-uri": {
       "version": "3.1.7",
@@ -3003,6 +3188,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/help-me": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-5.0.0.tgz",
+      "integrity": "sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==",
+      "license": "MIT"
+    },
     "node_modules/hosted-git-info": {
       "version": "2.8.9",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
@@ -3057,6 +3248,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3143,6 +3354,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-array-buffer": {
@@ -3677,6 +3897,16 @@
       },
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/js-sdsl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/js-sdsl"
       }
     },
     "node_modules/js-tokens": {
@@ -4368,6 +4598,103 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/mqtt": {
+      "version": "5.14.1",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-5.14.1.tgz",
+      "integrity": "sha512-NxkPxE70Uq3Ph7goefQa7ggSsVzHrayCD0OyxlJgITN/EbzlZN+JEPmaAZdxP1LsIT5FamDyILoQTF72W7Nnbw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/readable-stream": "^4.0.21",
+        "@types/ws": "^8.18.1",
+        "commist": "^3.2.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.4.1",
+        "help-me": "^5.0.0",
+        "lru-cache": "^10.4.3",
+        "minimist": "^1.2.8",
+        "mqtt-packet": "^9.0.2",
+        "number-allocator": "^1.0.14",
+        "readable-stream": "^4.7.0",
+        "rfdc": "^1.4.1",
+        "socks": "^2.8.6",
+        "split2": "^4.2.0",
+        "worker-timers": "^8.0.23",
+        "ws": "^8.18.3"
+      },
+      "bin": {
+        "mqtt": "build/bin/mqtt.js",
+        "mqtt_pub": "build/bin/pub.js",
+        "mqtt_sub": "build/bin/sub.js"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/mqtt-packet": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-9.0.2.tgz",
+      "integrity": "sha512-MvIY0B8/qjq7bKxdN1eD+nrljoeaai+qjLJgfRn3TiMuz0pamsIWY2bFODPZMSNmabsLANXsLl4EMoWvlaTZWA==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^6.0.8",
+        "debug": "^4.3.4",
+        "process-nextick-args": "^2.0.1"
+      }
+    },
+    "node_modules/mqtt/node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/mqtt/node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/mqtt/node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/mqtt/node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4522,6 +4849,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/number-allocator": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.14.tgz",
+      "integrity": "sha512-OrL44UTVAvkKdOdRQZIJpLkAdjXGTRda052sN4sO77bKEzYYqWKMBjQvrJFzqygI99gL6Z4u2xctPW1tB8ErvA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.1",
+        "js-sdsl": "4.3.0"
       }
     },
     "node_modules/oauth-sign": {
@@ -5627,6 +5964,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "license": "MIT"
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6090,6 +6433,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.10",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.10.tgz",
+      "integrity": "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6146,6 +6513,15 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
       "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
       "license": "CC0-1.0"
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -6891,6 +7267,12 @@
         "node": ">=20.18.1"
       }
     },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -7103,6 +7485,53 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/worker-factory": {
+      "version": "7.0.50",
+      "resolved": "https://registry.npmjs.org/worker-factory/-/worker-factory-7.0.50.tgz",
+      "integrity": "sha512-hhwc0G+sFwM4qBuhJIUBn2p1Jf8v/FwmLUANBf/Q+Lt2uI8mfIZQhXaZQACodQD4R7Zp6cn/6702bIvNn2puJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1"
+      }
+    },
+    "node_modules/worker-timers": {
+      "version": "8.0.34",
+      "resolved": "https://registry.npmjs.org/worker-timers/-/worker-timers-8.0.34.tgz",
+      "integrity": "sha512-WXL+Dqsm0G6dnC66rQsvM3tPT2adhbqSirWUCZGglkALOr8ocS0KlpU0iuKbjflJOlu3ydZikMEVrYnHOM9suw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-timers-broker": "^8.0.18",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-broker": {
+      "version": "8.0.18",
+      "resolved": "https://registry.npmjs.org/worker-timers-broker/-/worker-timers-broker-8.0.18.tgz",
+      "integrity": "sha512-FrjzDVX1wKfZN0gRbCFqv8VHuTncG4sbI/WGEg4tSSQeIsnwqg4YBYWMAHYLJtUDEYYmiK65UKFrVMVk2irDSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "broker-factory": "^3.1.15",
+        "fast-unique-numbers": "^9.0.27",
+        "tslib": "^2.8.1",
+        "worker-timers-worker": "^9.0.15"
+      }
+    },
+    "node_modules/worker-timers-worker": {
+      "version": "9.0.15",
+      "resolved": "https://registry.npmjs.org/worker-timers-worker/-/worker-timers-worker-9.0.15.tgz",
+      "integrity": "sha512-KKUe7lZ/Aignr51H6hOUik8LwTnIgojH/1lwhli8A8qIEIyewogZTpNpMW5B6BF7nmwBOkUoTYgf1H3QShcjSA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.7",
+        "tslib": "^2.8.1",
+        "worker-factory": "^7.0.50"
+      }
+    },
     "node_modules/wrap-ansi": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
@@ -7205,6 +7634,27 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -15,7 +15,8 @@
   "license": "MIT",
   "dependencies": {
     "@cucumber/cucumber": "11.1.1",
-    "apickli": "3.0.3"
+    "apickli": "3.0.3",
+    "mqtt": "5.14.1"
   },
   "devDependencies": {
     "@dotenvx/dotenvx": "^1.51.4",

--- a/scripts/docker-compose.e2e.yml
+++ b/scripts/docker-compose.e2e.yml
@@ -12,6 +12,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
       - WUD_TRIGGER_MOCK_EXAMPLE_MOCK=mock
+      - WUD_TRIGGER_MQTT_E2E_URL=mqtt://mosquitto:1883
+      - WUD_TRIGGER_MQTT_E2E_TOPIC=wud/container
+      - WUD_TRIGGER_MQTT_E2E_HASS_ENABLED=true
+      - WUD_TRIGGER_MQTT_E2E_HASS_DISCOVERY=true
+      - WUD_TRIGGER_MQTT_E2E_HASS_PREFIX=homeassistant
+      - WUD_TRIGGER_MQTT_E2E_HASS_DEVICEID=wud
+      - WUD_TRIGGER_MQTT_E2E_HASS_DEVICENAME=wud
       - WUD_WATCHER_LOCAL_WATCHBYDEFAULT=false
       - WUD_REGISTRY_ECR_PRIVATE_ACCESSKEYID=${AWS_ACCESSKEY_ID:-dummy}
       - WUD_REGISTRY_ECR_PRIVATE_SECRETACCESSKEY=${AWS_SECRET_ACCESSKEY:-dummy}
@@ -46,6 +53,15 @@ services:
       - WUD_AUTH_OIDC_MOCK_DISCOVERY=http://mock-oidc:8080/.well-known/openid-configuration
     depends_on:
       - mock-oidc
+      - mosquitto
+
+  mosquitto:
+    image: eclipse-mosquitto:2
+    container_name: mosquitto
+    ports:
+      - "1883:1883"
+    volumes:
+      - ./mosquitto.conf:/mosquitto/config/mosquitto.conf:ro
 
   mock-oidc:
     image: node:24-alpine

--- a/scripts/mosquitto.conf
+++ b/scripts/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -14,5 +14,6 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference (fixes #1226)
 - 📝 [DOCS] Update documentation URLs in registry error logs to point to getwud.app (fixes #1233)
 - 🐛 [STORE] Fix container query filtering on updateAvailable and hydrated properties (fixes #1197)
+- 🧪 [TESTS] Add end-to-end MQTT and Home Assistant discovery test suite
 - 🐛 [UI] Fix application version display in UI, mock data, and store
 - 🛠️ [RELEASE] Improve release script for non-major versions and prune unreleased changelog from doc snapshots


### PR DESCRIPTION
### Description
Adds comprehensive end-to-end test scenarios for MQTT trigger and Home Assistant auto-discovery:
- Mosquitto broker service in `scripts/docker-compose.e2e.yml` with custom config (`scripts/mosquitto.conf`)
- MQTT client helper and step definitions in `e2e/features/step_definitions/mqtt.js`
- Gherkin feature suite in `e2e/features/mqtt.feature` covering:
  - Broker connection status (`online`)
  - Global container count sensors & HA discovery (`total_count`, `update_count`, `update_status`)
  - Per-watcher sensors & HA discovery (`total_count`, `update_count`, `update_status`, `running`)
  - Container update entity discovery (`update` component, `command_topic`, `payload_install`, `icon`, `device`)
  - Container state payloads and `updateAvailable` status
- Updated API trigger exposure feature in `e2e/features/api-trigger.feature`

### Checklist
- [x] Dependencies installed (`mqtt` 5.14.1)
- [x] Linter passes cleanly in `e2e/` (`npm run lint`)
- [x] Cucumber features pass dry-run (`npm run cucumber:local -- --dry-run`: 69 scenarios, 637 steps)
- [x] Changelog entry added in `website/docs/changelog/next.md`
- [x] Website builds cleanly (`npm run build` in `website/`)