### PR TITLE
🚀 [AUTH] Add rogroup and defaultrole support to OIDC authentication provider (fixes #1232)

### DIFF
--- a/app/authentications/providers/oidc/Oidc.test.ts
+++ b/app/authentications/providers/oidc/Oidc.test.ts
@@ -24,6 +24,7 @@ const configurationValid = {
     ttl: 60,
     usernameclaim: 'email',
     groupsclaim: 'groups',
+    defaultrole: 'ro',
 };
 
 const mockConfig = {
@@ -92,6 +93,7 @@ test('maskConfiguration should mask configuration secrets', async () => {
         ttl: 60,
         usernameclaim: 'email',
         groupsclaim: 'groups',
+        defaultrole: 'ro',
     });
 });
 
@@ -435,4 +437,113 @@ test('getUserFromAccessToken should assign admin role when group matches admingr
 
     const user = await oidc.getUserFromAccessToken('token');
     expect(user.role).toEqual('admin');
+});
+
+test('validateConfiguration should accept rogroup and defaultrole none', async () => {
+    const config = {
+        ...configurationValid,
+        rogroup: 'readers',
+        defaultrole: 'none',
+    };
+    const validated = oidc.validateConfiguration(config);
+    expect(validated.rogroup).toEqual('readers');
+    expect(validated.defaultrole).toEqual('none');
+});
+
+test('validateConfiguration should throw error when defaultrole is invalid', async () => {
+    const config = {
+        ...configurationValid,
+        defaultrole: 'invalid',
+    };
+    expect(() => {
+        oidc.validateConfiguration(config);
+    }).toThrow(ValidationError);
+});
+
+test('getEffectiveScope should include groups when rogroup is configured', () => {
+    oidc.configuration = { ...configurationValid, rogroup: 'readers' };
+    expect(oidc.getEffectiveScope()).toEqual('openid email profile groups');
+});
+
+test('getUserFromAccessToken should assign ro role when group matches rogroup', async () => {
+    oidc.configuration = {
+        ...configurationValid,
+        rogroup: 'wud-ro',
+        ttl: -1,
+    };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'reader@example.com',
+        groups: ['wud-ro'],
+    });
+
+    const user = await oidc.getUserFromAccessToken('token');
+    expect(user.role).toEqual('ro');
+});
+
+test('getUserFromAccessToken should throw access denied when defaultrole is none and user has no matching group', async () => {
+    oidc.configuration = {
+        ...configurationValid,
+        admingroup: 'wud-admin',
+        rwgroup: 'wud-rw',
+        rogroup: 'wud-ro',
+        defaultrole: 'none',
+        ttl: -1,
+    };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'unauthorized@example.com',
+        groups: ['other-group'],
+    });
+
+    await expect(oidc.getUserFromAccessToken('token')).rejects.toThrow(
+        'Access denied: user does not belong to any authorized group',
+    );
+});
+
+test('getUserFromAccessToken should allow access when defaultrole is none and group matches rogroup', async () => {
+    oidc.configuration = {
+        ...configurationValid,
+        rogroup: 'wud-ro',
+        defaultrole: 'none',
+        ttl: -1,
+    };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.fetchUserInfo as jest.Mock).mockResolvedValue({
+        email: 'reader@example.com',
+        groups: ['wud-ro'],
+    });
+
+    const user = await oidc.getUserFromAccessToken('token');
+    expect(user.role).toEqual('ro');
+});
+
+test('callback should redirect to login with error parameter when authentication fails', async () => {
+    oidc.configuration = { ...configurationValid, ttl: -1 };
+    (oidc as any).cachedConfig = mockConfig;
+    (client.authorizationCodeGrant as jest.Mock).mockRejectedValue(
+        new Error('Invalid authorization code'),
+    );
+
+    const req: any = {
+        protocol: 'http',
+        headers: { host: 'localhost:3000' },
+        originalUrl: '/auth/oidc/oidc/cb?code=123',
+        session: {
+            oidc: {
+                codeVerifier: 'verifier',
+                state: 'state123',
+            },
+        },
+        query: {},
+    };
+    const res: any = {
+        redirect: jest.fn(),
+    };
+
+    await oidc.callback(req, res);
+
+    expect(res.redirect).toHaveBeenCalledWith(
+        'http://localhost:3000/#/login?error=Invalid%20authorization%20code',
+    );
 });

