### PR TITLE
🚀 [WATCHER] Add update delay / cool-down period (fixes #507)

### DIFF
--- a/app/api/openapi.yaml
+++ b/app/api/openapi.yaml
@@ -674,6 +674,15 @@ components:
                 stack:
                     type: string
                     description: Docker Compose project / stack name
+                delay:
+                    type: string
+                    description: Cool-down duration before update is considered available (e.g. 3d, 24h)
+                isCoolingDown:
+                    type: boolean
+                    description: Whether the update is currently held in cool-down period
+                coolingDownUntil:
+                    type: integer
+                    description: Epoch timestamp (ms) until which the update is held in cool-down
                 includeTags:
                     type: string
                 excludeTags:

--- a/app/model/container.test.ts
+++ b/app/model/container.test.ts
@@ -65,6 +65,8 @@ test('model should be validated when compliant', async () => {
 
         linkTemplate: 'https://release-${major}.${minor}.${patch}.acme.com',
         link: 'https://release-1.0.0.acme.com',
+        coolingDownUntil: undefined,
+        isCoolingDown: false,
         isSnoozed: false,
         updateAvailable: true,
         updateKind: {
@@ -339,6 +341,8 @@ test('flatten should be flatten the nested properties with underscores when call
         display_icon: 'mdi:docker',
         result_link: 'https://release-2.0.0.acme.com',
         result_tag: '2.0.0',
+        cooling_down_until: undefined,
+        is_cooling_down: false,
         update_available: true,
         update_kind_kind: 'tag',
         update_kind_local_value: '1.0.0',
@@ -623,6 +627,188 @@ describe('snooze functionality', () => {
         };
         const validated = container.validate(digestContainer);
         expect(validated.isSnoozed).toBe(true);
+        expect(validated.updateAvailable).toBe(false);
+    });
+});
+
+describe('parseDurationMs', () => {
+    test('should return undefined for undefined, null, or empty string', () => {
+        expect(container.parseDurationMs(undefined)).toBeUndefined();
+        expect(container.parseDurationMs(null)).toBeUndefined();
+        expect(container.parseDurationMs('')).toBeUndefined();
+        expect(container.parseDurationMs('   ')).toBeUndefined();
+    });
+
+    test('should parse raw milliseconds as number or string', () => {
+        expect(container.parseDurationMs(5000)).toBe(5000);
+        expect(container.parseDurationMs('5000')).toBe(5000);
+        expect(container.parseDurationMs(0)).toBe(0);
+        expect(container.parseDurationMs(-10)).toBeUndefined();
+    });
+
+    test('should parse seconds', () => {
+        expect(container.parseDurationMs('30s')).toBe(30000);
+        expect(container.parseDurationMs('10 sec')).toBe(10000);
+        expect(container.parseDurationMs('1 second')).toBe(1000);
+        expect(container.parseDurationMs('45 seconds')).toBe(45000);
+    });
+
+    test('should parse minutes', () => {
+        expect(container.parseDurationMs('10m')).toBe(600000);
+        expect(container.parseDurationMs('5 min')).toBe(300000);
+        expect(container.parseDurationMs('1 minute')).toBe(60000);
+        expect(container.parseDurationMs('2 minutes')).toBe(120000);
+    });
+
+    test('should parse hours', () => {
+        expect(container.parseDurationMs('24h')).toBe(86400000);
+        expect(container.parseDurationMs('2 hr')).toBe(7200000);
+        expect(container.parseDurationMs('1 hour')).toBe(3600000);
+        expect(container.parseDurationMs('3 hours')).toBe(10800000);
+    });
+
+    test('should parse days', () => {
+        expect(container.parseDurationMs('3d')).toBe(259200000);
+        expect(container.parseDurationMs('1 day')).toBe(86400000);
+        expect(container.parseDurationMs('5 days')).toBe(432000000);
+    });
+
+    test('should parse weeks', () => {
+        expect(container.parseDurationMs('1w')).toBe(604800000);
+        expect(container.parseDurationMs('2 weeks')).toBe(1209600000);
+    });
+
+    test('should parse fractional values', () => {
+        expect(container.parseDurationMs('1.5h')).toBe(5400000);
+        expect(container.parseDurationMs('0.5d')).toBe(43200000);
+    });
+
+    test('should return undefined for invalid strings', () => {
+        expect(container.parseDurationMs('invalid')).toBeUndefined();
+        expect(container.parseDurationMs('10xyz')).toBeUndefined();
+        expect(container.parseDurationMs('abc10m')).toBeUndefined();
+    });
+});
+
+describe('cool-down delay logic', () => {
+    const baseContainer = {
+        id: 'container-delay-test',
+        name: 'test-delay',
+        watcher: 'local',
+        image: {
+            id: 'img-1',
+            registry: { name: 'hub', url: 'https://hub' },
+            name: 'app',
+            tag: { value: '1.0.0', semver: true },
+            digest: { watch: false },
+            architecture: 'amd64',
+            os: 'linux',
+            created: '2023-01-01T00:00:00.000Z',
+        },
+    };
+
+    test('should hold update in cool-down when remote release is within delay window', () => {
+        // Released 1 hour ago, delay is 24h -> cooling down until 23h from now
+        const releaseTime = new Date(Date.now() - 3600 * 1000).toISOString();
+        const validated = container.validate({
+            ...baseContainer,
+            delay: '24h',
+            result: {
+                tag: '2.0.0',
+                created: releaseTime,
+            },
+        });
+
+        expect(validated.isCoolingDown).toBe(true);
+        expect(validated.updateAvailable).toBe(false);
+        expect(validated.updateKind.kind).toBe('unknown');
+        expect(validated.coolingDownUntil).toBe(
+            new Date(releaseTime).getTime() + 24 * 3600 * 1000,
+        );
+    });
+
+    test('should mark updateAvailable=true when cool-down period has elapsed', () => {
+        // Released 2 days ago, delay is 24h -> cool-down finished yesterday
+        const releaseTime = new Date(
+            Date.now() - 48 * 3600 * 1000,
+        ).toISOString();
+        const validated = container.validate({
+            ...baseContainer,
+            delay: '24h',
+            result: {
+                tag: '2.0.0',
+                created: releaseTime,
+            },
+        });
+
+        expect(validated.isCoolingDown).toBe(false);
+        expect(validated.updateAvailable).toBe(true);
+        expect(validated.updateKind.kind).toBe('tag');
+        expect(validated.updateKind.semverDiff).toBe('major');
+    });
+
+    test('should not be cooling down if no candidate update exists', () => {
+        // Same tag and same created date -> no update
+        const validated = container.validate({
+            ...baseContainer,
+            delay: '24h',
+            result: {
+                tag: '1.0.0',
+                created: baseContainer.image.created,
+            },
+        });
+
+        expect(validated.isCoolingDown).toBe(false);
+        expect(validated.updateAvailable).toBe(false);
+    });
+
+    test('should not be cooling down if container has no delay', () => {
+        const releaseTime = new Date().toISOString();
+        const validated = container.validate({
+            ...baseContainer,
+            result: {
+                tag: '2.0.0',
+                created: releaseTime,
+            },
+        });
+
+        expect(validated.coolingDownUntil).toBeUndefined();
+        expect(validated.isCoolingDown).toBe(false);
+        expect(validated.updateAvailable).toBe(true);
+    });
+
+    test('should not be cooling down if result has no created date', () => {
+        const validated = container.validate({
+            ...baseContainer,
+            delay: '24h',
+            result: {
+                tag: '2.0.0',
+            },
+        });
+
+        expect(validated.coolingDownUntil).toBeUndefined();
+        expect(validated.isCoolingDown).toBe(false);
+        expect(validated.updateAvailable).toBe(true);
+    });
+
+    test('should handle digest updates with cool-down', () => {
+        const releaseTime = new Date(Date.now() - 1000).toISOString();
+        const validated = container.validate({
+            ...baseContainer,
+            delay: '1h',
+            image: {
+                ...baseContainer.image,
+                tag: { value: 'latest', semver: false },
+                digest: { watch: true, value: 'sha256:old', repo: 'app' },
+            },
+            result: {
+                tag: 'latest',
+                digest: 'sha256:new',
+                created: releaseTime,
+            },
+        });
+
+        expect(validated.isCoolingDown).toBe(true);
         expect(validated.updateAvailable).toBe(false);
     });
 });

--- a/app/model/container.ts
+++ b/app/model/container.ts
@@ -48,6 +48,9 @@ export interface Container {
     status: string;
     watcher: string;
     stack?: string;
+    delay?: string;
+    isCoolingDown?: boolean;
+    coolingDownUntil?: number;
     includeTags?: string;
     excludeTags?: string;
     transformTags?: string;
@@ -69,6 +72,70 @@ export interface Container {
     isSnoozed?: boolean;
 }
 
+/**
+ * Parse human duration string into milliseconds.
+ * Supports units: s (seconds), m (minutes), h (hours), d (days), w (weeks), or raw ms.
+ *
+ * @param duration string | number | undefined
+ * @returns number | undefined
+ */
+export function parseDurationMs(
+    duration: string | number | undefined,
+): number | undefined {
+    if (duration === undefined || duration === null) {
+        return undefined;
+    }
+    if (typeof duration === 'number') {
+        return !isNaN(duration) && duration >= 0 ? duration : undefined;
+    }
+    const trimmed = String(duration).trim();
+    if (trimmed === '') {
+        return undefined;
+    }
+    if (/^\d+$/.test(trimmed)) {
+        const parsed = parseInt(trimmed, 10);
+        return !isNaN(parsed) && parsed >= 0 ? parsed : undefined;
+    }
+    const match = trimmed.match(/^(\d+(?:\.\d+)?)\s*([a-zA-Z]+)$/);
+    if (!match) {
+        return undefined;
+    }
+    const value = parseFloat(match[1]);
+    const unit = match[2].toLowerCase();
+    switch (unit) {
+        case 's':
+        case 'sec':
+        case 'second':
+        case 'seconds':
+            return Math.round(value * 1000);
+        case 'm':
+        case 'min':
+        case 'minute':
+        case 'minutes':
+            return Math.round(value * 60 * 1000);
+        case 'h':
+        case 'hr':
+        case 'hour':
+        case 'hours':
+            return Math.round(value * 60 * 60 * 1000);
+        case 'd':
+        case 'day':
+        case 'days':
+            return Math.round(value * 24 * 60 * 60 * 1000);
+        case 'w':
+        case 'week':
+        case 'weeks':
+            return Math.round(value * 7 * 24 * 60 * 60 * 1000);
+        case 'ms':
+        case 'millis':
+        case 'millisecond':
+        case 'milliseconds':
+            return Math.round(value);
+        default:
+            return undefined;
+    }
+}
+
 // Container data schema
 const schema = joi.object({
     id: joi.string().min(1).required(),
@@ -78,6 +145,9 @@ const schema = joi.object({
     status: joi.string().default('unknown'),
     watcher: joi.string().min(1).required(),
     stack: joi.string().allow('').optional(),
+    delay: joi.string().allow('', null).optional(),
+    isCoolingDown: joi.boolean().default(false),
+    coolingDownUntil: joi.number().optional(),
     includeTags: joi.string(),
     excludeTags: joi.string(),
     transformTags: joi.string(),
@@ -206,57 +276,96 @@ function addIsSnoozedProperty(container: Container) {
 }
 
 /**
+ * Check whether a candidate update exists (different tag, digest, or created date).
+ * @param container
+ * @returns {boolean}
+ */
+function isCandidateUpdateAvailable(container: Container): boolean {
+    if (container.image === undefined || container.result === undefined) {
+        return false;
+    }
+
+    // Compare digests if we have them
+    if (
+        container.image.digest.watch &&
+        container.image.digest.value !== undefined &&
+        container.result.digest !== undefined
+    ) {
+        return container.image.digest.value !== container.result.digest;
+    }
+
+    // Compare tags otherwise
+    let updateAvailable = false;
+    const localTag = transformTag(
+        container.transformTags,
+        container.image.tag.value,
+    );
+    const remoteTag = transformTag(
+        container.transformTags,
+        container.result.tag,
+    );
+    updateAvailable = localTag !== remoteTag;
+
+    // Fallback to image created date (especially for legacy v1 manifests)
+    if (
+        container.image.created !== undefined &&
+        container.result.created !== undefined
+    ) {
+        const createdDate = new Date(container.image.created).getTime();
+        const createdDateResult = new Date(container.result.created!).getTime();
+
+        updateAvailable = updateAvailable || createdDate !== createdDateResult;
+    }
+    return updateAvailable;
+}
+
+/**
  * Computed function to check whether there is an update.
  * @param container
  * @returns {boolean}
  */
 function addUpdateAvailableProperty(container: Container) {
+    Object.defineProperty(container, 'coolingDownUntil', {
+        enumerable: true,
+        get(this: Container) {
+            if (!this.delay || !this.result?.created) {
+                return undefined;
+            }
+            const delayMs = parseDurationMs(this.delay);
+            if (delayMs === undefined) {
+                return undefined;
+            }
+            const createdDate = new Date(this.result.created).getTime();
+            if (isNaN(createdDate)) {
+                return undefined;
+            }
+            return createdDate + delayMs;
+        },
+    });
+
+    Object.defineProperty(container, 'isCoolingDown', {
+        enumerable: true,
+        get(this: Container) {
+            if (this.coolingDownUntil === undefined) {
+                return false;
+            }
+            if (Date.now() >= this.coolingDownUntil) {
+                return false;
+            }
+            return isCandidateUpdateAvailable(this);
+        },
+    });
+
     Object.defineProperty(container, 'updateAvailable', {
         enumerable: true,
         get(this: Container) {
-            if (this.image === undefined || this.result === undefined) {
+            if (this.isCoolingDown) {
                 return false;
             }
-
             if (this.isSnoozed) {
                 return false;
             }
-
-            // Compare digests if we have them
-            if (
-                this.image.digest.watch &&
-                this.image.digest.value !== undefined &&
-                this.result.digest !== undefined
-            ) {
-                return this.image.digest.value !== this.result.digest;
-            }
-
-            // Compare tags otherwise
-            let updateAvailable = false;
-            const localTag = transformTag(
-                container.transformTags,
-                this.image.tag.value,
-            );
-            const remoteTag = transformTag(
-                container.transformTags,
-                this.result.tag,
-            );
-            updateAvailable = localTag !== remoteTag;
-
-            // Fallback to image created date (especially for legacy v1 manifests)
-            if (
-                this.image.created !== undefined &&
-                this.result.created !== undefined
-            ) {
-                const createdDate = new Date(this.image.created).getTime();
-                const createdDateResult = new Date(
-                    this.result.created!,
-                ).getTime();
-
-                updateAvailable =
-                    updateAvailable || createdDate !== createdDateResult;
-            }
-            return updateAvailable;
+            return isCandidateUpdateAvailable(this);
         },
     });
 }

--- a/app/prometheus/container.test.ts
+++ b/app/prometheus/container.test.ts
@@ -176,3 +176,50 @@ test('container event should mark metrics dirty and rebuild on next interval', a
 
     expect(spySet).toHaveBeenCalledTimes(1);
 });
+
+test('gauge should register container with delay and cool-down labels without warning', async () => {
+    let onAdded;
+    event.registerContainerAdded.mockImplementation((handler) => {
+        onAdded = handler;
+        return jest.fn();
+    });
+    event.registerContainerUpdated.mockImplementation(() => jest.fn());
+    event.registerContainerRemoved.mockImplementation(() => jest.fn());
+
+    const coolContainer = {
+        id: 'c1',
+        name: 'app',
+        watcher: 'test',
+        delay: '24h',
+        isCoolingDown: true,
+        coolingDownUntil: 1700000000000,
+        image: {
+            id: 'img1',
+            registry: { name: 'reg', url: 'https://hub' },
+            name: 'img',
+            tag: { value: '1.0', semver: false },
+            digest: { watch: false },
+            architecture: 'amd64',
+            os: 'linux',
+        },
+    };
+    store.getContainers = jest.fn(() => [coolContainer]);
+
+    const spyWarn = jest.spyOn(log, 'warn');
+    const gauge = container.init();
+    const spySet = jest.spyOn(gauge, 'set');
+    spySet.mockClear();
+
+    onAdded(coolContainer);
+    jest.advanceTimersByTime(5000);
+
+    expect(spyWarn).not.toHaveBeenCalled();
+    expect(spySet).toHaveBeenCalledWith(
+        expect.objectContaining({
+            delay: '24h',
+            is_cooling_down: true,
+            cooling_down_until: 1700000000000,
+        }),
+        1,
+    );
+});

--- a/app/prometheus/container.ts
+++ b/app/prometheus/container.ts
@@ -55,6 +55,8 @@ export function init() {
             populateGauge();
         },
         labelNames: [
+            'cooling_down_until',
+            'delay',
             'display_icon',
             'display_name',
             'error_message',
@@ -74,6 +76,7 @@ export function init() {
             'image_tag_value',
             'image_variant',
             'include_tags',
+            'is_cooling_down',
             'is_snoozed',
             'labels',
             'link_template',

--- a/app/store/container.test.ts
+++ b/app/store/container.test.ts
@@ -348,4 +348,37 @@ describe('Container Store (SQLite)', () => {
             'Container unknown-id not found',
         );
     });
+
+    test('insertContainer and getContainer should preserve delay property and calculate cool-down', () => {
+        const containerWithDelay = {
+            ...sampleContainer,
+            id: 'container-with-delay',
+            delay: '2d',
+            result: {
+                tag: '2.0.0',
+                created: new Date().toISOString(),
+            },
+        };
+
+        container.insertContainer(containerWithDelay);
+
+        const fetched = container.getContainer('container-with-delay');
+        expect(fetched).toBeDefined();
+        expect(fetched?.delay).toBe('2d');
+        expect(fetched?.isCoolingDown).toBe(true);
+        expect(fetched?.updateAvailable).toBe(false);
+    });
+
+    test('updateContainer should update delay property', () => {
+        container.insertContainer(sampleContainer);
+
+        const updated = container.updateContainer({
+            ...sampleContainer,
+            delay: '1w',
+        });
+        expect(updated.delay).toBe('1w');
+
+        const fetched = container.getContainer(sampleContainer.id);
+        expect(fetched?.delay).toBe('1w');
+    });
 });

--- a/app/store/container.ts
+++ b/app/store/container.ts
@@ -39,9 +39,9 @@ function buildContainerFromRows(
         link: containerRow.link ?? undefined,
         triggerInclude: containerRow.triggerInclude ?? undefined,
         triggerExclude: containerRow.triggerExclude ?? undefined,
-        labels: containerRow.labels ?? undefined,
         snoozedVersion: containerRow.snoozedVersion ?? undefined,
         snoozedUntil: containerRow.snoozedUntil ?? undefined,
+        delay: containerRow.delay ?? undefined,
     };
 
     if (imageRow) {
@@ -128,6 +128,7 @@ export function insertContainer(container: any): Container {
             labels: containerToSave.labels,
             snoozedVersion: containerToSave.snoozedVersion,
             snoozedUntil: containerToSave.snoozedUntil,
+            delay: containerToSave.delay,
         })
         .run();
 
@@ -203,6 +204,7 @@ export function updateContainer(container: any): Container {
             labels: containerToReturn.labels,
             snoozedVersion: containerToReturn.snoozedVersion,
             snoozedUntil: containerToReturn.snoozedUntil,
+            delay: containerToReturn.delay,
             updatedAt: sql`CURRENT_TIMESTAMP`,
         })
         .onConflictDoUpdate({
@@ -230,6 +232,7 @@ export function updateContainer(container: any): Container {
                     containerToReturn.snoozedUntil !== undefined
                         ? containerToReturn.snoozedUntil
                         : sql`snoozed_until`,
+                delay: containerToReturn.delay,
                 updatedAt: sql`CURRENT_TIMESTAMP`,
             },
         })

--- a/app/store/db/migrations.ts
+++ b/app/store/db/migrations.ts
@@ -135,6 +135,11 @@ export const migrations: Migration[] = [
             `ALTER TABLE containers ADD COLUMN snoozed_until INTEGER;`,
         ],
     },
+    {
+        id: 4,
+        name: '0004_container_delay',
+        sql: [`ALTER TABLE containers ADD COLUMN delay TEXT;`],
+    },
 ];
 
 export function runMigrations(sqlite: Database.Database) {

--- a/app/store/db/schema.ts
+++ b/app/store/db/schema.ts
@@ -39,6 +39,7 @@ export const containers = sqliteTable('containers', {
     labels: text('labels', { mode: 'json' }),
     snoozedVersion: text('snoozed_version'),
     snoozedUntil: integer('snoozed_until'),
+    delay: text('delay'),
     createdAt: text('created_at').default(sql`(CURRENT_TIMESTAMP)`),
     updatedAt: text('updated_at').default(sql`(CURRENT_TIMESTAMP)`),
 });

--- a/app/watchers/providers/docker/Docker.test.ts
+++ b/app/watchers/providers/docker/Docker.test.ts
@@ -133,6 +133,14 @@ describe('Docker Watcher', () => {
             };
             expect(() => docker.validateConfiguration(config)).not.toThrow();
         });
+
+        test('should validate configuration with delay option', async () => {
+            const config = {
+                socket: '/var/run/docker.sock',
+                delay: '24h',
+            };
+            expect(() => docker.validateConfiguration(config)).not.toThrow();
+        });
     });
 
     describe('Initialization', () => {
@@ -1489,6 +1497,93 @@ describe('Docker Watcher', () => {
             const result = await docker.addImageDetailsToContainer(container);
             expect(result).toBeDefined();
             expect(result.stack).toBe('custom-override');
+        });
+
+        test('should extract delay from wud.watch.delay label', async () => {
+            await docker.register('watcher', 'docker', 'test', {});
+            const container = {
+                Id: 'custom-delay-container',
+                Names: ['/my-custom-app'],
+                Image: 'test-image',
+                State: 'running',
+                Labels: {
+                    'wud.watch.delay': '3d',
+                },
+            };
+            mockImage.inspect.mockResolvedValue({
+                Architecture: 'amd64',
+                Os: 'linux',
+                Created: '2023-01-01',
+                Id: 'img123',
+                RepoDigests: [],
+            });
+
+            const containerModule = await import('../../../model/container');
+            const validateContainer = containerModule.validate;
+            // @ts-ignore
+            validateContainer.mockImplementation((c) => c);
+
+            const result = await docker.addImageDetailsToContainer(container);
+            expect(result).toBeDefined();
+            expect(result.delay).toBe('3d');
+        });
+
+        test('should extract delay from wud.tag.delay label as fallback', async () => {
+            await docker.register('watcher', 'docker', 'test', {});
+            const container = {
+                Id: 'custom-delay-container-2',
+                Names: ['/my-custom-app'],
+                Image: 'test-image',
+                State: 'running',
+                Labels: {
+                    'wud.tag.delay': '12h',
+                },
+            };
+            mockImage.inspect.mockResolvedValue({
+                Architecture: 'amd64',
+                Os: 'linux',
+                Created: '2023-01-01',
+                Id: 'img123',
+                RepoDigests: [],
+            });
+
+            const containerModule = await import('../../../model/container');
+            const validateContainer = containerModule.validate;
+            // @ts-ignore
+            validateContainer.mockImplementation((c) => c);
+
+            const result = await docker.addImageDetailsToContainer(container);
+            expect(result).toBeDefined();
+            expect(result.delay).toBe('12h');
+        });
+
+        test('should extract delay from watcher configuration when not defined on labels', async () => {
+            await docker.register('watcher', 'docker', 'test', {
+                delay: '1w',
+            });
+            const container = {
+                Id: 'custom-delay-container-3',
+                Names: ['/my-custom-app'],
+                Image: 'test-image',
+                State: 'running',
+                Labels: {},
+            };
+            mockImage.inspect.mockResolvedValue({
+                Architecture: 'amd64',
+                Os: 'linux',
+                Created: '2023-01-01',
+                Id: 'img123',
+                RepoDigests: [],
+            });
+
+            const containerModule = await import('../../../model/container');
+            const validateContainer = containerModule.validate;
+            // @ts-ignore
+            validateContainer.mockImplementation((c) => c);
+
+            const result = await docker.addImageDetailsToContainer(container);
+            expect(result).toBeDefined();
+            expect(result.delay).toBe('1w');
         });
     });
 

--- a/app/watchers/providers/docker/Docker.ts
+++ b/app/watchers/providers/docker/Docker.ts
@@ -25,6 +25,8 @@ import {
     wudTriggerExclude,
     dockerComposeProject,
     wudStack,
+    wudWatchDelay,
+    wudTagDelay,
 } from './label';
 import * as storeContainer from '../../../store/container';
 import {
@@ -306,6 +308,7 @@ export class Docker extends Watcher {
             watchdigestdefault: this.joi.boolean().optional(),
             watchevents: this.joi.boolean().default(true),
             watchatstart: this.joi.boolean().default(true),
+            delay: this.joi.string().optional(),
         });
     }
 
