### PR TITLE
🚀 [REGISTRY] Add icon configuration option for custom registries (fixes #716)

### DIFF
--- a/app/registries/providers/custom/Custom.test.ts
+++ b/app/registries/providers/custom/Custom.test.ts
@@ -16,6 +16,7 @@ test('validatedConfiguration should initialize when configuration is valid', asy
             password: 'password',
         }),
     ).toStrictEqual({
+        icon: 'si-opencontainersinitiative',
         url: 'http://localhost:5000',
         login: 'login',
         password: 'password',
@@ -36,10 +37,32 @@ test('validatedConfiguration should initialize with a bearer token', async () =>
             token: 'personal-access-token',
         }),
     ).toStrictEqual({
+        icon: 'si-opencontainersinitiative',
         url: 'http://localhost:5000',
         token: 'personal-access-token',
         concurrency: 2,
     });
+});
+
+test('validatedConfiguration should contain default icon si-opencontainersinitiative', async () => {
+    const validated = custom.validateConfiguration({
+        url: 'http://localhost:5000',
+    });
+    expect(validated.icon).toBe('si-opencontainersinitiative');
+});
+
+test('validatedConfiguration should accept and validate custom icon', async () => {
+    const serverIcon = custom.validateConfiguration({
+        url: 'http://localhost:5000',
+        icon: 'mdi:server',
+    });
+    expect(serverIcon.icon).toBe('mdi:server');
+
+    const gitlabIcon = custom.validateConfiguration({
+        url: 'http://localhost:5000',
+        icon: 'logos:gitlab',
+    });
+    expect(gitlabIcon.icon).toBe('logos:gitlab');
 });
 
 test('validatedConfiguration should throw error when auth is not base64', async () => {

--- a/app/registries/providers/custom/Custom.ts
+++ b/app/registries/providers/custom/Custom.ts
@@ -9,6 +9,7 @@ import { ContainerImage } from '../../../model/container';
 class Custom extends DockerRegistryV2 {
     getConfigurationSchema(): AnySchema<any> {
         return this.joi.object().keys({
+            icon: this.joi.string().default('si-opencontainersinitiative'),
             url: this.joi.string().uri().required(),
             login: this.joi.alternatives().conditional('password', {
                 not: undefined,

--- a/ui/src/services/registry.ts
+++ b/ui/src/services/registry.ts
@@ -1,18 +1,43 @@
+import { url } from "./base";
+import { isDemoMode, mockService } from "./mock";
+
+let registriesCache: any[] = [];
+
 /**
  * Get registry component icon.
  * @returns {string}
  */
-function getRegistryIcon() {
+function getRegistryIcon(): string {
   return "mdi-database-search";
 }
 
 /**
  * Get registry provider icon (acr, ecr...).
  * @param provider
+ * @param registryItem
  * @returns {string}
  */
-function getRegistryProviderIcon(provider) {
+function getRegistryProviderIcon(provider: string, registryItem?: any): string {
+  if (registryItem?.configuration?.icon) {
+    return registryItem.configuration.icon;
+  }
+
+  if (provider && registriesCache && registriesCache.length > 0) {
+    const cached = registriesCache.find(
+      (r: any) =>
+        r &&
+        (r.id === provider || `${r.type}.${r.name}` === provider) &&
+        r.configuration?.icon
+    );
+    if (cached) {
+      return cached.configuration.icon;
+    }
+  }
+
   let icon = "si-linuxcontainers";
+  if (!provider) {
+    return icon;
+  }
   switch (provider.split(".")[0]) {
     case "acr":
       icon = "si-microsoftazure";
@@ -59,16 +84,16 @@ function getRegistryProviderIcon(provider) {
  * get all registries.
  * @returns {Promise<any>}
  */
-import { url } from "./base";
-import { isDemoMode, mockService } from "./mock";
-
-async function getAllRegistries() {
+async function getAllRegistries(): Promise<any> {
   if (isDemoMode()) {
-    return mockService.getAllRegistries();
+    const data = await mockService.getAllRegistries();
+    registriesCache = Array.isArray(data) ? data : [];
+    return data;
   }
   const response = await fetch(url("api/registries"), { credentials: "include" });
-  return response.json();
+  const data = await response.json();
+  registriesCache = Array.isArray(data) ? data : [];
+  return data;
 }
 
 export { getRegistryIcon, getRegistryProviderIcon, getAllRegistries };
-

--- a/ui/src/views/ConfigurationRegistriesView.vue
+++ b/ui/src/views/ConfigurationRegistriesView.vue
@@ -238,7 +238,7 @@ export default defineComponent({
         this.registries = registries
           .map((registry: any) => ({
             ...registry,
-            icon: getRegistryProviderIcon(registry.type),
+            icon: registry.configuration?.icon || getRegistryProviderIcon(registry.type, registry),
           }))
           .sort((r1: any, r2: any) => r1.id.localeCompare(r2.id));
         if (this.selectedRegistry) {
@@ -265,7 +265,7 @@ export default defineComponent({
       const registriesWithIcons = registries
         .map((registry: any) => ({
           ...registry,
-          icon: getRegistryProviderIcon(registry.type),
+          icon: registry.configuration?.icon || getRegistryProviderIcon(registry.type, registry),
         }))
         .sort((r1: any, r2: any) => r1.id.localeCompare(r2.id));
       next((vm: any) => (vm.registries = registriesWithIcons));

--- a/ui/tests/services/registry.spec.ts
+++ b/ui/tests/services/registry.spec.ts
@@ -5,7 +5,7 @@ global.fetch = jest.fn();
 
 describe('Registry Service', () => {
   beforeEach(() => {
-    fetch.mockClear();
+    (fetch as jest.Mock).mockClear();
   });
 
   describe('getRegistryProviderIcon', () => {
@@ -26,6 +26,54 @@ describe('Registry Service', () => {
       expect(getRegistryProviderIcon('hub.docker.com')).toBe('si-docker');
       expect(getRegistryProviderIcon('gcr.io')).toBe('si-googlecloud');
     });
+
+    it('returns custom icon when registryItem has configuration.icon', () => {
+      const registryItem = {
+        id: 'custom.myreg',
+        type: 'custom',
+        name: 'myreg',
+        configuration: { icon: 'mdi:server' },
+      };
+      expect(getRegistryProviderIcon('custom', registryItem)).toBe('mdi:server');
+    });
+
+    it('returns custom icon from cache when provider matches registry id', async () => {
+      const mockRegistries = [
+        {
+          id: 'custom.myreg',
+          type: 'custom',
+          name: 'myreg',
+          configuration: { icon: 'logos:gitlab' },
+        },
+      ];
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockRegistries,
+      });
+
+      await getAllRegistries();
+
+      expect(getRegistryProviderIcon('custom.myreg')).toBe('logos:gitlab');
+    });
+
+    it('returns custom icon from cache when provider matches type.name', async () => {
+      const mockRegistries = [
+        {
+          id: 'custom-1',
+          type: 'custom',
+          name: 'myreg2',
+          configuration: { icon: 'mdi:server' },
+        },
+      ];
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockRegistries,
+      });
+
+      await getAllRegistries();
+
+      expect(getRegistryProviderIcon('custom.myreg2')).toBe('mdi:server');
+    });
   });
 
   describe('getAllRegistries', () => {
@@ -34,7 +82,7 @@ describe('Registry Service', () => {
         { name: 'hub', type: 'docker' },
         { name: 'ghcr', type: 'github' }
       ];
-      fetch.mockResolvedValueOnce({
+      (fetch as jest.Mock).mockResolvedValueOnce({
         ok: true,
         json: async () => mockRegistries
       });

--- a/ui/tests/views/ConfigurationRegistriesView.spec.ts
+++ b/ui/tests/views/ConfigurationRegistriesView.spec.ts
@@ -62,4 +62,33 @@ describe('ConfigurationRegistriesView.vue', () => {
     await vm.refreshRegistries();
     expect(registryService.getAllRegistries).toHaveBeenCalled();
   });
+
+  it('maps custom icon from configuration.icon on refreshRegistries', async () => {
+    const customRegistries = [
+      {
+        id: 'custom.myreg',
+        type: 'custom',
+        name: 'myreg',
+        configuration: { url: 'http://localhost:5000', icon: 'mdi:server' },
+      },
+      {
+        id: 'hub.docker',
+        type: 'hub',
+        name: 'docker',
+        configuration: { url: 'https://hub.docker.com' },
+      },
+    ];
+    (registryService.getAllRegistries as jest.Mock).mockResolvedValue(customRegistries);
+
+    const wrapper = mount(ConfigurationRegistriesView);
+    const vm = wrapper.vm as any;
+
+    await vm.refreshRegistries();
+
+    expect(vm.registries).toHaveLength(2);
+    const customReg = vm.registries.find((r: any) => r.id === 'custom.myreg');
+    const defaultReg = vm.registries.find((r: any) => r.id === 'hub.docker');
+    expect(customReg.icon).toBe('mdi:server');
+    expect(defaultReg.icon).toBe('si-docker');
+  });
 });

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -9,5 +9,6 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 
 ---
 
+- 🚀 [REGISTRY] Add icon configuration option for custom registries (fixes #716)
 - 🚀 [TRIGGER] Add support for Telegram topics / message_thread_id (fixes #506)
 - 🛠️ [DOCS] Add CSpell and Markdownlint quality gates for documentation

--- a/website/docs/configuration/registries/custom/README.md
+++ b/website/docs/configuration/registries/custom/README.md
@@ -57,6 +57,14 @@ import TabItem from '@theme/TabItem';
     supported="Bearer token (mutually exclusive with LOGIN/PASSWORD and AUTH)">
     Access token sent as `Authorization: Bearer &lt;token&gt;`
   </ConfigOption>
+
+  <ConfigOption
+    name="WUD_REGISTRY_CUSTOM_{registry_name}_ICON"
+    type="string"
+    defaultValue="si-opencontainersinitiative"
+    required={false}>
+    Icon displayed in the user interface, compatible with Iconify identifiers (e.g. `mdi:server`, `si-gitlab`).
+  </ConfigOption>
 </ConfigList>
 
 ---


### PR DESCRIPTION
## Description

This PR adds an `icon` configuration option for custom registries, addressing issue #716.

### Changes
- **Backend**:
  - Added `icon: this.joi.string().default('si-opencontainersinitiative')` to `Custom.ts` configuration schema.
  - Added unit tests in `Custom.test.ts` to verify default icon and custom icon validation.
- **Frontend**:
  - Added `registriesCache` memory cache in `registry.ts` updated on `getAllRegistries()`.
  - Updated `getRegistryProviderIcon` to respect `registryItem?.configuration?.icon` and resolve custom icons from cached registries by id or `${type}.${name}`.
  - Updated `ConfigurationRegistriesView.vue` to map custom registry icons.
  - Added/updated unit tests in `registry.spec.ts` and `ConfigurationRegistriesView.spec.ts`.
- **Documentation**:
  - Documented `WUD_REGISTRY_CUSTOM_{registry_name}_ICON` in `website/docs/configuration/registries/custom/README.md`.
  - Added changelog entry in `website/docs/changelog/next.md`.

Closes #716