--- a/app/authentications/providers/oidc/Oidc.ts
+++ b/app/authentications/providers/oidc/Oidc.ts
@@ -39,6 +39,8 @@ class Oidc extends Authentication {
             usernameclaim: this.joi.string().default('email'),
             admingroup: this.joi.string().optional(),
             rwgroup: this.joi.string().optional(),
+            rogroup: this.joi.string().optional(),
+            defaultrole: this.joi.string().valid('ro', 'none').default('ro'),
             groupsclaim: this.joi.string().default('groups'),
             scope: this.joi.string().optional(),
         });
@@ -167,7 +169,11 @@ class Oidc extends Authentication {
             return this.configuration.scope;
         }
         const scopes = ['openid', 'email', 'profile'];
-        if (this.configuration.admingroup || this.configuration.rwgroup) {
+        if (
+            this.configuration.admingroup ||
+            this.configuration.rwgroup ||
+            this.configuration.rogroup
+        ) {
             const scopesSupported = config?.serverMetadata()?.scopes_supported;
             // Only request 'groups' scope if the IdP explicitly declares supporting it (or if no discovery metadata available)
             if (
@@ -305,7 +311,10 @@ class Oidc extends Authentication {
                     this.log.warn(
                         `Error when logging the user [${err.message}]`,
                     );
-                    res.status(401).send(err.message);
+                    const publicUrl = getPublicUrl(req).replace(/\/$/, '');
+                    res.redirect(
+                        `${publicUrl}/#/login?error=${encodeURIComponent(err.message)}`,
+                    );
                 } else {
                     const publicUrl = getPublicUrl(req).replace(/\/$/, '');
                     const destination = nextUrl
@@ -317,9 +326,12 @@ class Oidc extends Authentication {
                     res.redirect(destination);
                 }
             });
-        } catch (err) {
+        } catch (err: any) {
             this.log.warn(`Error when logging the user [${err.message}]`);
-            res.status(401).send(err.message);
+            const publicUrl = getPublicUrl(req).replace(/\/$/, '');
+            res.redirect(
+                `${publicUrl}/#/login?error=${encodeURIComponent(err.message)}`,
+            );
         }
     }
 
@@ -369,9 +381,11 @@ class Oidc extends Authentication {
         }
 
         // Determine role from groups if configured
