### PR TITLE
🚀 [TRIGGER] Support Telegram topics via message_thread_id (fixes #506)

### DIFF
--- a/app/triggers/providers/telegram/Telegram.test.ts
+++ b/app/triggers/providers/telegram/Telegram.test.ts
@@ -39,6 +39,9 @@ beforeEach(async () => {
     jest.restoreAllMocks();
     mockedPost.mockReset();
     mockedPost.mockResolvedValue({ status: 200, data: {} } as any);
+    (telegram as any).proxyAgent = undefined;
+    telegram.configuration = { ...configurationValid };
+    telegram.name = undefined as any;
 });
 
 test('maskConfiguration should mask sensitive data', async () => {
@@ -210,5 +213,264 @@ test('sendMessage should call the Telegram API with proxy settings when configur
             httpAgent: expect.any(HttpsProxyAgent),
             httpsAgent: expect.any(HttpsProxyAgent),
         }),
+    );
+});
+
+test('validateConfiguration should accept messagethreadid as integer or string', () => {
+    const configWithNumber = telegram.validateConfiguration({
+        ...configurationValid,
+        messagethreadid: 12345,
+    });
+    expect(configWithNumber.messagethreadid).toEqual(12345);
+
+    const configWithString = telegram.validateConfiguration({
+        ...configurationValid,
+        messagethreadid: '67890',
+    });
+    expect(configWithString.messagethreadid).toEqual('67890');
+});
+
+test('validateConfiguration should normalize message_thread_id and message.thread.id to messagethreadid', () => {
+    const configWithUnderscore = telegram.validateConfiguration({
+        ...configurationValid,
+        message_thread_id: 111,
+    });
+    expect(configWithUnderscore.messagethreadid).toEqual(111);
+    expect(configWithUnderscore.message_thread_id).toBeUndefined();
+
+    const configWithNested = telegram.validateConfiguration({
+        ...configurationValid,
+        message: { thread: { id: 222 } },
+    });
+    expect(configWithNested.messagethreadid).toEqual(222);
+    expect(configWithNested.message).toBeUndefined();
+});
+
+test('sendMessage should not include message_thread_id when not configured', async () => {
+    telegram.configuration = { ...configurationValid };
+    await (telegram as any).sendMessage('Test Body');
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        {
+            chat_id: configurationValid.chatid,
+            text: 'Test Body',
+            parse_mode: 'MarkdownV2',
+        },
+        undefined,
+    );
+});
+
+test('sendMessage should include message_thread_id when configured on trigger', async () => {
+    telegram.configuration = {
+        ...configurationValid,
+        messagethreadid: 42,
+    };
+    await (telegram as any).sendMessage('Test Body');
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        {
+            chat_id: configurationValid.chatid,
+            text: 'Test Body',
+            parse_mode: 'MarkdownV2',
+            message_thread_id: 42,
+        },
+        undefined,
+    );
+});
+
+test('trigger should use container label for message_thread_id over trigger configuration', async () => {
+    telegram.name = 'telegram1';
+    telegram.configuration = {
+        ...configurationValid,
+        messagethreadid: 42,
+    };
+
+    const containerWithLabel: Container = {
+        name: 'test-container',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+        labels: {
+            'wud.trigger.telegram.telegram1.message_thread_id': '100',
+        },
+    } as any;
+
+    await telegram.trigger(containerWithLabel);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: '100',
+        }),
+        undefined,
+    );
+});
+
+test('trigger should fallback to generic container label for message_thread_id', async () => {
+    telegram.name = 'telegram1';
+    telegram.configuration = {
+        ...configurationValid,
+    };
+
+    const containerWithGenericLabel: Container = {
+        name: 'test-container',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+        labels: {
+            'wud.trigger.telegram.message_thread_id': '200',
+        },
+    } as any;
+
+    await telegram.trigger(containerWithGenericLabel);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: '200',
+        }),
+        undefined,
+    );
+});
+
+test('triggerBatch should pass message_thread_id from configuration', async () => {
+    telegram.configuration = {
+        ...configurationValid,
+        messagethreadid: 555,
+    };
+
+    const containers: Container[] = [
+        {
+            name: 'container1',
+            updateKind: { kind: 'tag', localValue: '1', remoteValue: '2' },
+        } as any,
+    ];
+
+    await telegram.triggerBatch(containers);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: 555,
+        }),
+        undefined,
+    );
+});
+
+test('trigger should recognize messagethreadid label without underscores', async () => {
+    telegram.name = 'telegram1';
+    telegram.configuration = {
+        ...configurationValid,
+    };
+
+    const containerWithLabel: Container = {
+        name: 'test-container',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+        labels: {
+            'wud.trigger.telegram.telegram1.messagethreadid': '300',
+        },
+    } as any;
+
+    await telegram.trigger(containerWithLabel);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: '300',
+        }),
+        undefined,
+    );
+});
+
+test('trigger should recognize generic messagethreadid label without underscores', async () => {
+    telegram.name = 'telegram1';
+    telegram.configuration = {
+        ...configurationValid,
+    };
+
+    const containerWithLabel: Container = {
+        name: 'test-container',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+        labels: {
+            'wud.trigger.telegram.messagethreadid': '400',
+        },
+    } as any;
+
+    await telegram.trigger(containerWithLabel);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: '400',
+        }),
+        undefined,
+    );
+});
+
+test('trigger with disabletitle should also include message_thread_id', async () => {
+    telegram.configuration = {
+        ...configurationValid,
+        disabletitle: true,
+        messagethreadid: 777,
+    };
+
+    const container: Container = {
+        name: 'test-container',
+        updateKind: {
+            kind: 'tag',
+            localValue: '1.0.0',
+            remoteValue: '2.0.0',
+        },
+    } as any;
+
+    await telegram.trigger(container);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: 777,
+        }),
+        undefined,
+    );
+});
+
+test('triggerBatch with disabletitle should also include message_thread_id from first container label', async () => {
+    telegram.configuration = {
+        ...configurationValid,
+        disabletitle: true,
+    };
+
+    const containers: Container[] = [
+        {
+            name: 'container1',
+            updateKind: { kind: 'tag', localValue: '1', remoteValue: '2' },
+            labels: {
+                'wud.trigger.telegram.message_thread_id': '888',
+            },
+        } as any,
+    ];
+
+    await telegram.triggerBatch(containers);
+
+    expect(mockedPost).toHaveBeenCalledWith(
+        'https://api.telegram.org/bottoken/sendMessage',
+        expect.objectContaining({
+            message_thread_id: '888',
+        }),
+        undefined,
     );
 });