@@ -769,6 +772,10 @@ export class Docker extends Watcher {
             containerLabels[dockerComposeProject] ||
             containerLabels['com.docker.compose.project'] ||
             undefined;
+        const delay =
+            containerLabels[wudWatchDelay] ||
+            containerLabels[wudTagDelay] ||
+            this.configuration.delay;
 
         // Is container already in store? just return it :)
         const containerInStore = storeContainer.getContainer(containerId);
@@ -779,6 +786,9 @@ export class Docker extends Watcher {
             this.log.debug(`Container ${containerInStore.id} already in store`);
             if (stack && !containerInStore.stack) {
                 containerInStore.stack = stack;
+            }
+            if (delay && containerInStore.delay !== delay) {
+                containerInStore.delay = delay;
             }
             return containerInStore;
         }
@@ -872,6 +882,7 @@ export class Docker extends Watcher {
             status,
             watcher: this.name,
             stack,
+            delay,
             includeTags,
             excludeTags,
             transformTags,

--- a/app/watchers/providers/docker/label.ts
+++ b/app/watchers/providers/docker/label.ts
@@ -62,3 +62,9 @@ export const dockerComposeProject = 'com.docker.compose.project';
  * Optional stack/project override label.
  */
 export const wudStack = 'wud.stack';
+
+/**
+ * Optional cool-down delay before update is considered available.
+ */
+export const wudWatchDelay = 'wud.watch.delay';
+export const wudTagDelay = 'wud.tag.delay';

--- a/ui/src/components/ContainerItem.vue
+++ b/ui/src/components/ContainerItem.vue
@@ -146,6 +146,8 @@
                 :semver="container.image.tag.semver"
                 :update-kind="container.updateKind"
                 :update-available="container.updateAvailable"
+                :is-cooling-down="container.isCoolingDown"
+                :cooling-down-until="container.coolingDownUntil"
               />
             </v-window-item>
             <v-window-item>

--- a/ui/src/components/ContainerUpdate.vue
+++ b/ui/src/components/ContainerUpdate.vue
@@ -1,6 +1,20 @@
 <template>
   <div>
     <v-alert
+      v-if="isCoolingDown"
+      color="info"
+      variant="tonal"
+      density="compact"
+      icon="mdi-timer-sand"
+      class="mb-3"
+    >
+      <div class="font-weight-medium">Update in cool-down</div>
+      <div class="text-caption">
+        A new version is available but currently held in cool-down period{{ coolingDownUntil ? ` until ${new Date(coolingDownUntil).toLocaleString()}` : '' }}.
+      </div>
+    </v-alert>
+
+    <v-alert
       v-if="isSnoozed || snoozedVersion"
       color="warning"
       variant="tonal"
@@ -14,7 +28,7 @@
       </div>
     </v-alert>
 
-    <v-list density="compact" v-if="updateAvailable || isSnoozed || snoozedVersion">
+    <v-list density="compact" v-if="updateAvailable || isCoolingDown || isSnoozed || snoozedVersion">
       <v-list-item v-if="result.tag">
         <template v-slot:prepend>
           <v-icon color="secondary">mdi-tag</v-icon>
@@ -75,7 +89,7 @@
           </v-tooltip>
         </v-list-item-subtitle>
       </v-list-item>
-      <v-list-item>
+      <v-list-item v-if="updateKind && updateKind.kind && updateKind.kind !== 'unknown'">
         <template v-slot:prepend>
           <v-icon v-if="updateKind.semverDiff === 'patch'" color="success"
             >mdi-information</v-icon
@@ -111,6 +125,14 @@ export default defineComponent({
     },
     updateAvailable: {
       type: Boolean,
+    },
+    isCoolingDown: {
+      type: Boolean,
+      default: false,
+    },
+    coolingDownUntil: {
+      type: Number,
+      default: null,
     },
     isSnoozed: {
       type: Boolean,

--- a/ui/src/views/ContainersView.vue
+++ b/ui/src/views/ContainersView.vue
@@ -177,6 +177,26 @@
                   </span>
                 </v-tooltip>
               </template>
+              <template v-else-if="item.raw ? item.raw.isCoolingDown : item.isCoolingDown">
+                <v-tooltip bottom>
+                  <template v-slot:activator="{ props }">
+                    <v-chip
+                      label
+                      variant="tonal"
+                      color="info"
+                      size="small"
+                      v-bind="props"
+                      class="font-weight-medium"
+                    >
+                      <v-icon start size="small">mdi-timer-sand</v-icon>
+                      Cooling down
+                    </v-chip>
+                  </template>
+                  <span>
+                    Update available but cooling down{{ (item.raw ? item.raw.coolingDownUntil : item.coolingDownUntil) ? ` until ${new Date(item.raw ? item.raw.coolingDownUntil : item.coolingDownUntil).toLocaleString()}` : '' }}
+                  </span>
+                </v-tooltip>
+              </template>
               <span v-else class="text-grey text-caption">Up to date</span>
             </template>
 
@@ -317,6 +337,8 @@
                 :semver="selectedContainer.image?.tag?.semver"
                 :update-kind="selectedContainer.updateKind"
                 :update-available="selectedContainer.updateAvailable"
+                :is-cooling-down="selectedContainer.isCoolingDown"
+                :cooling-down-until="selectedContainer.coolingDownUntil"
                 :is-snoozed="selectedContainer.isSnoozed"
                 :snoozed-version="selectedContainer.snoozedVersion"
                 :snoozed-until="selectedContainer.snoozedUntil"

--- a/ui/tests/components/ContainerUpdate.spec.ts
+++ b/ui/tests/components/ContainerUpdate.spec.ts
@@ -116,4 +116,16 @@ describe('ContainerUpdate', () => {
   it('computes correct update type', () => {
     expect(wrapper.vm.updateKind.kind).toBe('tag');
   });
+
+  it('displays cool-down alert when isCoolingDown is true', async () => {
+    const futureTime = Date.now() + 86400000;
+    await wrapper.setProps({
+      isCoolingDown: true,
+      coolingDownUntil: futureTime,
+      updateAvailable: false,
+    });
+
+    expect(wrapper.text()).toContain('Update in cool-down');
+    expect(wrapper.text()).toContain('held in cool-down period');
+  });
 });

--- a/ui/tests/views/ContainersView.spec.ts
+++ b/ui/tests/views/ContainersView.spec.ts
@@ -544,4 +544,30 @@ describe('ContainersView', () => {
       expect(actionHeader.title).toBe('Actions');
     });
   });
+
+  describe('cool-down period', () => {
+    it('handles cooling down containers correctly in view and drawer', async () => {
+      const coolingContainer = {
+        id: 'cool-1',
+        displayName: 'Cooling App',
+        watcher: 'local',
+        image: { registry: { name: 'hub' }, tag: { value: '1.0.0' } },
+        updateAvailable: false,
+        isCoolingDown: true,
+        coolingDownUntil: Date.now() + 3600000,
+        result: { tag: '2.0.0' },
+      };
+      wrapper.vm.onRefreshAllContainers([coolingContainer]);
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.vm.containers).toHaveLength(1);
+      expect(wrapper.vm.containers[0].isCoolingDown).toBe(true);
+      expect(wrapper.vm.containers[0].coolingDownUntil).toBeDefined();
+
+      wrapper.vm.onRowClick(null, { item: coolingContainer });
+      expect(wrapper.vm.drawerOpen).toBe(true);
+      expect(wrapper.vm.selectedContainer.isCoolingDown).toBe(true);
+      expect(wrapper.vm.drawerTab).toBe('update');
+    });
+  });
 });