-        let determinedRole: UserRole = 'ro';
+        let determinedRole: UserRole | 'none' = this.configuration.defaultrole;
         const hasGroupConfig = Boolean(
-            this.configuration.admingroup || this.configuration.rwgroup,
+            this.configuration.admingroup ||
+                this.configuration.rwgroup ||
+                this.configuration.rogroup,
         );
 
         if (hasGroupConfig) {
@@ -390,19 +404,35 @@ class Oidc extends Authentication {
             userGroups.includes(this.configuration.rwgroup)
         ) {
             determinedRole = 'rw';
+        } else if (
+            this.configuration.rogroup &&
+            userGroups.includes(this.configuration.rogroup)
+        ) {
+            determinedRole = 'ro';
         }
+
+        if (determinedRole === 'none') {
+            this.log.warn(
+                `Access denied for user '${validUsername}': does not belong to any authorized group.`,
+            );
+            throw new Error(
+                'Access denied: user does not belong to any authorized group',
+            );
+        }
+
+        const role: UserRole = determinedRole;
 
         // Check if user exists in database
         const existingUser = await getUserByUsername(validUsername);
         if (existingUser) {
             if (hasGroupConfig) {
                 // If group claims are configured on OIDC, sync role from IDP
-                if (existingUser.role !== determinedRole) {
+                if (existingUser.role !== role) {
                     this.log.info(
-                        `Syncing OIDC user role for '${validUsername}' from '${existingUser.role}' to '${determinedRole}'`,
+                        `Syncing OIDC user role for '${validUsername}' from '${existingUser.role}' to '${role}'`,
                     );
-                    await updateUser(existingUser.id, { role: determinedRole });
-                    existingUser.role = determinedRole;
+                    await updateUser(existingUser.id, { role });
+                    existingUser.role = role;
                 }
             }
             return {
@@ -416,11 +446,11 @@ class Oidc extends Authentication {
 
         // User onboarding: create new OIDC user in database
         this.log.info(
-            `Onboarding new OIDC user '${validUsername}' with role '${determinedRole}'`,
+            `Onboarding new OIDC user '${validUsername}' with role '${role}'`,
         );
         const newUser = await createUser({
             username: validUsername,
-            role: determinedRole,
+            role,
             provider: 'oidc',
         });
 

--- a/ui/src/views/LoginView.vue
+++ b/ui/src/views/LoginView.vue
@@ -85,6 +85,20 @@ export default defineComponent({
     };
   },
 
+  mounted() {
+    const errorMsg = this.$route.query.error as string;
+    if (errorMsg) {
+      this.$router.replace({
+        query: { ...this.$route.query, error: undefined },
+      });
+      setTimeout(() => {
+        if (this.eventBus) {
+          this.eventBus.emit("notify", errorMsg, "error");
+        }
+      }, 100);
+    }
+  },
+
   methods: {
     /**
      * Format display label for strategy tab.
@@ -152,10 +166,15 @@ export default defineComponent({
       // Auto-redirect if:
       // 1. An OIDC strategy has redirect: true configured, OR
       // 2. ONLY OIDC is enabled (no basic auth)
-      const oidcWithExplicitRedirect = supported.find(
-        (strategy: any) => strategy.type === "oidc" && strategy.redirect,
-      );
-      const isOnlyOidc = supported.length === 1 && supported[0].type === "oidc";
+      // AND no error is present in query parameters
+      const hasError = Boolean(to?.query?.error);
+      const oidcWithExplicitRedirect =
+        !hasError &&
+        supported.find(
+          (strategy: any) => strategy.type === "oidc" && strategy.redirect,
+        );
+      const isOnlyOidc =
+        !hasError && supported.length === 1 && supported[0].type === "oidc";
       const oidcToRedirect =
         oidcWithExplicitRedirect || (isOnlyOidc ? supported[0] : null);
 

--- a/ui/tests/views/LoginView.spec.ts
+++ b/ui/tests/views/LoginView.spec.ts
@@ -12,19 +12,22 @@ jest.mock('@/services/auth', () => ({
 
 // Mock router
 const mockRouter = {
-  push: jest.fn()
+  push: jest.fn(),
+  replace: jest.fn()
 };
 const mockRoute = {
-    query: {}
+    query: {} as Record<string, any>
 };
 
 describe('LoginView', () => {
-  let wrapper;
+  let wrapper: any;
 
   beforeEach(() => {
     (getStrategies as jest.Mock).mockReset();
     (getOidcRedirection as jest.Mock).mockReset();
     mockRouter.push.mockReset();
+    mockRouter.replace.mockReset();
+    mockRoute.query = {};
   });
 
   afterEach(() => {
@@ -80,7 +83,34 @@ describe('LoginView', () => {
       mockRoute.query.next = undefined; // reset
   });
 
+  it('emits error notification and clears error from query when error is present on mount', (done) => {
+      mockRoute.query = { error: 'Access denied: user does not belong to any authorized group' };
+      mountComponent([{ type: 'basic' }]);
+      expect(mockRouter.replace).toHaveBeenCalledWith({
+          query: {},
+      });
+      setTimeout(() => {
+          expect(wrapper.vm.eventBus.emit).toHaveBeenCalledWith(
+              'notify',
+              'Access denied: user does not belong to any authorized group',
+              'error',
+          );
+          done();
+      }, 150);
+  });
+
   describe('Route Hook (beforeRouteEnter)', () => {
+      it('does NOT automatically redirect to OIDC when an error is present in query', async () => {
+          (getStrategies as jest.Mock).mockResolvedValue([
+              { type: 'oidc', name: 'authentik', redirect: true }
+          ]);
+          const next = jest.fn();
+          const to = { query: { error: 'Access denied' } };
+          await LoginView.beforeRouteEnter.call(LoginView, to, {}, next);
+
+          expect(getOidcRedirection).not.toHaveBeenCalled();
+          expect(next).toHaveBeenCalledWith(expect.any(Function));
+      });
       it('redirects to home if anonymous auth is enabled', async () => {
           (getStrategies as jest.Mock).mockResolvedValue([{ type: 'anonymous' }]);
           const next = jest.fn();

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -9,6 +9,7 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 
 ---
 - 🐛 [AUTH] Hide basic strategy from login when no local users exist in database
+- 🚀 [AUTH] Add rogroup and defaultrole support to OIDC authentication provider (fixes #1232)
 - 🚀 [COMMUNITY] Add GitHub Sponsors integration across repository and documentation
 - 🐛 [DOCS] Fix live demo chunk loading, footer API link, and duplicate version badges
 - 📝 [DOCS] Clarify OIDC admin group configuration and remove invalid global env var reference (fixes #1226)

--- a/website/docs/configuration/authentications/oidc/README.md
+++ b/website/docs/configuration/authentications/oidc/README.md
@@ -97,18 +97,35 @@ WUD supports any compliant OpenID Connect Identity Provider. Step-by-step guides
   </ConfigOption>
 
   <ConfigOption
+    name="WUD_AUTH_OIDC_{auth_name}_ROGROUP"
+    required={false}
+    type="string">
+    Identity provider group or role name that grants WUD `ro` (Read-Only) privileges upon login
+  </ConfigOption>
+
+  <ConfigOption
+    name="WUD_AUTH_OIDC_{auth_name}_DEFAULTROLE"
+    required={false}
+    type="string"
+    defaultValue="ro"
+    supported="`ro`, `none`">
+    Default role assigned to authenticated users who do not match any configured group. Set to `none` to strictly deny access and reject logins for users who do not belong to any authorized group
+  </ConfigOption>
+
+  <ConfigOption
     name="WUD_AUTH_OIDC_{auth_name}_SCOPE"
     required={false}
     type="string"
     defaultValue="openid email profile">
-    OpenID Connect scopes to request during authorization flow. Automatically appends `groups` when `ADMINGROUP` or `RWGROUP` is configured unless overridden.
+    OpenID Connect scopes to request during authorization flow. Automatically appends `groups` when `ADMINGROUP`, `RWGROUP`, or `ROGROUP` is configured unless overridden.
   </ConfigOption>
 </ConfigList>
 
 :::tip[Automatic User Onboarding & Role Sync]
 When a user logs in through OIDC, WUD automatically creates an account in the internal database.
-- If `ADMINGROUP` or `RWGROUP` is configured, the user's role is automatically synchronized with their IDP groups on each login (granting `admin`, `rw`, or falling back to `ro`).
-- If no groups are configured, new OIDC users default to `ro` (Read-Only), and a local administrator can promote their role directly in the WUD Web UI.
+- If group mapping is configured (`ADMINGROUP`, `RWGROUP`, `ROGROUP`), the user's role is automatically synchronized with their IDP groups on each login (granting `admin`, `rw`, or `ro`).
+- If a user does not match any configured group, their role falls back to `DEFAULTROLE` (`ro` by default).
+- When `DEFAULTROLE=none`, access is strictly locked down: any user not belonging to at least one authorized group (`ADMINGROUP`, `RWGROUP`, or `ROGROUP`) is denied access and redirected to login with an error notification.
 :::
 
 :::tip[Zero Local Credentials: Omit Local Administrator with OIDC]


### PR DESCRIPTION
### Description
Implements `rogroup` and `defaultrole` ('ro' | 'none') support in the OIDC authentication provider to allow fine-grained role synchronization and mandatory group membership checks.

### Key Changes
- **Backend (`app/authentications/providers/oidc/Oidc.ts`)**:
  - Added `rogroup` (string, optional) and `defaultrole` ('ro' | 'none', default: 'ro') to Joi configuration schema.
  - Automatically requests `groups` OIDC scope if `admingroup`, `rwgroup`, or `rogroup` is defined.
  - Dynamically evaluates user roles against configured groups. When `defaultrole: 'none'`, any authenticated user without a matching group is denied access with an explicit error.
  - On login failure or access denial in the OIDC callback, redirects the user back to `/#/login?error=...` instead of returning a raw 401 HTTP response.
- **Frontend (`ui/src/views/LoginView.vue`)**:
  - Intercepts `error` query parameter on mount to display a toast notification via `eventBus` and clears it from the URL.
  - Prevents automated OIDC redirect loop if an error parameter is present.
- **Tests**:
  - Unit tests in `Oidc.test.ts` covering Joi validation, scope requests, group-to-role mappings, access denial, and callback redirection.
  - Unit tests in `LoginView.spec.ts` covering error notification emission, query cleaning, and preventing infinite redirects.
- **Documentation (`website/docs/`)**:
  - Added documentation for `WUD_AUTH_OIDC_{NAME}_ROGROUP` and `WUD_AUTH_OIDC_{NAME}_DEFAULTROLE`.
  - Added changelog entry in `next.md`.

Closes #1232.