### PR TITLE
🚀 [TRIGGER] Add ondigest configuration option to filter out digest updates (fixes #756)

### DIFF
--- a/app/triggers/providers/Trigger.test.ts
+++ b/app/triggers/providers/Trigger.test.ts
@@ -27,6 +27,7 @@ const configurationValid = {
 
     batchtitle: '${containers.length} updates available',
     includebydefault: true,
+    ondigest: true,
 };
 
 beforeEach(async () => {
@@ -521,4 +522,190 @@ test('renderBatchBody should replace placeholders when called', async () => {
     ).toEqual(
         '- Container container-name running with tag 1.0.0 can be updated to tag 2.0.0\nhttp://test\n',
     );
+});
+
+test('validateConfiguration should accept ondigest option', async () => {
+    const validatedConfiguration = trigger.validateConfiguration({});
+    expect(validatedConfiguration.ondigest).toBeUndefined();
+
+    const validatedWithFalse = trigger.validateConfiguration({
+        ondigest: false,
+    });
+    expect(validatedWithFalse.ondigest).toBe(false);
+
+    const validatedWithTrue = trigger.validateConfiguration({
+        ondigest: true,
+    });
+    expect(validatedWithTrue.ondigest).toBe(true);
+});
+
+test('mustTrigger should return false for digest update when ondigest is false', async () => {
+    trigger.configuration.ondigest = false;
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+                localValue: 'sha256:111',
+                remoteValue: 'sha256:222',
+            },
+        }),
+    ).toBe(false);
+});
+
+test('mustTrigger should return true for tag update when ondigest is false', async () => {
+    trigger.configuration.ondigest = false;
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'tag',
+                localValue: '1.0.0',
+                remoteValue: '2.0.0',
+            },
+        }),
+    ).toBe(true);
+});
+
+test('mustTrigger should return true for digest update when ondigest is true', async () => {
+    trigger.configuration.ondigest = true;
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+                localValue: 'sha256:111',
+                remoteValue: 'sha256:222',
+            },
+        }),
+    ).toBe(true);
+});
+
+test('mustTrigger should allow overriding ondigest via specific container label', async () => {
+    trigger.type = 'mock';
+    trigger.name = 'trigger1';
+    trigger.configuration.ondigest = false;
+
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+            },
+            labels: {
+                'wud.trigger.mock.trigger1.ondigest': 'true',
+            },
+        }),
+    ).toBe(true);
+
+    trigger.configuration.ondigest = true;
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+            },
+            labels: {
+                'wud.trigger.mock.trigger1.ondigest': 'false',
+            },
+        }),
+    ).toBe(false);
+});
+
+test('mustTrigger should allow overriding ondigest via type container label', async () => {
+    trigger.type = 'mock';
+    trigger.name = 'trigger1';
+    trigger.configuration.ondigest = false;
+
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+            },
+            labels: {
+                'wud.trigger.mock.ondigest': 'true',
+            },
+        }),
+    ).toBe(true);
+});
+
+test('mustTrigger should allow overriding ondigest via generic container label', async () => {
+    trigger.type = 'mock';
+    trigger.name = 'trigger1';
+    trigger.configuration.ondigest = false;
+
+    expect(
+        trigger.mustTrigger({
+            name: 'container1',
+            updateKind: {
+                kind: 'digest',
+            },
+            labels: {
+                'wud.trigger.ondigest': 'true',
+            },
+        }),
+    ).toBe(true);
+});
+
+test('handleContainerReport should ignore digest update and log debug when ondigest is false', async () => {
+    trigger.configuration.ondigest = false;
+    const triggerSpy = jest.spyOn(trigger, 'trigger');
+    const debugSpy = jest.fn();
+    trigger.log = {
+        ...log,
+        child: () => ({
+            debug: debugSpy,
+            warn: jest.fn(),
+        }),
+    };
+
+    await trigger.handleContainerReport({
+        changed: true,
+        container: {
+            name: 'container1',
+            updateAvailable: true,
+            updateKind: {
+                kind: 'digest',
+            },
+        },
+    });
+
+    expect(triggerSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledWith(
+        'Digest update ignored because ondigest is disabled',
+    );
+});
+
+test('handleContainerReports should filter out digest updates when ondigest is false in batch mode', async () => {
+    trigger.configuration.ondigest = false;
+    const triggerBatchSpy = jest.spyOn(trigger, 'triggerBatch');
+
+    const digestContainer = {
+        name: 'container-digest',
+        updateAvailable: true,
+        updateKind: {
+            kind: 'digest',
+        },
+    };
+    const tagContainer = {
+        name: 'container-tag',
+        updateAvailable: true,
+        updateKind: {
+            kind: 'tag',
+        },
+    };
+
+    await trigger.handleContainerReports([
+        {
+            changed: true,
+            container: digestContainer,
+        },
+        {
+            changed: true,
+            container: tagContainer,
+        },
+    ]);
+
+    expect(triggerBatchSpy).toHaveBeenCalledWith([tagContainer]);
 });

--- a/app/triggers/providers/Trigger.ts
+++ b/app/triggers/providers/Trigger.ts
@@ -13,6 +13,7 @@ export interface TriggerConfiguration extends ComponentConfiguration {
     simplebody?: string;
     batchtitle?: string;
     includebydefault?: boolean;
+    ondigest?: boolean;
 }
 
 export interface ContainerReport {
@@ -178,6 +179,10 @@ class Trigger extends Component {
                     )
                 ) {
                     logContainer.debug('Threshold not reached => ignore');
+                } else if (!this.isDigestAllowed(containerReport.container)) {
+                    logContainer.debug(
+                        'Digest update ignored because ondigest is disabled',
+                    );
                 } else if (!this.mustTrigger(containerReport.container)) {
                     logContainer.debug('Trigger conditions not met => ignore');
                 } else {
@@ -293,11 +298,43 @@ class Trigger extends Component {
     }
 
     /**
+     * Return true if digest update is allowed for this container.
+     */
+    isDigestAllowed(containerResult: Container) {
+        if (containerResult.updateKind?.kind !== 'digest') {
+            return true;
+        }
+        let ondigest = this.configuration.ondigest !== false;
+        if (containerResult.labels) {
+            const specificLabel =
+                this.type && this.name
+                    ? containerResult.labels[
+                          `wud.trigger.${this.type}.${this.name}.ondigest`
+                      ]
+                    : undefined;
+            const typeLabel = this.type
+                ? containerResult.labels[`wud.trigger.${this.type}.ondigest`]
+                : undefined;
+            const genericLabel = containerResult.labels['wud.trigger.ondigest'];
+
+            const labelValue = specificLabel ?? typeLabel ?? genericLabel;
+            if (labelValue !== undefined) {
+                ondigest =
+                    typeof labelValue === 'boolean'
+                        ? labelValue
+                        : String(labelValue).toLowerCase() === 'true';
+            }
+        }
+        return ondigest;
+    }
+
+    /**
      * Return true if must trigger on this container.
      */
     mustTrigger(containerResult: Container) {
         const { triggerInclude, triggerExclude } = containerResult;
         return (
+            this.isDigestAllowed(containerResult) &&
             this.isTriggerIncluded(containerResult, triggerInclude) &&
             !this.isTriggerExcluded(containerResult, triggerExclude)
         );
@@ -372,6 +409,7 @@ class Trigger extends Component {
                 .string()
                 .default('${containers.length} updates available'),
             includebydefault: this.joi.boolean(),
+            ondigest: this.joi.boolean(),
         });
         const schemaValidated =
             schemaWithDefaultOptions.validate(configuration);

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -10,3 +10,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 ---
 
 - 🛠️ [DOCS] Add CSpell and Markdownlint quality gates for documentation
+- 🚀 [TRIGGER] Add ondigest configuration option to filter out digest updates (fixes #756)

--- a/website/docs/configuration/triggers/README.md
+++ b/website/docs/configuration/triggers/README.md
@@ -80,6 +80,14 @@ In addition to provider-specific settings, all triggers support the following co
   </ConfigOption>
 
   <ConfigOption
+    name="WUD_TRIGGER_{trigger_type}_{trigger_name}_ONDIGEST"
+    required={false}
+    type="boolean"
+    defaultValue="true">
+    Enable or disable notifications when only the image digest has changed (without semver tag bump)
+  </ConfigOption>
+
+  <ConfigOption
     name="WUD_TRIGGER_{trigger_type}_{trigger_name}_SIMPLEBODY"
     required={false}
     type="string"


### PR DESCRIPTION
### Description
Introduces an `ondigest` configuration option across all triggers to allow users to disable notifications when only the image digest has changed (without any SemVer tag bump).

### Changes
- **Backend (`app/triggers/providers/Trigger.ts`)**:
  - Adds optional `ondigest` boolean schema to default trigger configuration (evaluating to true by default).
  - Adds `isDigestAllowed` method supporting global trigger configuration and container label overrides (`wud.trigger.<type>.<name>.ondigest`, `wud.trigger.<type>.ondigest`, `wud.trigger.ondigest`).
  - Integrates check into `mustTrigger` and `handleContainerReport`, filtering out digest updates in both simple and batch modes when disabled.
- **Unit Tests (`app/triggers/providers/Trigger.test.ts`)**:
  - Adds unit tests verifying default behavior, disabled digest updates, tag update pass-through, and container label overrides.
- **Documentation**:
  - Documents `WUD_TRIGGER_{trigger_type}_{trigger_name}_ONDIGEST` in `website/docs/configuration/triggers/README.md`.
  - Updates changelog in `website/docs/changelog/next.md`.

Fixes #756