--- a/website/docs/changelog/next.md
+++ b/website/docs/changelog/next.md
@@ -14,3 +14,4 @@ description: Unreleased changes and upcoming features in WUD (What's Up Docker?)
 - 🛠️ [DOCS] Add CSpell and Markdownlint quality gates for documentation
 - 🚀 [TRIGGER] Add ondigest configuration option to filter out digest updates (fixes #756)
 - 🚀 [UI] Add snooze functionality to temporarily or indefinitely ignore container updates (fixes #702)
+- 🚀 [WATCHER] Add update delay / cool-down period before triggering updates (fixes #507)

--- a/website/docs/configuration/watchers/README.md
+++ b/website/docs/configuration/watchers/README.md
@@ -51,6 +51,14 @@ To customize how WUD monitors specific containers (opt-in/opt-out, tag filtering
   </ConfigOption>
 
   <ConfigOption
+    name="WUD_WATCHER_{watcher_name}_DELAY"
+    type="string"
+    required={false}
+    supported="Duration string (e.g. `30s`, `10m`, `24h`, `3d`, `1w`)">
+    Cool-down period before considering an update available for discovered containers
+  </ConfigOption>
+
+  <ConfigOption
     name="WUD_WATCHER_{watcher_name}_HOST"
     type="string"
     required={false}

--- a/website/docs/configuration/watchers/labels.md
+++ b/website/docs/configuration/watchers/labels.md
@@ -87,6 +87,14 @@ Container labels allow you to customize WUD behavior on a **per-container basis*
   </ConfigOption>
 
   <ConfigOption
+    name="wud.watch.delay"
+    required={false}
+    type="string"
+    supported="Duration string (e.g. `30s`, `10m`, `24h`, `3d`, `1w`)">
+    Cool-down period before considering an update available for this container (can also be specified as `wud.tag.delay`)
+  </ConfigOption>
+
+  <ConfigOption
     name="wud.watch.digest"
     required={false}
     type="boolean"
@@ -396,6 +404,35 @@ services:
 ```bash
 docker run -d --name web_app \
   --label 'wud.trigger.include=smtp.gmail,dockercompose.local:minor' \
+  web_app:1.2.0
+```
+
+</TabItem>
+</Tabs>
+
+---
+
+### 9. Configure Cool-Down Period Before Update Trigger
+
+To prevent updating to fresh upstream releases immediately (e.g. to wait for hotfixes or community feedback), you can set a cool-down delay:
+
+<Tabs>
+<TabItem value="docker-compose" label="Docker Compose">
+
+```yaml
+services:
+  web_app:
+    image: web_app:1.2.0
+    labels:
+      - wud.watch.delay=3d
+```
+
+</TabItem>
+<TabItem value="docker" label="Docker">
+
+```bash
+docker run -d --name web_app \
+  --label 'wud.watch.delay=3d' \
   web_app:1.2.0
 ```
 


### PR DESCRIPTION
### Description
Introduces an update delay / cool-down mechanism for containers before triggering update alerts or marking an update as available.

### Features
- **Flexible Duration Parsing**: Supports human durations like `30s`, `10m`, `24h`, `3d`, `1w`, or raw milliseconds.
- **Docker Label & Configuration**: Supports per-container labels (`wud.watch.delay`, `wud.tag.delay`) as well as global watcher configuration (`WUD_WATCHER_{watcher_name}_DELAY`).
- **Store & DB Migration**: SQLite migration adding `delay` column to `containers` table.
- **OpenAPI & Prometheus Integration**: Schema backward-compatibility preserved and Prometheus metrics updated with `cooling_down_until`, `delay`, and `is_cooling_down` in `wud_containers` gauge.
- **UI Enhancements**:
  - Displays `Cooling down` status chip and hourglass icon in container list.
  - Detailed cool-down alert banner in container update drawer showing remaining time.

Fixes #507