--- a/app/triggers/providers/telegram/Telegram.ts
+++ b/app/triggers/providers/telegram/Telegram.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { SocksProxyAgent } from 'socks-proxy-agent';
 import { Container } from '../../../model/container';
+import { ComponentConfiguration } from '../../../registry/Component';
 import Trigger from '../Trigger';
 
 function createProxyAgent(proxyUrl: string) {
@@ -37,6 +38,12 @@ class Telegram extends Trigger {
         return this.joi.object().keys({
             bottoken: this.joi.string().required(),
             chatid: this.joi.string().required(),
+            messagethreadid: this.joi
+                .alternatives([
+                    this.joi.number().integer().strict(),
+                    this.joi.string(),
+                ])
+                .optional(),
             disabletitle: this.joi.boolean().default(false),
             messageformat: this.joi
                 .string()
@@ -45,6 +52,33 @@ class Telegram extends Trigger {
                 .default('Markdown'),
             proxy: this.joi.string().uri().optional(),
         });
+    }
+
+    validateConfiguration(
+        configuration: ComponentConfiguration,
+    ): ComponentConfiguration {
+        const normalizedConfig = { ...configuration };
+
+        const threadId =
+            normalizedConfig.messagethreadid ??
+            normalizedConfig.message_thread_id ??
+            normalizedConfig.message?.thread?.id;
+
+        if (threadId !== undefined) {
+            normalizedConfig.messagethreadid = threadId;
+            delete normalizedConfig.message_thread_id;
+            if (normalizedConfig.message?.thread) {
+                delete normalizedConfig.message.thread.id;
+                if (Object.keys(normalizedConfig.message.thread).length === 0) {
+                    delete normalizedConfig.message.thread;
+                }
+                if (Object.keys(normalizedConfig.message).length === 0) {
+                    delete normalizedConfig.message;
+                }
+            }
+        }
+
+        return super.validateConfiguration(normalizedConfig);
     }
 
     maskConfiguration() {
@@ -62,36 +96,80 @@ class Telegram extends Trigger {
             : undefined;
     }
 
+    private getMessageThreadId(
+        container?: Container,
+    ): string | number | undefined {
+        if (container && container.labels) {
+            const specificLabel =
+                container.labels[
+                    `wud.trigger.telegram.${this.name}.message_thread_id`
+                ] ??
+                container.labels[
+                    `wud.trigger.telegram.${this.name}.messagethreadid`
+                ];
+            if (specificLabel !== undefined) {
+                return specificLabel;
+            }
+
+            const genericLabel =
+                container.labels['wud.trigger.telegram.message_thread_id'] ??
+                container.labels['wud.trigger.telegram.messagethreadid'];
+            if (genericLabel !== undefined) {
+                return genericLabel;
+            }
+        }
+        return this.configuration.messagethreadid;
+    }
+
     trigger(container: Container) {
+        const threadId = this.getMessageThreadId(container);
         const body = this.renderSimpleBody(container);
 
         if (this.configuration.disabletitle) {
-            return this.sendMessage(body);
+            return threadId !== undefined
+                ? this.sendMessage(body, threadId)
+                : this.sendMessage(body);
         }
 
         const title = this.renderSimpleTitle(container);
 
-        return this.sendMessage(
-            `${this.bold(title)}\n\n${this.escapeMarkdown(body)}`,
-        );
+        const message = `${this.bold(title)}\n\n${this.escapeMarkdown(body)}`;
+        return threadId !== undefined
+            ? this.sendMessage(message, threadId)
+            : this.sendMessage(message);
     }
 
     triggerBatch(containers: Container[]) {
+        const threadId = this.getMessageThreadId(containers[0]);
         const body = this.renderBatchBody(containers);
         if (this.configuration.disabletitle) {
-            return this.sendMessage(body);
+            return threadId !== undefined
+                ? this.sendMessage(body, threadId)
+                : this.sendMessage(body);
         }
 
         const title = this.renderBatchTitle(containers);
-        return this.sendMessage(`${this.bold(title)}\n\n${body}`);
+        const message = `${this.bold(title)}\n\n${body}`;
+        return threadId !== undefined
+            ? this.sendMessage(message, threadId)
+            : this.sendMessage(message);
     }
 
-    private async sendMessage(text: string) {
-        const message = {
+    private async sendMessage(text: string, threadId?: string | number) {
+        const message: Record<string, any> = {
             chat_id: this.configuration.chatid,
             text,
             parse_mode: this.getParseMode(),
         };
+        const effectiveThreadId =
+            threadId ?? this.configuration.messagethreadid;
+        if (
+            effectiveThreadId !== undefined &&
+            effectiveThreadId !== null &&
+            effectiveThreadId !== ''
+        ) {
+            message.message_thread_id = effectiveThreadId;
+        }
         const requestConfig = this.proxyAgent
             ? {
                   httpAgent: this.proxyAgent as any,

--- a/website/cspell.json
+++ b/website/cspell.json
@@ -69,6 +69,7 @@
     "lokijs",
     "lscr",
     "mdx",
+    "messagethreadid",
     "mosquitto",
     "mqtt",
     "mqttjs",

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -9,4 +9,5 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 
 ---
 
+- 🚀 [TRIGGER] Add support for Telegram topics / message_thread_id (fixes #506)
 - 🛠️ [DOCS] Add CSpell and Markdownlint quality gates for documentation

--- a/website/docs/configuration/triggers/telegram/README.md
+++ b/website/docs/configuration/triggers/telegram/README.md
@@ -53,6 +53,14 @@ import TabItem from '@theme/TabItem';
   </ConfigOption>
 
   <ConfigOption
+    name="WUD_TRIGGER_TELEGRAM_{trigger_name}_MESSAGE_THREAD_ID"
+    required={false}
+    type="integer | string"
+    supported="Numeric message thread ID (e.g. `42`)">
+    Unique identifier for the target message thread (topic) of the forum supergroup
+  </ConfigOption>
+
+  <ConfigOption
     name="WUD_TRIGGER_TELEGRAM_{trigger_name}_PROXY"
     required={false}
     type="url"
@@ -96,6 +104,46 @@ docker run \
 </TabItem>
 </Tabs>
 
+### Send Notifications to a Topic (Forum Supergroup)
+
+<Tabs>
+<TabItem value="docker-compose" label="Docker Compose">
+
+```yaml
+services:
+  whatsupdocker:
+    image: getwud/wud
+    environment:
+      - WUD_TRIGGER_TELEGRAM_LOCAL_BOTTOKEN=123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q
+      - WUD_TRIGGER_TELEGRAM_LOCAL_CHATID=-1001234567890
+      - WUD_TRIGGER_TELEGRAM_LOCAL_MESSAGE_THREAD_ID=42
+```
+
+</TabItem>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run \
+  -e WUD_TRIGGER_TELEGRAM_LOCAL_BOTTOKEN="123456789:AApFzFLD0g0NVg8l0bZf55ex3sajC4Aw84Q" \
+  -e WUD_TRIGGER_TELEGRAM_LOCAL_CHATID="-1001234567890" \
+  -e WUD_TRIGGER_TELEGRAM_LOCAL_MESSAGE_THREAD_ID="42" \
+  getwud/wud
+```
+
+</TabItem>
+<TabItem value="container-label" label="Per-Container Override">
+
+```yaml
+services:
+  my-app:
+    image: my-app:1.2.0
+    labels:
+      - wud.trigger.telegram.local.message_thread_id=42
+```
+
+</TabItem>
+</Tabs>
+
 ---
 
 ## 📖 Setup Guide
@@ -111,3 +159,11 @@ docker run \
 1. Send a message to your newly created bot or add it to your target group.
 2. Start a chat with [@userinfobot](https://t.me/userinfobot) or [@GetIDsBot](https://t.me/GetIDsBot) to see your numeric Chat ID.
 3. Set your Chat ID as `WUD_TRIGGER_TELEGRAM_{trigger_name}_CHATID`.
+
+### 3. Find Your Message Thread ID (Topic)
+
+If you are posting to a specific topic within a forum supergroup:
+
+1. In Telegram Desktop, right-click the topic and select **Copy Link to Topic**.
+2. The copied link will be in the format `https://t.me/c/1234567890/42`.
+3. The last number (`42`) is the `MESSAGE_THREAD_ID`.


### PR DESCRIPTION
### Description
Enables sending container update notifications to specific Telegram topics / forum threads via the Telegram Bot API.

### Changes
- **Backend (`app/triggers/providers/telegram/Telegram.ts`)**:
  - Adds optional `messagethreadid` configuration supporting number and string types.
  - Normalizes `message_thread_id` and nested `message.thread.id` to `messagethreadid`.
  - Supports container-level label override: `wud.trigger.telegram.<trigger_name>.message_thread_id` and `wud.trigger.telegram.message_thread_id`.
  - Passes `message_thread_id` in JSON body to `https://api.telegram.org/bot<token>/sendMessage` when defined.
- **Unit Tests (`app/triggers/providers/telegram/Telegram.test.ts`)**:
  - Validates schema validation, normalization, absence/presence in HTTP payload, container label overrides, batch mode.
- **Documentation**:
  - Documents `WUD_TRIGGER_TELEGRAM_{trigger_name}_MESSAGE_THREAD_ID` with Compose, CLI, and label examples.
  - Updates changelog in `website/docs/changelog/next.md`.

Fixes #506